### PR TITLE
Update timeplus.json with latest JDBC driver

### DIFF
--- a/chat2db-server/chat2db-plugins/chat2db-timeplus/src/main/java/ai/chat2db/plugin/timeplus/timeplus.json
+++ b/chat2db-server/chat2db-plugins/chat2db-timeplus/src/main/java/ai/chat2db/plugin/timeplus/timeplus.json
@@ -8,9 +8,9 @@
       "defaultDriver": true,
       "custom": false,
       "downloadJdbcDriverUrls": [
-        "https://timeplus.io/downloads/timeplus-native-jdbc-shaded-2.0.7.jar"
+        "https://timeplus.io/downloads/timeplus-native-jdbc-shaded-2.0.9.jar"
       ],
-      "jdbcDriver": "timeplus-native-jdbc-shaded-2.0.7.jar",
+      "jdbcDriver": "timeplus-native-jdbc-shaded-2.0.9.jar",
       "jdbcDriverClass": "com.timeplus.jdbc.TimeplusDriver"
     }
   ],

--- a/chat2db-server/chat2db-plugins/chat2db-timeplus/src/main/java/ai/chat2db/plugin/timeplus/timeplus.json
+++ b/chat2db-server/chat2db-plugins/chat2db-timeplus/src/main/java/ai/chat2db/plugin/timeplus/timeplus.json
@@ -8,9 +8,9 @@
       "defaultDriver": true,
       "custom": false,
       "downloadJdbcDriverUrls": [
-        "https://timeplus.io/downloads/timeplus-native-jdbc-shaded-2.0.5.jar"
+        "https://timeplus.io/downloads/timeplus-native-jdbc-shaded-2.0.7.jar"
       ],
-      "jdbcDriver": "timeplus-native-jdbc-shaded-2.0.5.jar",
+      "jdbcDriver": "timeplus-native-jdbc-shaded-2.0.7.jar",
       "jdbcDriverClass": "com.timeplus.jdbc.TimeplusDriver"
     }
   ],


### PR DESCRIPTION
With the new version, tables will be listed in the navigation tree (2.0.5 cannot list them, because they are considered as `streams` not `tables` in Timeplus. Now this is fixed, you can query them as `TABLE` in the JDBC metadata API)