### PR TITLE
fix: handle null content in SSE stream chunks for REST and Zhipu AI

### DIFF
--- a/chat2db-server/chat2db-server-web/chat2db-server-web-api/src/main/java/ai/chat2db/server/web/api/controller/ai/rest/listener/RestAIEventSourceListener.java
+++ b/chat2db-server/chat2db-server-web/chat2db-server-web-api/src/main/java/ai/chat2db/server/web/api/controller/ai/rest/listener/RestAIEventSourceListener.java
@@ -64,6 +64,11 @@ public class RestAIEventSourceListener extends EventSourceListener {
             String text = chatCompletions.getChoices().get(0).getDelta()==null?
                     chatCompletions.getChoices().get(0).getText()
                     :chatCompletions.getChoices().get(0).getDelta().getContent();
+            // Local LLMs (e.g. llama.cpp) may return null content in the first SSE chunk
+            // (only role is present). Treat null as empty string to avoid NullPointerException.
+            if (text == null) {
+                text = "";
+            }
             message.setContent(text);
             sseEmitter.send(SseEmitter.event()
                 .id(id)

--- a/chat2db-server/chat2db-server-web/chat2db-server-web-api/src/main/java/ai/chat2db/server/web/api/controller/ai/zhipu/listener/ZhipuChatAIEventSourceListener.java
+++ b/chat2db-server/chat2db-server-web/chat2db-server-web-api/src/main/java/ai/chat2db/server/web/api/controller/ai/zhipu/listener/ZhipuChatAIEventSourceListener.java
@@ -62,6 +62,11 @@ public class ZhipuChatAIEventSourceListener extends EventSourceListener {
         String text = chatCompletions.getChoices().get(0).getDelta()==null?
                 chatCompletions.getChoices().get(0).getText()
                 :chatCompletions.getChoices().get(0).getDelta().getContent();
+        // The first SSE chunk may carry only "role" with null "content".
+        // Guard against NullPointerException from Message.setContent().
+        if (text == null) {
+            text = "";
+        }
 
         Message message = new Message();
         message.setContent(text);


### PR DESCRIPTION
Fixes #1808
Fixes #1788

## Problem

When using local LLMs (e.g. `llama.cpp`) with the custom REST AI endpoint, or when using Zhipu AI, the SSE stream's **first chunk** typically contains only the `role` field with `"content": null`. The two affected listeners passed this `null` value directly to `Message.setContent()`, which throws a `NullPointerException` (caused by a `@NonNull` enforcement in Lombok-generated code), making the entire AI chat session fail immediately.

Affected files:
- `RestAIEventSourceListener.java` — used by the custom REST AI integration (issue #1808)
- `ZhipuChatAIEventSourceListener.java` — used by the Zhipu AI integration (issue #1788)

## Solution

Added a null guard after extracting `text` from the delta: if `text` is `null`, it is replaced with an empty string before calling `message.setContent(text)`. This matches the existing behaviour of `FastChatAIEventSourceListener`, which already handles this case correctly.

```java
// Before (broken)
String text = ... getDelta().getContent();  // may be null
message.setContent(text);                   // NPE if null

// After (fixed)
String text = ... getDelta().getContent();
if (text == null) {
    text = "";
}
message.setContent(text);  // safe
```

## Testing

- Manually verified the diff aligns with the pattern already used in `FastChatAIEventSourceListener`.
- The fix is minimal and confined to the two affected listener classes.