### PR TITLE
fix: use schemaName as fallback for databaseName in Hive DDL/columns/view queries

### DIFF
--- a/chat2db-server/chat2db-plugins/chat2db-hive/src/main/java/ai/chat2db/plugin/hive/HiveMetaData.java
+++ b/chat2db-server/chat2db-plugins/chat2db-hive/src/main/java/ai/chat2db/plugin/hive/HiveMetaData.java
@@ -48,7 +48,9 @@ public class HiveMetaData extends DefaultMetaService implements MetaData {
     @Override
     public String tableDDL(Connection connection, @NotEmpty String databaseName, String schemaName,
                            @NotEmpty String tableName) {
-        String sql = "SHOW CREATE TABLE " + format(databaseName) + "."
+        // In Hive, schema and database are the same concept. Fall back to schemaName when databaseName is absent.
+        String effectiveDb = StringUtils.isNotBlank(databaseName) ? databaseName : schemaName;
+        String sql = "SHOW CREATE TABLE " + format(effectiveDb) + "."
                 + format(tableName);
         return SQLExecutor.getInstance().execute(connection, sql, resultSet -> {
             StringBuilder sb = new StringBuilder();
@@ -97,7 +99,9 @@ public class HiveMetaData extends DefaultMetaService implements MetaData {
     // TODO 待完善
     @Override
     public List<TableColumn> columns(Connection connection, String databaseName, String schemaName, String tableName) {
-        String sql = String.format(SELECT_TAB_COLS, databaseName, tableName);
+        // In Hive, schema and database are the same concept. Fall back to schemaName when databaseName is absent.
+        String effectiveDb = StringUtils.isNotBlank(databaseName) ? databaseName : schemaName;
+        String sql = String.format(SELECT_TAB_COLS, effectiveDb, tableName);
         return SQLExecutor.getInstance().execute(connection, sql, resultSet -> {
             List<TableColumn> tableColumns = new ArrayList<>();
             Map<String, String> detailTableInfo = new HashMap<>();
@@ -268,7 +272,9 @@ public class HiveMetaData extends DefaultMetaService implements MetaData {
 
     @Override
     public Table view(Connection connection, String databaseName, String schemaName, String viewName) {
-        String sql = String.format(VIEW_SQL, databaseName, viewName);
+        // In Hive, schema and database are the same concept. Fall back to schemaName when databaseName is absent.
+        String effectiveDb = StringUtils.isNotBlank(databaseName) ? databaseName : schemaName;
+        String sql = String.format(VIEW_SQL, effectiveDb, viewName);
         return SQLExecutor.getInstance().execute(connection, sql, resultSet -> {
             Table table = new Table();
             table.setDatabaseName(databaseName);


### PR DESCRIPTION
Fixes #1745

## Problem

When viewing a Hive table's DDL structure, the query fails with:

```
Table not found null.ods_cancel_order RuntimeException
```

Root cause: In Hive, schema and database represent the same concept. The `HiveMetaData.schemas()` method already reflects this by returning `Schema(name=databaseName)`. However, when a client calls the DDL export endpoint passing only `schemaName` (without `databaseName`), the `tableDDL()`, `columns()`, and `view()` methods all used `databaseName` directly in their SQL queries — producing `null.table_name` when `databaseName` was absent.

## Solution

Apply a `schemaName` fallback in the three affected methods so the effective database name is resolved correctly:

```java
String effectiveDb = StringUtils.isNotBlank(databaseName) ? databaseName : schemaName;
```

This is applied to:
- `tableDDL()` — `SHOW CREATE TABLE`
- `columns()` — `DESCRIBE FORMATTED`
- `view()` — `SHOW CREATE TABLE` for views

## Testing

The fix resolves the `Table not found null.table_name` error reported in the issue. No existing behavior is changed when `databaseName` is already populated.