### PR TITLE
fix(sql): preserve execution context correctness

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/index.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useReducer,
   useState,
   forwardRef,
   ForwardedRef,
@@ -30,7 +31,7 @@ import {
   getResultIdentity,
   hasLegacyResultTab,
   hasTabularResult,
-  resolveAvailableActiveTabId,
+  reduceActiveTabSelection,
 } from './tabSelection';
 
 interface IProps {
@@ -39,6 +40,7 @@ interface IProps {
   historyResultDataList?: IManageResultData[];
   executionLogRecords?: SqlExecutionLogRecord[];
   resultBatchKey?: number;
+  forceOutputTab?: boolean;
   viewTable?: boolean;
   onClearExecutionLog?: () => void;
   onResultDataListChange?: (params: {
@@ -88,9 +90,10 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
     props.historyResultDataList || [],
   );
   const [showHistory, setShowHistory] = useState(false);
-  const [activeTabId, setActiveTabId] = useState<string>(() =>
-    getPreferredActiveTabId(props.resultDataList[props.resultDataList.length - 1], consoleMode),
-  );
+  const [tabSelection, dispatchTabSelection] = useReducer(reduceActiveTabSelection, {
+    activeTabId: getPreferredActiveTabId(props.resultDataList[props.resultDataList.length - 1], consoleMode),
+  });
+  const activeTabId = tabSelection.activeTabId;
   const knownResultVersionMapRef = useRef<Map<string, string>>(new Map());
   const latestTerminalLogVersion = getLatestTerminalLogVersion(props.executionLogRecords);
   const visibleHistoryResultDataList = useMemo(
@@ -103,6 +106,7 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
   }));
 
   useEffect(() => {
+    dispatchTabSelection({ type: 'resetPreference' });
     setShowHistory(false);
   }, [props.resultBatchKey]);
 
@@ -126,9 +130,12 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
     setResultDataList(nextResultDataList);
 
     if (latestChangedResult) {
-      setActiveTabId(getPreferredActiveTabId(latestChangedResult, consoleMode));
+      dispatchTabSelection({
+        type: 'prefer',
+        tabId: getPreferredActiveTabId(latestChangedResult, consoleMode, props.forceOutputTab),
+      });
     }
-  }, [props.resultDataList, consoleMode]);
+  }, [props.resultDataList, consoleMode, props.forceOutputTab]);
 
   useEffect(() => {
     const nextHistoryResultDataList = props.historyResultDataList || [];
@@ -143,12 +150,18 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
 
   useEffect(() => {
     if (consoleMode && latestTerminalLogVersion) {
-      setActiveTabId(CONSOLE_TAB_ID);
+      dispatchTabSelection({ type: 'activate', tabId: CONSOLE_TAB_ID });
     }
   }, [consoleMode, latestTerminalLogVersion]);
 
+  useEffect(() => {
+    if (consoleMode && props.forceOutputTab) {
+      dispatchTabSelection({ type: 'activate', tabId: CONSOLE_TAB_ID });
+    }
+  }, [consoleMode, props.forceOutputTab, props.resultBatchKey]);
+
   const onChange = useCallback((uuid) => {
-    setActiveTabId(uuid);
+    dispatchTabSelection({ type: 'activate', tabId: uuid });
   }, []);
 
   const tabsList = useMemo(() => {
@@ -270,7 +283,7 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
         (item) => hasTabularResult(item) && item.extra?.resultKey === resultKey,
       );
       if (currentResult?.uuid) {
-        setActiveTabId(currentResult.uuid);
+        dispatchTabSelection({ type: 'activate', tabId: currentResult.uuid });
         return;
       }
       const historyResult = historyResultDataList.find(
@@ -278,7 +291,7 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
       );
       if (historyResult?.uuid) {
         setShowHistory(true);
-        setActiveTabId(historyResult.uuid);
+        dispatchTabSelection({ type: 'activate', tabId: historyResult.uuid });
       }
     },
     [resultDataList, historyResultDataList],
@@ -353,7 +366,7 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
 
   useEffect(() => {
     const availableTabIds = tabsItems.map((item) => String(item.key));
-    setActiveTabId((currentActiveTabId) => resolveAvailableActiveTabId(currentActiveTabId, availableTabIds));
+    dispatchTabSelection({ type: 'tabsChanged', availableTabIds });
   }, [tabsItems]);
 
   return (
@@ -365,7 +378,10 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
             onClick={() => {
               setShowHistory((value) => !value);
               if (showHistory && visibleHistoryResultDataList.some((item) => item.uuid === activeTabId)) {
-                setActiveTabId(consoleMode ? CONSOLE_TAB_ID : ABSTRACT_TAB_ID);
+                dispatchTabSelection({
+                  type: 'activate',
+                  tabId: consoleMode ? CONSOLE_TAB_ID : ABSTRACT_TAB_ID,
+                });
               }
             }}
           >

--- a/chat2db-community-client/src/blocks/SearchResult/tabSelection.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/tabSelection.test.ts
@@ -3,9 +3,11 @@ import {
   CONSOLE_TAB_ID,
   MESSAGES_TAB_ID,
   getPreferredActiveTabId,
+  reduceActiveTabSelection,
   resolveAvailableActiveTabId,
 } from './tabSelection';
 import type { IManageResultData } from '@/typings';
+import { sortExecutionResults } from '@/service/sqlExecutionStream';
 
 function assertEqual(actual: unknown, expected: unknown, message: string) {
   if (actual !== expected) {
@@ -47,6 +49,16 @@ assertEqual(
 );
 assertEqual(getPreferredActiveTabId(tableResult, true), 'table-result', 'console queries open a new tabular result');
 assertEqual(
+  getPreferredActiveTabId(tableResult, true, true),
+  CONSOLE_TAB_ID,
+  'an explicit failed or cancelled execution outcome keeps Output active even when an old table result is restored',
+);
+assertEqual(
+  getPreferredActiveTabId(result({ uuid: 'command-result' }), true),
+  CONSOLE_TAB_ID,
+  'successful console commands without a table result open Output',
+);
+assertEqual(
   getPreferredActiveTabId(result({ uuid: 'message-only', extra: { messageOnly: true } }), false),
   MESSAGES_TAB_ID,
   'message-only legacy results open the messages tab',
@@ -61,6 +73,52 @@ assertEqual(
   CONSOLE_TAB_ID,
   'console failures open the execution console',
 );
+let batchedSelection = reduceActiveTabSelection(
+  { activeTabId: CONSOLE_TAB_ID },
+  { type: 'prefer', tabId: 'batched-table-result' },
+);
+batchedSelection = reduceActiveTabSelection(batchedSelection, {
+  type: 'tabsChanged',
+  availableTabIds: [CONSOLE_TAB_ID],
+});
+assertEqual(
+  batchedSelection.activeTabId,
+  CONSOLE_TAB_ID,
+  'a preferred result waits while the rendered tab list still contains only Output',
+);
+assertEqual(
+  batchedSelection.pendingPreferredTabId,
+  'batched-table-result',
+  'the preferred result remains pending until its tab is rendered',
+);
+batchedSelection = reduceActiveTabSelection(batchedSelection, {
+  type: 'tabsChanged',
+  availableTabIds: [CONSOLE_TAB_ID, 'batched-table-result'],
+});
+assertEqual(
+  batchedSelection.activeTabId,
+  'batched-table-result',
+  'a pending result becomes active when the result tab reaches the rendered tab list',
+);
+assertEqual(
+  batchedSelection.pendingPreferredTabId,
+  undefined,
+  'the pending preference is consumed after the result tab becomes active',
+);
+batchedSelection = reduceActiveTabSelection(
+  reduceActiveTabSelection(batchedSelection, { type: 'prefer', tabId: 'next-result' }),
+  { type: 'activate', tabId: CONSOLE_TAB_ID },
+);
+assertEqual(
+  batchedSelection.activeTabId,
+  CONSOLE_TAB_ID,
+  'failed and cancelled terminal states activate Output',
+);
+assertEqual(
+  batchedSelection.pendingPreferredTabId,
+  undefined,
+  'failed and cancelled terminal states discard a pending result preference',
+);
 assertEqual(
   resolveAvailableActiveTabId('table-result', [ABSTRACT_TAB_ID, 'table-result']),
   'table-result',
@@ -72,5 +130,41 @@ assertEqual(
   'closing the active result selects the first available tab',
 );
 assertEqual(resolveAvailableActiveTabId('closed-result', []), '', 'removing all tabs clears the active tab');
+
+const sortedWebBatchResults = sortExecutionResults([
+  result({
+    uuid: 'select-1',
+    statementSequence: 1,
+    headerList: [{ name: '#' }, { name: 'id' }] as any,
+    extra: { executionSequence: 1, resultSequence: 1 },
+  }),
+  result({
+    uuid: 'select-2',
+    statementSequence: 2,
+    headerList: [{ name: '#' }, { name: 'id' }] as any,
+    extra: { executionSequence: 1, resultSequence: 1 },
+  }),
+  result({
+    uuid: 'select-4',
+    statementSequence: 4,
+    headerList: [{ name: '#' }, { name: 'id' }] as any,
+    extra: { executionSequence: 1, resultSequence: 1 },
+  }),
+  result({
+    uuid: 'use-3',
+    statementSequence: 3,
+    extra: { executionSequence: 1, resultSequence: 3 },
+  }),
+]);
+assertEqual(
+  sortedWebBatchResults.map((item) => item.uuid).join(','),
+  'select-1,select-2,use-3,select-4',
+  'web batch results use the backend statement sequence when stream metadata is absent',
+);
+assertEqual(
+  getPreferredActiveTabId(sortedWebBatchResults[sortedWebBatchResults.length - 1], true),
+  'select-4',
+  'a web batch ending in SELECT opens its final result tab after a USE statement',
+);
 
 console.log('SearchResult tab selection tests passed');

--- a/chat2db-community-client/src/blocks/SearchResult/tabSelection.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/tabSelection.ts
@@ -4,6 +4,17 @@ export const CONSOLE_TAB_ID = 'execution-console';
 export const ABSTRACT_TAB_ID = 'abstract';
 export const MESSAGES_TAB_ID = 'messages';
 
+export interface ActiveTabSelectionState {
+  activeTabId: string;
+  pendingPreferredTabId?: string;
+}
+
+export type ActiveTabSelectionAction =
+  | { type: 'prefer'; tabId: string }
+  | { type: 'activate'; tabId: string }
+  | { type: 'resetPreference' }
+  | { type: 'tabsChanged'; availableTabIds: string[] };
+
 export function getResultIdentity(item: IManageResultData) {
   return item.uuid || item.extra?.resultKey || item.extra?.historyKey;
 }
@@ -20,7 +31,14 @@ export function shouldOpenLegacyMessagesTab(item: IManageResultData) {
   return item.extra?.messageOnly || (!!item.extra?.messages?.length && !hasLegacyResultTab(item));
 }
 
-export function getPreferredActiveTabId(item: IManageResultData | undefined, consoleMode: boolean) {
+export function getPreferredActiveTabId(
+  item: IManageResultData | undefined,
+  consoleMode: boolean,
+  forceOutputTab = false,
+) {
+  if (consoleMode && forceOutputTab) {
+    return CONSOLE_TAB_ID;
+  }
   if (!item) {
     return consoleMode ? CONSOLE_TAB_ID : '';
   }
@@ -36,12 +54,48 @@ export function getPreferredActiveTabId(item: IManageResultData | undefined, con
   return consoleMode ? CONSOLE_TAB_ID : ABSTRACT_TAB_ID;
 }
 
-export function resolveAvailableActiveTabId(currentActiveTabId: string, availableTabIds: string[]) {
+export function resolveAvailableActiveTabId(
+  currentActiveTabId: string,
+  availableTabIds: string[],
+  preferredActiveTabId?: string,
+) {
   if (!availableTabIds.length) {
     return '';
+  }
+  if (preferredActiveTabId && availableTabIds.includes(preferredActiveTabId)) {
+    return preferredActiveTabId;
   }
   if (currentActiveTabId && availableTabIds.includes(currentActiveTabId)) {
     return currentActiveTabId;
   }
   return availableTabIds[0];
+}
+
+export function reduceActiveTabSelection(
+  state: ActiveTabSelectionState,
+  action: ActiveTabSelectionAction,
+): ActiveTabSelectionState {
+  switch (action.type) {
+    case 'prefer':
+      return { ...state, pendingPreferredTabId: action.tabId };
+    case 'activate':
+      return { activeTabId: action.tabId };
+    case 'resetPreference':
+      return state.pendingPreferredTabId === undefined ? state : { activeTabId: state.activeTabId };
+    case 'tabsChanged': {
+      const activeTabId = resolveAvailableActiveTabId(
+        state.activeTabId,
+        action.availableTabIds,
+        state.pendingPreferredTabId,
+      );
+      const pendingPreferredTabId =
+        activeTabId === state.pendingPreferredTabId ? undefined : state.pendingPreferredTabId;
+      if (activeTabId === state.activeTabId && pendingPreferredTabId === state.pendingPreferredTabId) {
+        return state;
+      }
+      return { activeTabId, pendingPreferredTabId };
+    }
+    default:
+      return state;
+  }
 }

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
@@ -42,6 +42,7 @@ import {
   createSqlExecutionLogState,
   failWebSqlExecution,
   reduceDesktopSqlExecutionEvent,
+  rethrowNonCancellationSqlExecutionError,
   SqlExecutionLogContext,
 } from '@/service/sqlExecutionLog';
 import { isDesktop } from '@/utils/env';
@@ -630,7 +631,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
           );
         }
         restoreExecutionSnapshotIfEmpty();
-        return Promise.reject(error);
+        rethrowNonCancellationSqlExecutionError(error);
       });
   };
 

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
@@ -195,6 +195,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
   const statementBySequenceRef = useRef<Record<number, SqlExecutionStatement>>({});
   const currentStatementRef = useRef<SqlExecutionStatement>();
   const [resultBatchKey, setResultBatchKey] = useState(0);
+  const [forceOutputTab, setForceOutputTab] = useState(false);
   const { activeConsoleId, setEditorToList, deleteEditor, updateWorkspaceTabBoundInfo } = useWorkspaceStore(
     (state) => ({
       activeConsoleId: state.activeConsoleId,
@@ -260,6 +261,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
     currentStatementRef.current = undefined;
   }, []);
   const beginExecutionResultBatch = useCallback(() => {
+    setForceOutputTab(false);
     executionSnapshotRef.current = {
       resultDataList: resultDataListRef.current,
       historyResultDataList: historyResultDataListRef.current,
@@ -616,6 +618,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
       });
     })
       .catch((error) => {
+        setForceOutputTab(true);
         if (webExecutionId) {
           setSqlExecutionLogState((state) =>
             failWebSqlExecution(state, {
@@ -689,6 +692,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
                 historyResultDataList={historyResultDataList}
                 executionLogRecords={sqlExecutionLogState.records}
                 resultBatchKey={resultBatchKey}
+                forceOutputTab={forceOutputTab}
                 onClearExecutionLog={handleClearExecutionLog}
                 onResultDataListChange={handleResultDataListChange}
               />

--- a/chat2db-community-client/src/service/sqlExecutionLog.test.ts
+++ b/chat2db-community-client/src/service/sqlExecutionLog.test.ts
@@ -8,7 +8,9 @@ import {
   completeWebSqlExecution,
   createSqlExecutionLogState,
   failWebSqlExecution,
+  isSqlExecutionCancellationError,
   reduceDesktopSqlExecutionEvent,
+  rethrowNonCancellationSqlExecutionError,
 } from './sqlExecutionLog';
 
 const context = {
@@ -153,6 +155,16 @@ function webExecution() {
   const output = state.records[0].outputs[0];
   assert.equal(output.kind === 'result' ? output.updateCount : undefined, 3);
   assert.equal(output.kind === 'result' ? output.resultKey : undefined, undefined);
+}
+
+{
+  assert.equal(isSqlExecutionCancellationError({ name: 'AbortError' }), true);
+  assert.equal(isSqlExecutionCancellationError({ name: 'CanceledError' }), true);
+  assert.equal(isSqlExecutionCancellationError({ code: 'ERR_CANCELED' }), true);
+  const databaseError = { message: 'current transaction is aborted' };
+  assert.equal(isSqlExecutionCancellationError(databaseError), false);
+  assert.doesNotThrow(() => rethrowNonCancellationSqlExecutionError({ name: 'AbortError' }));
+  assert.throws(() => rethrowNonCancellationSqlExecutionError(databaseError), (error) => error === databaseError);
 }
 
 {

--- a/chat2db-community-client/src/service/sqlExecutionLog.test.ts
+++ b/chat2db-community-client/src/service/sqlExecutionLog.test.ts
@@ -36,6 +36,18 @@ function result(overrides: Partial<IManageResultData> = {}): IManageResultData {
   };
 }
 
+function rawExecutionContext(value: Record<string, unknown>) {
+  return value as unknown as NonNullable<IManageResultData['executionContext']>;
+}
+
+function assertTruncatedMessage(message: string | undefined) {
+  const value = message || '';
+  assert.equal(Array.from(value).length, 8_192);
+  assert.ok(value.startsWith('prefix:'));
+  assert.ok(value.endsWith(':suffix'));
+  assert.doesNotThrow(() => encodeURIComponent(value));
+}
+
 function webExecution() {
   return beginWebSqlExecution(createSqlExecutionLogState(), {
     executionId: 'web-1',
@@ -343,6 +355,250 @@ function webExecution() {
   assert.equal(state.records[0].status, 'running');
   assert.equal(state.records[1].status, 'cancelled');
   assert.equal(state.records[1].outputs.length, 0);
+}
+
+{
+  const state = completeWebSqlExecution(
+    beginWebSqlExecution(createSqlExecutionLogState(), {
+      executionId: 'web-context-presence',
+      sql: 'select 1; select 2; select 3',
+      context: { ...context, schemaName: 'PUBLIC' },
+      occurredAtEpochMs: 100,
+    }),
+    {
+      executionId: 'web-context-presence',
+      sql: 'select 1; select 2; select 3',
+      context: { ...context, schemaName: 'PUBLIC' },
+      occurredAtEpochMs: 110,
+      results: [
+        result({ statementSequence: 1, executionContext: { databaseName: 'next_database' } }),
+        result({
+          statementSequence: 2,
+          executionContext: rawExecutionContext({ databaseName: null, schemaName: null }),
+        }),
+        result({ statementSequence: 3, executionContext: { schemaName: '' } }),
+      ],
+    },
+  );
+  assert.deepEqual(
+    state.records.map((record) => record.context.schemaName),
+    ['PUBLIC', undefined, undefined],
+  );
+  assert.deepEqual(
+    state.records.map((record) => record.context.databaseName),
+    ['next_database', undefined, 'app'],
+  );
+}
+
+{
+  let state = createSqlExecutionLogState();
+  state = reduceDesktopSqlExecutionEvent(
+    state,
+    {
+      executionId: 'desktop-context-presence',
+      eventType: 'statementStarted',
+      statementSequence: 1,
+      message: { originalSql: 'select 1' },
+    },
+    { ...context, schemaName: 'PUBLIC' },
+  );
+  state = reduceDesktopSqlExecutionEvent(
+    state,
+    {
+      executionId: 'desktop-context-presence',
+      eventType: 'resultStarted',
+      statementSequence: 1,
+      message: result({ executionContext: { databaseName: 'next_database' } }),
+    },
+    context,
+  );
+  assert.equal(state.records[0].context.schemaName, 'PUBLIC');
+  assert.equal(state.records[0].context.databaseName, 'next_database');
+  state = reduceDesktopSqlExecutionEvent(
+    state,
+    {
+      executionId: 'desktop-context-presence',
+      eventType: 'resultStarted',
+      statementSequence: 1,
+      message: result({ executionContext: rawExecutionContext({ databaseName: null, schemaName: null }) }),
+    },
+    context,
+  );
+  assert.equal(state.records[0].context.schemaName, undefined);
+  assert.equal(state.records[0].context.databaseName, undefined);
+  state = reduceDesktopSqlExecutionEvent(
+    state,
+    {
+      executionId: 'desktop-context-presence',
+      eventType: 'resultStarted',
+      statementSequence: 1,
+      message: result({ executionContext: { schemaName: 'TARGET_SCHEMA' } }),
+    },
+    context,
+  );
+  state = reduceDesktopSqlExecutionEvent(
+    state,
+    {
+      executionId: 'desktop-context-presence',
+      eventType: 'resultStarted',
+      statementSequence: 1,
+      message: result({ executionContext: { schemaName: '' } }),
+    },
+    context,
+  );
+  assert.equal(state.records[0].context.schemaName, undefined);
+}
+
+{
+  let state = createSqlExecutionLogState();
+  state = reduceDesktopSqlExecutionEvent(
+    state,
+    {
+      executionId: 'desktop-message-id',
+      eventSequence: 1,
+      eventType: 'statementStarted',
+      statementSequence: 1,
+      message: { originalSql: 'select 1' },
+    },
+    context,
+  );
+  state = reduceDesktopSqlExecutionEvent(
+    state,
+    {
+      executionId: 'desktop-message-id',
+      eventSequence: 6,
+      eventType: 'resultFinished',
+      statementSequence: 1,
+      resultSequence: 1,
+      message: result({ extra: { messages: [{ level: 'ERROR', message: 'result-attached' }] } }),
+    },
+    context,
+  );
+  state = reduceDesktopSqlExecutionEvent(
+    state,
+    {
+      executionId: 'desktop-message-id',
+      eventSequence: 6000,
+      eventType: 'message',
+      statementSequence: 1,
+      message: { level: 'ERROR', message: 'direct-event' },
+    },
+    context,
+  );
+  const messages = state.records[0].outputs.filter((output) => output.kind === 'message');
+  assert.deepEqual(
+    messages.map((output) => output.message),
+    ['result-attached', 'direct-event'],
+  );
+  assert.equal(new Set(messages.map((output) => output.id)).size, 2);
+}
+
+{
+  let state = reduceDesktopSqlExecutionEvent(
+    createSqlExecutionLogState(),
+    {
+      executionId: 'desktop-bounded-replay',
+      eventSequence: 1,
+      eventType: 'statementStarted',
+      statementSequence: 1,
+      message: { originalSql: 'select 1' },
+    },
+    context,
+  );
+  const resultEvent = {
+    executionId: 'desktop-bounded-replay',
+    eventSequence: 2,
+    eventType: 'resultFinished' as const,
+    statementSequence: 1,
+    message: result({
+      success: false,
+      message: 'failed result',
+      extra: {
+        messages: [
+          { level: 'ERROR', message: 'pinned desktop error' },
+          ...Array.from({ length: 220 }, (_, index) => ({
+            level: 'INFO' as const,
+            message: `desktop-notice-${index}`,
+          })),
+        ],
+      },
+    }),
+  };
+  state = reduceDesktopSqlExecutionEvent(state, resultEvent, context);
+  const retainedOutputs = state.records[0].outputs;
+  state = reduceDesktopSqlExecutionEvent(state, resultEvent, context);
+  const outputs = state.records[0].outputs;
+  assert.equal(state.records[0].status, 'failed');
+  assert.equal(outputs.length, 200);
+  assert.deepEqual(outputs, retainedOutputs);
+  assert.equal(outputs.filter((output) => output.kind === 'result').length, 1);
+  assert.ok(outputs.some((output) => output.kind === 'message' && output.message === 'pinned desktop error'));
+  assert.ok(outputs.some((output) => output.kind === 'result' && !output.success));
+  assert.ok(outputs.some((output) => output.kind === 'message' && output.message === 'desktop-notice-219'));
+  assert.ok(!outputs.some((output) => output.kind === 'message' && output.message === 'desktop-notice-0'));
+}
+
+{
+  const state = completeWebSqlExecution(webExecution(), {
+    executionId: 'web-1',
+    sql: 'select 1',
+    context,
+    occurredAtEpochMs: 140,
+    results: [
+      result({
+        success: false,
+        message: 'failed result',
+        extra: {
+          messages: [
+            { level: 'ERROR', message: 'pinned error' },
+            ...Array.from({ length: 220 }, (_, index) => ({
+              level: 'INFO' as const,
+              message: `notice-${index}`,
+            })),
+          ],
+        },
+      }),
+    ],
+  });
+  const outputs = state.records[0].outputs;
+  assert.equal(state.records[0].status, 'failed');
+  assert.equal(outputs.length, 200);
+  assert.ok(outputs.some((output) => output.kind === 'message' && output.message === 'pinned error'));
+  assert.ok(outputs.some((output) => output.kind === 'result' && !output.success));
+  assert.ok(outputs.some((output) => output.kind === 'message' && output.message === 'notice-219'));
+  assert.ok(!outputs.some((output) => output.kind === 'message' && output.message === 'notice-0'));
+}
+
+{
+  const longMessage = `prefix:${'\u{1F642}'.repeat(9_000)}:suffix`;
+  const state = failWebSqlExecution(webExecution(), {
+    executionId: 'web-1',
+    sql: 'select 1',
+    context,
+    occurredAtEpochMs: 120,
+    error: { message: longMessage },
+  });
+  const output = state.records[0].outputs[0];
+  assert.equal(output.kind, 'message');
+  if (output.kind === 'message') {
+    assertTruncatedMessage(output.message);
+  }
+}
+
+{
+  const longMessage = `prefix:${'\u{1F642}'.repeat(9_000)}:suffix`;
+  const state = completeWebSqlExecution(webExecution(), {
+    executionId: 'web-1',
+    sql: 'select 1',
+    context,
+    occurredAtEpochMs: 140,
+    results: [result({ success: false, message: longMessage })],
+  });
+  const output = state.records[0].outputs.find((item) => item.kind === 'result');
+  assert.equal(output?.kind, 'result');
+  if (output?.kind === 'result') {
+    assertTruncatedMessage(output.message);
+  }
 }
 
 {

--- a/chat2db-community-client/src/service/sqlExecutionLog.ts
+++ b/chat2db-community-client/src/service/sqlExecutionLog.ts
@@ -74,6 +74,9 @@ export interface FailWebSqlExecutionParams extends BeginWebSqlExecutionParams {
 }
 
 const MAX_RECORDS = 200;
+const MAX_OUTPUTS_PER_RECORD = 200;
+const MAX_MESSAGE_LENGTH = 8_192;
+const MESSAGE_TRUNCATION_MARKER = '\n...[truncated]...\n';
 
 export function createSqlExecutionLogState(): SqlExecutionLogState {
   return { records: [] };
@@ -133,12 +136,18 @@ export function completeWebSqlExecution(
       context: mergeExecutionContext(params.context, first.executionContext),
       startedAtEpochMs,
     });
-    results.forEach((result, resultIndex) => {
-      (result.extra?.messages || []).forEach((message, messageIndex) => {
-        record = addMessage(record, message, completedAt, resultIndex * 1000 + messageIndex);
-      });
-      record = addResult(record, result, completedAt, undefined, resultIndex);
-    });
+    let messageSequence = 0;
+    record = appendOutputs(
+      record,
+      results.flatMap((result, resultIndex) => [
+        ...(result.extra?.messages || []).flatMap((message) => {
+          const output = createMessageOutput(record, message, completedAt, 'web-result', messageSequence);
+          messageSequence += 1;
+          return output ? [output] : [];
+        }),
+        createResultOutput(record, result, completedAt, undefined, resultIndex),
+      ]),
+    );
     const finishedAtEpochMs = results.reduce(
       (latest, result) => Math.max(latest, result.executionMetrics?.finishedAtEpochMs || 0),
       completedAt,
@@ -253,21 +262,31 @@ export function reduceDesktopSqlExecutionEvent(
         };
       }
       case 'message':
-        return addMessage(record, event.message, occurredAt, event.eventSequence);
+        return appendMessage(record, event.message, occurredAt, 'desktop-event', event.eventSequence);
       case 'resultFinished':
       case 'updateCount': {
         const contextualRecord = {
           ...record,
           context: mergeExecutionContext(record.context, event.message?.executionContext),
         };
-        const messageSequenceBase =
-          typeof event.eventSequence === 'number' ? event.eventSequence * 1000 : contextualRecord.outputs.length;
-        const withMessages = (event.message?.extra?.messages || []).reduce(
-          (current, message, index) =>
-            addMessage(current, message, occurredAt, messageSequenceBase + index),
-          contextualRecord,
-        );
-        const next = addResult(withMessages, event.message, occurredAt, event);
+        const messageSequenceBase = event.eventSequence ?? nextMessageSequence(contextualRecord);
+        const messageOutputs = (event.message?.extra?.messages || []).flatMap((message, index) => {
+          const output = createMessageOutput(
+            contextualRecord,
+            message,
+            occurredAt,
+            'desktop-result',
+            `${messageSequenceBase}:${index}`,
+          );
+          return output ? [output] : [];
+        });
+        const resultOutput = createResultOutput(contextualRecord, event.message, occurredAt, event);
+        const duplicateFallbackEvent =
+          resultOutput.id.startsWith(`${contextualRecord.id}:result:event:`) &&
+          contextualRecord.outputs.some((output) => output.id === resultOutput.id);
+        const next = duplicateFallbackEvent
+          ? contextualRecord
+          : appendOutputs(contextualRecord, [...messageOutputs, resultOutput]);
         return event.message?.success === false ? { ...next, status: 'failed' as const } : next;
       }
       case 'statementFinished':
@@ -302,9 +321,19 @@ function mergeExecutionContext(
   if (!executionContext) return context;
   return {
     ...context,
-    databaseName: executionContext.databaseName ?? context.databaseName,
-    schemaName: executionContext.schemaName ?? context.schemaName,
+    databaseName: mergeContextName(context.databaseName, executionContext, 'databaseName'),
+    schemaName: mergeContextName(context.schemaName, executionContext, 'schemaName'),
   };
+}
+
+function mergeContextName(
+  currentValue: string | undefined,
+  executionContext: IExecutionContext,
+  key: keyof IExecutionContext,
+) {
+  if (!Object.prototype.hasOwnProperty.call(executionContext, key)) return currentValue;
+  const value = executionContext[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function createRecord(params: {
@@ -331,75 +360,144 @@ function createRecord(params: {
   };
 }
 
-function addMessage(
+function appendMessage(
   record: SqlExecutionLogRecord,
   message: SqlExecutionMessage,
   occurredAtEpochMs: number,
-  sequence = record.outputs.length,
+  source: 'desktop-event' | 'generated' = 'generated',
+  sequence = nextMessageSequence(record),
 ): SqlExecutionLogRecord {
-  const messageText = text(message?.message);
-  if (!messageText) return record;
+  const output = createMessageOutput(record, message, occurredAtEpochMs, source, sequence);
+  return output ? appendOutputs(record, [output]) : record;
+}
+
+function createMessageOutput(
+  record: SqlExecutionLogRecord,
+  message: SqlExecutionMessage,
+  occurredAtEpochMs: number,
+  source: 'web-result' | 'desktop-event' | 'desktop-result' | 'generated',
+  sequence: number | string,
+): SqlExecutionLogMessageOutput | undefined {
+  const messageText = truncateMessage(text(message?.message));
+  if (!messageText) return undefined;
   const level = levelOf(message?.level);
-  const outputId = `${record.id}:message:${sequence}`;
-  if (record.outputs.some((output) => output.id === outputId)) return record;
+  const outputId = `${record.id}:message:${source}:${sequence}`;
   return {
-    ...record,
-    outputs: [
-      ...record.outputs,
-      {
-        kind: 'message',
-        id: outputId,
-        occurredAtEpochMs,
-        level,
-        message: messageText,
-        errorCode: message?.errorCode,
-        sqlState: message?.sqlState,
-        source: message?.source,
-      },
-    ],
+    kind: 'message',
+    id: outputId,
+    occurredAtEpochMs,
+    level,
+    message: messageText,
+    errorCode: message?.errorCode,
+    sqlState: message?.sqlState,
+    source: message?.source,
   };
 }
 
-function addResult(
+function createResultOutput(
   record: SqlExecutionLogRecord,
   result: IManageResultData,
   occurredAtEpochMs: number,
   event?: SqlExecutionEvent,
-  fallbackSequence = record.outputs.length,
-): SqlExecutionLogRecord {
-  const resultSequence =
+  fallbackSequence?: number,
+): SqlExecutionLogResultOutput {
+  const explicitResultSequence =
     event?.resultSequence ??
     numeric(result.extra?.resultSequence) ??
     numeric(result.extra?.streamResultId) ??
-    result.resultSetId ??
-    fallbackSequence + 1;
+    result.resultSetId;
+  const resultSequence =
+    explicitResultSequence ??
+    (fallbackSequence === undefined ? nextResultSequence(record) : fallbackSequence + 1);
   const rawResultKey = event?.resultKey || text(result.extra?.resultKey) || undefined;
   const resultKey = (result.headerList?.length || 0) > 1 ? rawResultKey : undefined;
-  const outputId = `${record.id}:result:${rawResultKey || resultSequence}`;
-  if (record.outputs.some((output) => output.kind === 'result' && output.id === outputId)) return record;
+  const outputIdentity = rawResultKey
+    ? `key:${rawResultKey}`
+    : explicitResultSequence !== undefined
+      ? `sequence:${explicitResultSequence}`
+      : event?.eventSequence !== undefined
+        ? `event:${event.eventSequence}`
+        : `fallback:${resultSequence}`;
+  const outputId = `${record.id}:result:${outputIdentity}`;
   const rowCount =
     result.executionMetrics?.fetchedRowCount ??
     record.pendingRowCounts[String(resultSequence)] ??
     (result.dataList ? result.dataList.length : undefined);
   return {
-    ...record,
-    outputs: [
-      ...record.outputs,
-      {
-        kind: 'result',
-        id: outputId,
-        occurredAtEpochMs: result.executionMetrics?.finishedAtEpochMs ?? occurredAtEpochMs,
-        resultKey,
-        resultSequence,
-        success: result.success !== false,
-        rowCount,
-        updateCount: result.updateCount,
-        durationMs: result.duration,
-        executionMetrics: result.executionMetrics,
-        message: result.message,
-      },
-    ],
+    kind: 'result',
+    id: outputId,
+    occurredAtEpochMs: result.executionMetrics?.finishedAtEpochMs ?? occurredAtEpochMs,
+    resultKey,
+    resultSequence,
+    success: result.success !== false,
+    rowCount,
+    updateCount: result.updateCount,
+    durationMs: result.duration,
+    executionMetrics: result.executionMetrics,
+    message: truncateMessage(text(result.message)) || undefined,
   };
+}
+
+function appendOutputs(record: SqlExecutionLogRecord, additions: SqlExecutionLogOutput[]): SqlExecutionLogRecord {
+  if (!additions.length) return record;
+  const outputIds = new Set(record.outputs.map((output) => output.id));
+  const uniqueAdditions = additions.filter((output) => {
+    if (outputIds.has(output.id)) return false;
+    outputIds.add(output.id);
+    return true;
+  });
+  if (!uniqueAdditions.length) return record;
+  return {
+    ...record,
+    outputs: retainOutputs([...record.outputs, ...uniqueAdditions]),
+  };
+}
+
+function retainOutputs(outputs: SqlExecutionLogOutput[]) {
+  if (outputs.length <= MAX_OUTPUTS_PER_RECORD) return outputs;
+  const retainedIndexes = new Set<number>();
+  for (let index = outputs.length - 1; index >= 0 && retainedIndexes.size < MAX_OUTPUTS_PER_RECORD; index -= 1) {
+    if (isCriticalOutput(outputs[index])) retainedIndexes.add(index);
+  }
+  for (let index = outputs.length - 1; index >= 0 && retainedIndexes.size < MAX_OUTPUTS_PER_RECORD; index -= 1) {
+    if (!retainedIndexes.has(index)) retainedIndexes.add(index);
+  }
+  return outputs.filter((_, index) => retainedIndexes.has(index));
+}
+
+function isCriticalOutput(output: SqlExecutionLogOutput) {
+  return output.kind === 'message' ? output.level === 'ERROR' : !output.success;
+}
+
+function truncateMessage(value: string) {
+  if (value.length <= MAX_MESSAGE_LENGTH) return value;
+  const characters = Array.from(value);
+  if (characters.length <= MAX_MESSAGE_LENGTH) return value;
+  const retainedLength = MAX_MESSAGE_LENGTH - MESSAGE_TRUNCATION_MARKER.length;
+  const prefixLength = Math.ceil(retainedLength / 2);
+  const suffixLength = Math.floor(retainedLength / 2);
+  return `${characters.slice(0, prefixLength).join('')}${MESSAGE_TRUNCATION_MARKER}${characters
+    .slice(-suffixLength)
+    .join('')}`;
+}
+
+function nextMessageSequence(record: SqlExecutionLogRecord) {
+  const prefix = `${record.id}:message:`;
+  return record.outputs.reduce((next, output) => {
+    if (!output.id.startsWith(prefix)) return next;
+    const sequence = Number(output.id.slice(prefix.length).split(':')[1]);
+    return Number.isFinite(sequence) ? Math.max(next, sequence + 1) : next;
+  }, 0);
+}
+
+function nextResultSequence(record: SqlExecutionLogRecord) {
+  return record.outputs.reduce(
+    (next, output) =>
+      output.kind === 'result' && typeof output.resultSequence === 'number'
+        ? Math.max(next, output.resultSequence + 1)
+        : next,
+    1,
+  );
 }
 
 function finishTerminal(record: SqlExecutionLogRecord, event: SqlExecutionEvent, occurredAtEpochMs: number) {
@@ -431,7 +529,7 @@ function finishTerminal(record: SqlExecutionLogRecord, event: SqlExecutionEvent,
 
 function addError(record: SqlExecutionLogRecord, error: unknown, occurredAtEpochMs: number) {
   const message = errorText(error);
-  return message ? addMessage(record, { level: 'ERROR', message }, occurredAtEpochMs) : record;
+  return message ? appendMessage(record, { level: 'ERROR', message }, occurredAtEpochMs) : record;
 }
 
 function updateRecord(

--- a/chat2db-community-client/src/service/sqlExecutionLog.ts
+++ b/chat2db-community-client/src/service/sqlExecutionLog.ts
@@ -171,7 +171,7 @@ export function failWebSqlExecution(
   params: FailWebSqlExecutionParams,
 ): SqlExecutionLogState {
   const finishedAtEpochMs = params.occurredAtEpochMs ?? Date.now();
-  const cancelled = isCancellationError(params.error);
+  const cancelled = isSqlExecutionCancellationError(params.error);
   const existing = latestRecord(state.records, params.executionId);
   if (!existing) {
     const record = createRecord({
@@ -598,13 +598,14 @@ function errorText(error: unknown): string {
   return text(value.message) || text(value.errorMessage);
 }
 
-function isCancellationError(error: unknown) {
-  if (!error || typeof error !== 'object') {
-    return typeof error === 'string' && isCancellationMessage(error);
-  }
-  const value = error as { name?: unknown; code?: unknown; message?: unknown };
-  if (value.name === 'AbortError' || value.code === 'ERR_CANCELED') return true;
-  return typeof value.message === 'string' && isCancellationMessage(value.message);
+export function isSqlExecutionCancellationError(error: unknown) {
+  if (!error || typeof error !== 'object') return false;
+  const value = error as { name?: unknown; code?: unknown };
+  return value.name === 'AbortError' || value.name === 'CanceledError' || value.code === 'ERR_CANCELED';
+}
+
+export function rethrowNonCancellationSqlExecutionError(error: unknown) {
+  if (!isSqlExecutionCancellationError(error)) throw error;
 }
 
 function isCancellationMessage(message?: string) {

--- a/chat2db-community-client/src/service/sqlExecutionStream.ts
+++ b/chat2db-community-client/src/service/sqlExecutionStream.ts
@@ -164,8 +164,8 @@ export function sortExecutionResults(current: IManageResultData[]) {
     if (leftExecution !== rightExecution) {
       return leftExecution - rightExecution;
     }
-    const leftStatement = Number(left.extra?.statementSequence || 0);
-    const rightStatement = Number(right.extra?.statementSequence || 0);
+    const leftStatement = Number(left.extra?.statementSequence ?? left.statementSequence ?? 0);
+    const rightStatement = Number(right.extra?.statementSequence ?? right.statementSequence ?? 0);
     if (leftStatement !== rightStatement) {
       return leftStatement - rightStatement;
     }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/SqlServerExecutor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/SqlServerExecutor.java
@@ -1,14 +1,20 @@
 package ai.chat2db.plugin.sqlserver;
 
 import ai.chat2db.community.domain.api.model.sql.SqlExecuteRequest;
+import ai.chat2db.community.domain.api.config.DBConfig;
 import ai.chat2db.community.domain.api.model.result.ExecutionContext;
 import ai.chat2db.community.domain.api.model.result.ExecuteResponse;
 import ai.chat2db.community.domain.api.model.sql.SimpleSqlStatement;
+import ai.chat2db.community.domain.api.service.db.ISqlExecutionCancellation;
+import ai.chat2db.community.domain.api.service.db.ISqlExecutionResultConsumer;
+import ai.chat2db.community.domain.api.service.db.ISqlExecutionStatementListener;
 import ai.chat2db.spi.model.ExecutionTiming;
 import ai.chat2db.spi.model.JdbcExecutionContext;
 import ai.chat2db.spi.model.request.SqlStatementExecuteRequest;
 import ai.chat2db.spi.DefaultSQLExecutor;
+import ai.chat2db.spi.util.SqlUtils;
 import cn.hutool.core.date.TimeInterval;
+import com.alibaba.druid.DbType;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -17,7 +23,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import static ai.chat2db.plugin.sqlserver.constant.SqlServerExecutorConstants.*;
 public class SqlServerExecutor extends DefaultSQLExecutor {
@@ -28,6 +33,45 @@ public class SqlServerExecutor extends DefaultSQLExecutor {
     public List<ExecuteResponse> execute(SqlExecuteRequest command) {
         prepareCommandScript(command);
         return super.execute(command);
+    }
+
+    @Override
+    public void executeStreaming(SqlExecuteRequest command, ISqlExecutionResultConsumer consumer,
+                                 ISqlExecutionStatementListener statementListener,
+                                 ISqlExecutionCancellation cancellation) throws SQLException {
+        prepareCommandScript(command);
+        super.executeStreaming(command, consumer, statementListener, cancellation);
+    }
+
+    @Override
+    protected List<SimpleSqlStatement> buildSimpleSqlStatements(SqlExecuteRequest command, DbType dbType,
+                                                                 String type, DBConfig dbConfig) {
+        List<String> sqlList = splitByGO(command.getScript());
+        if (GO_DELIMITER_PATTERN.matcher(command.getScript()).find()) {
+            List<SimpleSqlStatement> statements = new ArrayList<>(sqlList.size());
+            for (String sql : sqlList) {
+                List<SimpleSqlStatement> parsedStatements = SqlUtils.parseStatements(sql, dbType, type);
+                if (shouldUsePreservedCompositeStatement(command, dbConfig, parsedStatements)) {
+                    statements.add(preservedCompositeStatement(sql));
+                } else if (parsedStatements.size() == 1) {
+                    SimpleSqlStatement statement = parsedStatements.get(0);
+                    statement.setSql(sql);
+                    statements.add(statement);
+                } else {
+                    statements.add(new SimpleSqlStatement(sql));
+                }
+            }
+            return statements;
+        }
+        return super.buildSimpleSqlStatements(command, dbType, type, dbConfig);
+    }
+
+    @Override
+    protected ExecutionContext executionContextAfterExecute(SimpleSqlStatement statement, Connection connection,
+                                                             ExecutionContext statementStartContext) {
+        return isPreservedCompositeStatement(statement)
+                ? JdbcExecutionContext.capture(connection)
+                : statementStartContext;
     }
 
     void prepareCommandScript(SqlExecuteRequest command) {
@@ -95,10 +139,19 @@ public class SqlServerExecutor extends DefaultSQLExecutor {
     protected List<ExecuteResponse> executeMulti(SimpleSqlStatement simpleSqlStatement, Connection connection,
                                                boolean limitRowSize, Integer offset, Integer count, Integer resultSetId)
             throws SQLException {
+        return executeMulti(simpleSqlStatement, connection, limitRowSize, offset, count, resultSetId,
+                JdbcExecutionContext.capture(connection));
+    }
+
+    @Override
+    protected List<ExecuteResponse> executeMulti(SimpleSqlStatement simpleSqlStatement, Connection connection,
+                                               boolean limitRowSize, Integer offset, Integer count, Integer resultSetId,
+                                               ExecutionContext executionContext) throws SQLException {
         List<String> sqlList = splitByGO(simpleSqlStatement.getSql());
         if (sqlList.size() <= 1) {
             simpleSqlStatement.setSql(removeSpecialGO(simpleSqlStatement.getSql()));
-            return super.executeMulti(simpleSqlStatement, connection, limitRowSize, offset, count, resultSetId);
+            return super.executeMulti(simpleSqlStatement, connection, limitRowSize, offset, count, resultSetId,
+                    executionContext);
         }
         return executeSqlServerBatch(simpleSqlStatement.getSql(), sqlList, connection, limitRowSize, offset, count,
                 resultSetId);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/SqlServerExecutorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/SqlServerExecutorTest.java
@@ -1,20 +1,82 @@
 package ai.chat2db.plugin.sqlserver;
 
+import ai.chat2db.community.domain.api.config.DriverConfig;
+import ai.chat2db.community.domain.api.config.DBConfig;
+import ai.chat2db.community.domain.api.model.result.ResultCell;
 import ai.chat2db.community.domain.api.model.sql.SqlExecuteRequest;
 import ai.chat2db.community.domain.api.model.sql.SimpleSqlStatement;
 import ai.chat2db.community.domain.api.model.result.ExecuteResponse;
+import ai.chat2db.community.domain.api.service.db.ISqlExecutionResultConsumer;
+import ai.chat2db.community.domain.api.service.db.ISqlExecutionStatementListener;
+import ai.chat2db.community.tools.util.I18nUtils;
+import ai.chat2db.spi.IPlugin;
+import ai.chat2db.spi.model.datasource.ConnectInfo;
 import ai.chat2db.spi.model.request.SqlStatementExecuteRequest;
+import ai.chat2db.spi.sql.Chat2DBContext;
+import ai.chat2db.spi.sql.ConnectionPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceResolvable;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SqlServerExecutorTest {
+
+    private static final long DATA_SOURCE_ID = 707L;
+
+    private IPlugin previousPlugin;
+    private boolean contextBound;
+
+    @BeforeAll
+    static void setUpI18n() throws Exception {
+        Field field = I18nUtils.class.getDeclaredField("messageSourceStatic");
+        field.setAccessible(true);
+        field.set(null, new MessageSource() {
+            @Override
+            public String getMessage(String code, Object[] args, String defaultMessage, Locale locale) {
+                return defaultMessage == null ? code : defaultMessage;
+            }
+
+            @Override
+            public String getMessage(String code, Object[] args, Locale locale) {
+                return code;
+            }
+
+            @Override
+            public String getMessage(MessageSourceResolvable resolvable, Locale locale) {
+                String[] codes = resolvable.getCodes();
+                return codes == null || codes.length == 0 ? resolvable.getDefaultMessage() : codes[0];
+            }
+        });
+    }
+
+    @AfterEach
+    void tearDownContext() {
+        if (!contextBound) {
+            return;
+        }
+        Chat2DBContext.removeContext();
+        ConnectionPool.removeConnection(DATA_SOURCE_ID);
+        if (previousPlugin == null) {
+            Chat2DBContext.PLUGIN_MAP.remove("SQLSERVER");
+        } else {
+            Chat2DBContext.PLUGIN_MAP.put("SQLSERVER", previousPlugin);
+        }
+    }
 
     @Test
     void shouldKeepGoBatchWhenExecutingFormalSql() {
@@ -105,6 +167,231 @@ class SqlServerExecutorTest {
                     >= results.get(0).getExecutionMetrics().getStartedAtEpochMs());
             assertTrue(results.get(2).getExecutionMetrics().getStartedAtEpochMs()
                     >= results.get(1).getExecutionMetrics().getStartedAtEpochMs());
+        }
+    }
+
+    @Test
+    void topLevelStreamingTreatsGoBatchesAsIndependentStatements() throws Exception {
+        List<String> preparedSql = new ArrayList<>();
+        String[] catalog = {"source_database"};
+        Connection connection = streamingConnection(catalog, preparedSql);
+        putContext(connection);
+        SqlExecuteRequest request = request(
+                "USE target_database;\nGO\nUPDATE sample SET value = 1;\nGO\nUPDATE sample SET value = 2;");
+        CapturingConsumer consumer = new CapturingConsumer();
+        CountingStatementListener listener = new CountingStatementListener();
+
+        new SqlServerExecutor().executeStreaming(request, consumer, listener, () -> false);
+
+        assertEquals(3, consumer.startedSql.size());
+        assertEquals(3, consumer.finishedResults.size());
+        assertEquals(3, preparedSql.size());
+        assertEquals(3, listener.created);
+        assertEquals(List.of(1, 2, 3), consumer.finishedResults.stream()
+                .map(ExecuteResponse::getStatementSequence).toList());
+        assertEquals("target_database",
+                consumer.finishedResults.get(1).getExecutionContext().getDatabaseName());
+    }
+
+    @Test
+    void topLevelStreamingRemovesSingleTrailingGoDelimiter() throws Exception {
+        List<String> preparedSql = new ArrayList<>();
+        Connection connection = streamingConnection(new String[]{"source_database"}, preparedSql);
+        putContext(connection);
+        CapturingConsumer consumer = new CapturingConsumer();
+
+        SqlExecuteRequest request = request("UPDATE sample SET value = 1;\nGO");
+        request.setSingle(true);
+        new SqlServerExecutor().executeStreaming(request, consumer, new CountingStatementListener(), () -> false);
+
+        assertEquals(1, consumer.startedSql.size());
+        assertEquals(List.of("UPDATE sample SET value = 1;"), preparedSql);
+    }
+
+    @Test
+    void preservedBatchUsesPostExecutionContextWithoutSplittingOnSemicolons() throws Exception {
+        assertPreservedBatchUsesPostExecutionContext(false);
+    }
+
+    @Test
+    void singleSelectionPreservesCompositeBatchAndUsesPostExecutionContext() throws Exception {
+        assertPreservedBatchUsesPostExecutionContext(true);
+    }
+
+    private void assertPreservedBatchUsesPostExecutionContext(boolean single) throws Exception {
+        List<String> preparedSql = new ArrayList<>();
+        String[] catalog = {"source_database"};
+        Connection connection = streamingConnection(catalog, preparedSql);
+        putContext(connection);
+        String sql = "USE target_database; DECLARE @value INT = 1; UPDATE sample SET value = @value;";
+        CapturingConsumer consumer = new CapturingConsumer();
+        SqlExecuteRequest request = request(sql);
+        request.setSingle(single);
+
+        new SqlServerExecutor().executeStreaming(request, consumer,
+                new CountingStatementListener(), () -> false);
+
+        assertEquals(1, consumer.startedSql.size());
+        assertEquals(1, preparedSql.size());
+        assertEquals(sql, preparedSql.get(0));
+        assertEquals(1, consumer.finishedResults.size());
+        assertEquals("target_database",
+                consumer.finishedResults.get(0).getExecutionContext().getDatabaseName());
+    }
+
+    private void putContext(Connection connection) {
+        previousPlugin = Chat2DBContext.PLUGIN_MAP.put("SQLSERVER", new TestSqlServerPlugin());
+        contextBound = true;
+        ConnectInfo connectInfo = new ConnectInfo();
+        connectInfo.setDataSourceId(DATA_SOURCE_ID);
+        connectInfo.setConsoleId(1L);
+        connectInfo.setDbType("SQLSERVER");
+        connectInfo.setDatabaseName("");
+        connectInfo.setSchemaName("dbo");
+        connectInfo.setUrl("jdbc:test:sqlserver");
+        connectInfo.setConnection(connection);
+        DriverConfig driverConfig = new DriverConfig();
+        driverConfig.setDbType("SQLSERVER");
+        connectInfo.setDriverConfig(driverConfig);
+        Chat2DBContext.putContext(connectInfo);
+    }
+
+    private static SqlExecuteRequest request(String sql) {
+        SqlExecuteRequest request = new SqlExecuteRequest();
+        request.setScript(sql);
+        request.setConsoleId(1L);
+        request.setDataSourceId(DATA_SOURCE_ID);
+        request.setDatabaseName("");
+        request.setSchemaName("dbo");
+        request.setPageNo(1);
+        request.setPageSize(10);
+        request.setErrorContinue(Boolean.TRUE);
+        return request;
+    }
+
+    private static Connection streamingConnection(String[] catalog, List<String> preparedSql) {
+        return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class<?>[]{Connection.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "prepareStatement" -> preparedStatement((String) args[0], catalog, preparedSql);
+                    case "getCatalog" -> catalog[0];
+                    case "getSchema" -> "dbo";
+                    case "isClosed" -> false;
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static PreparedStatement preparedStatement(String sql, String[] catalog, List<String> preparedSql) {
+        preparedSql.add(sql);
+        boolean[] exhausted = {false};
+        return (PreparedStatement) Proxy.newProxyInstance(PreparedStatement.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class}, (proxy, method, args) -> switch (method.getName()) {
+                    case "execute" -> {
+                        exhausted[0] = false;
+                        if (sql.toLowerCase(Locale.ROOT).contains("use target_database")) {
+                            catalog[0] = "target_database";
+                        }
+                        yield false;
+                    }
+                    case "getUpdateCount" -> exhausted[0] ? -1 : 1;
+                    case "getMoreResults" -> {
+                        exhausted[0] = true;
+                        yield false;
+                    }
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == double.class) {
+            return 0D;
+        }
+        if (returnType == float.class) {
+            return 0F;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+        return null;
+    }
+
+    private static final class CapturingConsumer implements ISqlExecutionResultConsumer {
+
+        private final List<String> startedSql = new ArrayList<>();
+        private final List<ExecuteResponse> finishedResults = new ArrayList<>();
+
+        @Override
+        public void statementStarted(String sql, String originalSql, String comment) {
+            startedSql.add(sql);
+        }
+
+        @Override
+        public void resultStarted(ExecuteResponse result) {
+        }
+
+        @Override
+        public void rows(ExecuteResponse result, List<List<ResultCell>> rows) {
+        }
+
+        @Override
+        public void resultFinished(ExecuteResponse result) {
+            finishedResults.add(result);
+        }
+
+        @Override
+        public void updateCount(ExecuteResponse result) {
+        }
+
+        @Override
+        public void statementFinished(String sql, long duration) {
+        }
+    }
+
+    private static final class CountingStatementListener implements ISqlExecutionStatementListener {
+
+        private int created;
+
+        @Override
+        public void onStatementCreated(Statement statement) {
+            created++;
+        }
+
+        @Override
+        public void onStatementClosed(Statement statement) {
+        }
+    }
+
+    private static final class TestSqlServerPlugin extends SqlServerSyntaxPlugin implements IPlugin {
+
+        private final DBConfig dbConfig = new DBConfig();
+
+        private TestSqlServerPlugin() {
+            dbConfig.setDbType("SQLSERVER");
+            dbConfig.setSupportDatabase(true);
+            dbConfig.setSupportSchema(true);
+            dbConfig.setPreserveScriptBatchExecution(true);
+        }
+
+        @Override
+        public DBConfig getDBConfig() {
+            return dbConfig;
         }
     }
 

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
@@ -252,6 +252,8 @@ public class DefaultSQLExecutor implements ICommandExecutor {
             long executeStartedNanos = System.nanoTime();
             boolean query = stmt.execute();
             long executeDurationNanos = ExecutionTiming.elapsedNanos(executeStartedNanos);
+            executionContext = executionContextAfterExecute(
+                    new SimpleSqlStatement(sql), connection, executionContext);
             long fetchDurationNanos = 0L;
             executeResult.setDescription(I18nUtils.getMessage("sqlResult.success"));
             if (query) {
@@ -555,6 +557,9 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         DBConfig dbConfig = Chat2DBContext.getDBConfig();
         DbType dbType = JdbcUtils.parse2DruidDbType(type);
         Connection connection = Chat2DBContext.getConnection();
+        alignConnectionContext(command, connection);
+        JdbcExecutionContext.Cursor executionContextCursor = JdbcExecutionContext.cursor(
+                connection, command.getDatabaseName());
         List<SimpleSqlStatement> simpleSqlStatements = buildSimpleSqlStatements(command, dbType, type, dbConfig);
 
         if (CollectionUtils.isEmpty(simpleSqlStatements)) {
@@ -571,8 +576,9 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         for (SimpleSqlStatement simpleSqlStatement : simpleSqlStatements) {
             statementSequence++;
             String sqlType = simpleSqlStatement.getSqlType();
-            List<ExecuteResponse> executeResults = executeSQL(simpleSqlStatement, dbType, command);
-            synchronizeExecutionContext(simpleSqlStatement, connection, executeResults);
+            List<ExecuteResponse> executeResults = executeSQL(simpleSqlStatement, dbType, command, connection,
+                    executionContextCursor.current());
+            advanceExecutionContext(executionContextCursor, connection, simpleSqlStatement, executeResults);
             boolean errorOccurred = false;
             for (ExecuteResponse executeResult : executeResults) {
                 executeResult.setStatementSequence(statementSequence);
@@ -630,11 +636,15 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         if (StringUtils.isBlank(command.getScript())) {
             return;
         }
+        checkCanceled(cancellation);
         String type = Chat2DBContext.getConnectInfo().getDbType();
         IDbMetaData metaData = Chat2DBContext.getDbMetaData();
         DBConfig dbConfig = Chat2DBContext.getDBConfig();
         DbType dbType = JdbcUtils.parse2DruidDbType(type);
         Connection connection = Chat2DBContext.getConnection();
+        alignConnectionContext(command, connection);
+        JdbcExecutionContext.Cursor executionContextCursor = JdbcExecutionContext.cursor(
+                connection, command.getDatabaseName());
         List<SimpleSqlStatement> simpleSqlStatements = buildSimpleSqlStatements(command, dbType, type, dbConfig);
 
         if (CollectionUtils.isEmpty(simpleSqlStatements)) {
@@ -652,9 +662,11 @@ public class DefaultSQLExecutor implements ICommandExecutor {
             statementSequence++;
             checkCanceled(cancellation);
             String sqlType = simpleSqlStatement.getSqlType();
-            List<ExecuteResponse> executeResults = executeSQLStreaming(simpleSqlStatement, dbType, command, consumer,
-                    statementListener, cancellation, streamResultSequence, statementSequence);
-            synchronizeExecutionContext(simpleSqlStatement, connection, executeResults);
+            List<ExecuteResponse> executeResults = executeSQLStreaming(simpleSqlStatement, dbType, command, connection,
+                    consumer,
+                    statementListener, cancellation, streamResultSequence, statementSequence,
+                    executionContextCursor.current());
+            advanceExecutionContext(executionContextCursor, connection, simpleSqlStatement, executeResults);
             boolean errorOccurred = false;
             for (ExecuteResponse executeResult : executeResults) {
                 executeResult.setStatementSequence(statementSequence);
@@ -702,35 +714,43 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         }
     }
 
-    protected void synchronizeExecutionContext(SimpleSqlStatement statement, Connection connection,
-                                               List<ExecuteResponse> executeResults) {
-        if (CollectionUtils.isEmpty(executeResults)
-                || executeResults.stream().anyMatch(result -> !Boolean.TRUE.equals(result.getSuccess()))) {
+    protected void alignConnectionContext(SqlExecuteRequest command, Connection connection) {
+        ConnectInfo connectInfo = Chat2DBContext.getConnectInfo();
+        if (connectInfo == null) {
             return;
         }
-        List<RefreshTarget> targets = Optional.ofNullable(statement.getRefreshTargets())
+        DBConfig dbConfig = Chat2DBContext.getDBConfig();
+        if (dbConfig == null || !dbConfig.isSupportDatabase()
+                || StringUtils.isBlank(command.getDatabaseName())) {
+            return;
+        }
+        Chat2DBContext.getDbManager().connectDatabase(connection, command.getDatabaseName());
+    }
+
+    protected ExecutionContext executionContextAfterExecute(SimpleSqlStatement statement, Connection connection,
+                                                             ExecutionContext statementStartContext) {
+        return statementStartContext;
+    }
+
+    protected void advanceExecutionContext(JdbcExecutionContext.Cursor cursor, Connection connection,
+                                           SimpleSqlStatement statement, List<ExecuteResponse> executeResults) {
+        boolean succeeded = CollectionUtils.isNotEmpty(executeResults) && executeResults.stream()
+                .allMatch(result -> Boolean.TRUE.equals(result.getSuccess()));
+        cursor.advance(connection, succeeded ? databaseContextFallback(statement) : null);
+    }
+
+    private String databaseContextFallback(SimpleSqlStatement statement) {
+        if (!ai.chat2db.community.domain.api.enums.parser.SqlTypeEnum.USE_DATABASE.name()
+                .equals(statement.getSqlType())) {
+            return null;
+        }
+        return Optional.ofNullable(statement.getRefreshTargets())
                 .orElseGet(Collections::emptyList)
                 .stream()
-                .toList();
-        if (ai.chat2db.community.domain.api.enums.parser.SqlTypeEnum.USE_DATABASE.name()
-                .equals(statement.getSqlType())) {
-            String databaseName = targets.stream()
                 .map(RefreshTarget::getDatabaseName)
                 .filter(StringUtils::isNotBlank)
                 .findFirst()
                 .orElse(null);
-            JdbcExecutionContext.synchronizeCatalog(connection, databaseName);
-        } else if (ai.chat2db.community.domain.api.enums.parser.SqlTypeEnum.SET_SCHEMA.name()
-                .equals(statement.getSqlType())) {
-            List<String> schemaNames = targets.stream()
-                    .map(RefreshTarget::getSchemaName)
-                    .filter(StringUtils::isNotBlank)
-                    .distinct()
-                    .toList();
-            if (schemaNames.size() == 1) {
-                JdbcExecutionContext.synchronizeSchema(connection, schemaNames.get(0));
-            }
-        }
     }
 
     protected List<SimpleSqlStatement> buildSimpleSqlStatements(SqlExecuteRequest command, DbType dbType, String type,
@@ -743,6 +763,8 @@ public class DefaultSQLExecutor implements ICommandExecutor {
             if (CollectionUtils.isNotEmpty(sqlStatements) && sqlStatements.size() == 1) {
                 simpleSqlStatement = sqlStatements.get(0);
                 simpleSqlStatement.setSql(sql);
+            } else if (shouldUsePreservedCompositeStatement(command, dbConfig, sqlStatements)) {
+                simpleSqlStatement = preservedCompositeStatement(sql);
             } else {
                 simpleSqlStatement = new SimpleSqlStatement(sql);
             }
@@ -753,7 +775,7 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         if (command.getScript().length() < 50000) {
             simpleSqlStatements = SqlUtils.parseStatements(command.getScript(), dbType, type);
             if (shouldPreserveScriptBatchExecution(command, dbConfig, simpleSqlStatements)) {
-                return Collections.singletonList(new SimpleSqlStatement(command.getScript()));
+                return Collections.singletonList(preservedCompositeStatement(command.getScript()));
             }
         } else {
             List<String> parse = SqlUtils.parse(command.getScript(), dbType, true);
@@ -762,13 +784,33 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         return simpleSqlStatements;
     }
 
-    private boolean shouldPreserveScriptBatchExecution(SqlExecuteRequest command, DBConfig dbConfig,
-                                                       List<SimpleSqlStatement> simpleSqlStatements) {
+    protected boolean shouldPreserveScriptBatchExecution(SqlExecuteRequest command, DBConfig dbConfig,
+                                                         List<SimpleSqlStatement> simpleSqlStatements) {
+        return !command.isSingle()
+                && shouldUsePreservedCompositeStatement(command, dbConfig, simpleSqlStatements);
+    }
+
+    protected boolean shouldUsePreservedCompositeStatement(SqlExecuteRequest command, DBConfig dbConfig,
+                                                            List<SimpleSqlStatement> simpleSqlStatements) {
         return dbConfig != null
                 && dbConfig.isPreserveScriptBatchExecution()
-                && !command.isSingle()
                 && !command.isExplain()
                 && CollectionUtils.size(simpleSqlStatements) > 1;
+    }
+
+    protected SimpleSqlStatement preservedCompositeStatement(String sql) {
+        return new PreservedCompositeStatement(sql);
+    }
+
+    protected boolean isPreservedCompositeStatement(SimpleSqlStatement statement) {
+        return statement instanceof PreservedCompositeStatement;
+    }
+
+    private static final class PreservedCompositeStatement extends SimpleSqlStatement {
+
+        private PreservedCompositeStatement(String sql) {
+            super(sql);
+        }
     }
 
     private void setExplain(List<SimpleSqlStatement> simpleSqlStatements) {
@@ -781,8 +823,12 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         }
     }
 
-    private List<ExecuteResponse> executeSQL(SimpleSqlStatement simpleSqlStatement, DbType dbType, SqlExecuteRequest param) {
+    private List<ExecuteResponse> executeSQL(SimpleSqlStatement simpleSqlStatement, DbType dbType,
+                                              SqlExecuteRequest param, Connection connection,
+                                              ExecutionContext executionContext) {
         String originalSql = simpleSqlStatement.getSql();
+        long startedAtEpochMs = System.currentTimeMillis();
+        long startedAtNanos = System.nanoTime();
         int pageNo = Optional.ofNullable(param.getPageNo()).orElse(1);
         int pageSize = Optional.ofNullable(param.getPageSize()).orElse(IEasyToolsConstant.MAX_PAGE_SIZE);
         Integer offset = (pageNo - 1) * pageSize;
@@ -803,7 +849,8 @@ public class DefaultSQLExecutor implements ICommandExecutor {
                     if (type == null || !StringUtils.equals(type, ai.chat2db.community.domain.api.enums.parser.SqlTypeEnum.SELECT_INTO.name())) {
                         simpleSqlStatement.setSql(buildPageLimit);
                     }
-                    executeResults = executeMulti(simpleSqlStatement, Chat2DBContext.getConnection(), true, 0, count, param.getResultSetId());
+                    executeResults = executeMulti(simpleSqlStatement, connection, true, 0, count,
+                            param.getResultSetId(), executionContext);
                     if (CollectionUtils.isNotEmpty(executeResults)) {
                         for (ExecuteResponse executeResult : executeResults) {
                             executeResult.setSqlType(sqlType.getCode());
@@ -817,7 +864,6 @@ public class DefaultSQLExecutor implements ICommandExecutor {
             }
         }
         if (CollectionUtils.isEmpty(executeResults)) {
-            long startedAtEpochMs = System.currentTimeMillis();
             try {
                 simpleSqlStatement.setSql(originalSql);
                 if (type != null && StringUtils.equalsAnyIgnoreCase(type, ai.chat2db.community.domain.api.enums.parser.SqlTypeEnum.MERGE.name(),
@@ -826,12 +872,14 @@ public class DefaultSQLExecutor implements ICommandExecutor {
                         simpleSqlStatement.setSql(originalSql + ";");
                     }
                 }
-                executeResults = executeMulti(simpleSqlStatement, Chat2DBContext.getConnection(), true, offset, count, param.getResultSetId());
+                executeResults = executeMulti(simpleSqlStatement, connection, true, offset, count,
+                        param.getResultSetId(), executionContext);
                 for (ExecuteResponse executeResult : executeResults) {
                     executeResult.setSql(originalSql);
                 }
             } catch (Exception ee) {
-                ExecuteResponse executeResult = failedExecuteResponse(originalSql, ee, startedAtEpochMs);
+                ExecuteResponse executeResult = failedExecuteResponse(
+                        originalSql, ee, startedAtEpochMs, startedAtNanos, executionContext);
                 executeResults.add(executeResult);
             }
         }
@@ -847,13 +895,17 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         return executeResults;
     }
 
-    private List<ExecuteResponse> executeSQLStreaming(SimpleSqlStatement simpleSqlStatement, DbType dbType, SqlExecuteRequest param,
+    private List<ExecuteResponse> executeSQLStreaming(SimpleSqlStatement simpleSqlStatement, DbType dbType,
+                                                    SqlExecuteRequest param, Connection connection,
                                                     ISqlExecutionResultConsumer consumer,
                                                     ISqlExecutionStatementListener statementListener,
                                                     ISqlExecutionCancellation cancellation,
                                                     AtomicInteger streamResultSequence,
-                                                    int statementSequence) {
+                                                    int statementSequence,
+                                                    ExecutionContext executionContext) {
         String originalSql = simpleSqlStatement.getSql();
+        long startedAtEpochMs = System.currentTimeMillis();
+        long startedAtNanos = System.nanoTime();
         int pageNo = Optional.ofNullable(param.getPageNo()).orElse(1);
         int pageSize = Optional.ofNullable(param.getPageSize()).orElse(IEasyToolsConstant.MAX_PAGE_SIZE);
         Integer offset = (pageNo - 1) * pageSize;
@@ -875,9 +927,10 @@ public class DefaultSQLExecutor implements ICommandExecutor {
                     if (type == null || !StringUtils.equals(type, ai.chat2db.community.domain.api.enums.parser.SqlTypeEnum.SELECT_INTO.name())) {
                         simpleSqlStatement.setSql(buildPageLimit);
                     }
-                    executeResults = executeMultiStreaming(simpleSqlStatement, Chat2DBContext.getConnection(), true,
+                    executeResults = executeMultiStreaming(simpleSqlStatement, connection, true,
                             0, count, param.getResultSetId(), consumer, statementListener, cancellation,
-                            sqlType, originalSql, pageNo, pageSize, streamResultSequence, statementSequence);
+                            sqlType, originalSql, pageNo, pageSize, streamResultSequence, statementSequence,
+                            executionContext);
                     if (CollectionUtils.isNotEmpty(executeResults)) {
                         for (ExecuteResponse executeResult : executeResults) {
                             executeResult.setSqlType(sqlType.getCode());
@@ -891,7 +944,6 @@ public class DefaultSQLExecutor implements ICommandExecutor {
             }
         }
         if (CollectionUtils.isEmpty(executeResults)) {
-            long startedAtEpochMs = System.currentTimeMillis();
             try {
                 simpleSqlStatement.setSql(originalSql);
                 if (type != null && StringUtils.equalsAnyIgnoreCase(type, ai.chat2db.community.domain.api.enums.parser.SqlTypeEnum.MERGE.name(),
@@ -900,14 +952,16 @@ public class DefaultSQLExecutor implements ICommandExecutor {
                         simpleSqlStatement.setSql(originalSql + ";");
                     }
                 }
-                executeResults = executeMultiStreaming(simpleSqlStatement, Chat2DBContext.getConnection(), true,
+                executeResults = executeMultiStreaming(simpleSqlStatement, connection, true,
                         offset, count, param.getResultSetId(), consumer, statementListener, cancellation,
-                        sqlType, originalSql, pageNo, pageSize, streamResultSequence, statementSequence);
+                        sqlType, originalSql, pageNo, pageSize, streamResultSequence, statementSequence,
+                        executionContext);
                 for (ExecuteResponse executeResult : executeResults) {
                     executeResult.setSql(originalSql);
                 }
             } catch (Exception ee) {
-                ExecuteResponse executeResult = failedExecuteResponse(originalSql, ee, startedAtEpochMs);
+                ExecuteResponse executeResult = failedExecuteResponse(
+                        originalSql, ee, startedAtEpochMs, startedAtNanos, executionContext);
                 executeResults.add(executeResult);
             }
         }
@@ -922,7 +976,15 @@ public class DefaultSQLExecutor implements ICommandExecutor {
     }
 
     protected List<ExecuteResponse> executeMulti(SimpleSqlStatement simpleSqlStatement, Connection connection,
-                                             boolean limitRowSize, Integer offset, Integer count, Integer resultSetId) throws SQLException {
+                                             boolean limitRowSize, Integer offset, Integer count,
+                                             Integer resultSetId) throws SQLException {
+        return executeMulti(simpleSqlStatement, connection, limitRowSize, offset, count, resultSetId,
+                JdbcExecutionContext.capture(connection));
+    }
+
+    protected List<ExecuteResponse> executeMulti(SimpleSqlStatement simpleSqlStatement, Connection connection,
+                                             boolean limitRowSize, Integer offset, Integer count, Integer resultSetId,
+                                             ExecutionContext executionContext) throws SQLException {
         String sql = simpleSqlStatement.getSql();
         String type = simpleSqlStatement.getSqlType();
         Assert.notNull(sql, "SQL must not be null");
@@ -938,11 +1000,11 @@ public class DefaultSQLExecutor implements ICommandExecutor {
                 }
             }
             TimeInterval timeInterval = new TimeInterval();
-            ExecutionContext executionContext = JdbcExecutionContext.capture(connection);
             long startedAtEpochMs = System.currentTimeMillis();
             long executeStartedNanos = System.nanoTime();
             boolean query = stmt.execute();
             long executeDurationNanos = ExecutionTiming.elapsedNanos(executeStartedNanos);
+            executionContext = executionContextAfterExecute(simpleSqlStatement, connection, executionContext);
             int resultCount = 0;
             while (true) {
                 ExecuteResponse executeResult = ExecuteResponse.builder().sql(sql).success(Boolean.TRUE).build();
@@ -989,6 +1051,20 @@ public class DefaultSQLExecutor implements ICommandExecutor {
                                                         String originalSql, int pageNo, int pageSize,
                                                         AtomicInteger streamResultSequence,
                                                         int statementSequence) throws SQLException {
+        return executeMultiStreaming(simpleSqlStatement, connection, limitRowSize, offset, count, resultSetId,
+                consumer, statementListener, cancellation, sqlType, originalSql, pageNo, pageSize,
+                streamResultSequence, statementSequence, JdbcExecutionContext.capture(connection));
+    }
+
+    protected List<ExecuteResponse> executeMultiStreaming(SimpleSqlStatement simpleSqlStatement, Connection connection,
+                                                        boolean limitRowSize, Integer offset, Integer count,
+                                                        Integer resultSetId, ISqlExecutionResultConsumer consumer,
+                                                        ISqlExecutionStatementListener statementListener,
+                                                        ISqlExecutionCancellation cancellation, SqlTypeEnum sqlType,
+                                                        String originalSql, int pageNo, int pageSize,
+                                                        AtomicInteger streamResultSequence,
+                                                        int statementSequence,
+                                                        ExecutionContext executionContext) throws SQLException {
         String sql = simpleSqlStatement.getSql();
         String type = simpleSqlStatement.getSqlType();
         Assert.notNull(sql, "SQL must not be null");
@@ -1007,11 +1083,11 @@ public class DefaultSQLExecutor implements ICommandExecutor {
             }
             TimeInterval timeInterval = new TimeInterval();
             checkCanceled(cancellation);
-            ExecutionContext executionContext = JdbcExecutionContext.capture(connection);
             long startedAtEpochMs = System.currentTimeMillis();
             long executeStartedNanos = System.nanoTime();
             boolean query = stmt.execute();
             long executeDurationNanos = ExecutionTiming.elapsedNanos(executeStartedNanos);
+            executionContext = executionContextAfterExecute(simpleSqlStatement, connection, executionContext);
             int resultCount = 0;
             while (true) {
                 checkCanceled(cancellation);
@@ -1221,14 +1297,17 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         }
     }
 
-    private ExecuteResponse failedExecuteResponse(String sql, Exception exception, long startedAtEpochMs) {
-        ExecutionMetrics executionMetrics = ExecutionTiming.finished(ExecutionTiming.started(startedAtEpochMs));
+    private ExecuteResponse failedExecuteResponse(String sql, Exception exception, long startedAtEpochMs,
+                                                  long startedAtNanos, ExecutionContext executionContext) {
+        ExecutionMetrics executionMetrics = ExecutionTiming.complete(
+                ExecutionTiming.started(startedAtEpochMs), ExecutionTiming.elapsedNanos(startedAtNanos), 0L, 0);
         return ExecuteResponse.builder()
                 .sql(sql)
                 .success(Boolean.FALSE)
                 .message(exception.getMessage())
-                .duration(ExecutionTiming.elapsedEpochMillis(executionMetrics))
+                .duration(executionMetrics.getTotalDurationMs())
                 .executionMetrics(executionMetrics)
+                .executionContext(executionContext)
                 .build();
     }
 

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/model/JdbcExecutionContext.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/model/JdbcExecutionContext.java
@@ -4,6 +4,7 @@ import ai.chat2db.community.domain.api.model.result.ExecutionContext;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Objects;
 
 public final class JdbcExecutionContext {
 
@@ -17,26 +18,70 @@ public final class JdbcExecutionContext {
                 .build();
     }
 
-    public static void synchronizeCatalog(Connection connection, String databaseName) {
-        if (connection == null || databaseName == null || databaseName.isBlank()) {
-            return;
+    public static Cursor cursor(Connection connection) {
+        return cursor(connection, null);
+    }
+
+    public static Cursor cursor(Connection connection, String databaseFallback) {
+        return new Cursor(capture(connection), databaseFallback);
+    }
+
+    public static final class Cursor {
+
+        private ExecutionContext current;
+        private ExecutionContext lastObserved;
+
+        private Cursor(ExecutionContext observed, String databaseFallback) {
+            this.lastObserved = copy(observed);
+            this.current = copy(observed);
+            if (isNotBlank(databaseFallback)) {
+                this.current.setDatabaseName(databaseFallback);
+            }
         }
-        try {
-            connection.setCatalog(databaseName);
-        } catch (SQLException | RuntimeException | AbstractMethodError exception) {
-            // Context capture is best effort for drivers that do not support catalogs.
+
+        public ExecutionContext current() {
+            return copy(current);
+        }
+
+        public void advance(Connection connection, String databaseFallback) {
+            ExecutionContext observed = capture(connection);
+            String databaseName = current.getDatabaseName();
+            String schemaName = current.getSchemaName();
+            if (isNotBlank(observed.getDatabaseName())
+                    && (!Objects.equals(observed.getDatabaseName(), lastObserved.getDatabaseName())
+                    || !isNotBlank(databaseName))) {
+                databaseName = observed.getDatabaseName();
+            }
+            if (isNotBlank(observed.getSchemaName())
+                    && (!Objects.equals(observed.getSchemaName(), lastObserved.getSchemaName())
+                    || !isNotBlank(schemaName))) {
+                schemaName = observed.getSchemaName();
+            }
+            if (isNotBlank(databaseFallback)
+                    && (!isNotBlank(observed.getDatabaseName())
+                    || Objects.equals(observed.getDatabaseName(), lastObserved.getDatabaseName()))) {
+                databaseName = databaseFallback;
+            }
+            current = ExecutionContext.builder()
+                    .databaseName(databaseName)
+                    .schemaName(schemaName)
+                    .build();
+            lastObserved = copy(observed);
         }
     }
 
-    public static void synchronizeSchema(Connection connection, String schemaName) {
-        if (connection == null || schemaName == null || schemaName.isBlank()) {
-            return;
+    private static ExecutionContext copy(ExecutionContext context) {
+        if (context == null) {
+            return new ExecutionContext();
         }
-        try {
-            connection.setSchema(schemaName);
-        } catch (SQLException | RuntimeException | AbstractMethodError exception) {
-            // Context capture is best effort for drivers that do not support schemas.
-        }
+        return ExecutionContext.builder()
+                .databaseName(context.getDatabaseName())
+                .schemaName(context.getSchemaName())
+                .build();
+    }
+
+    private static boolean isNotBlank(String value) {
+        return value != null && !value.isBlank();
     }
 
     private static String catalog(Connection connection) {

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/sql/DefaultSQLExecutorExecutionMetricsTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/sql/DefaultSQLExecutorExecutionMetricsTest.java
@@ -3,6 +3,7 @@ package ai.chat2db.community.test.spi.sql;
 import ai.chat2db.community.domain.api.config.DBConfig;
 import ai.chat2db.community.domain.api.config.DriverConfig;
 import ai.chat2db.community.domain.api.model.result.ExecuteResponse;
+import ai.chat2db.community.domain.api.model.result.ExecutionContext;
 import ai.chat2db.community.domain.api.model.result.ExecutionMetrics;
 import ai.chat2db.community.domain.api.model.result.ResultCell;
 import ai.chat2db.community.domain.api.model.sql.RefreshTarget;
@@ -12,10 +13,13 @@ import ai.chat2db.community.domain.api.service.db.ISqlExecutionResultConsumer;
 import ai.chat2db.community.domain.api.service.db.ISqlExecutionStatementListener;
 import ai.chat2db.community.tools.util.I18nUtils;
 import ai.chat2db.spi.DefaultMetaService;
+import ai.chat2db.spi.DefaultDBManager;
 import ai.chat2db.spi.DefaultSQLExecutor;
+import ai.chat2db.spi.IDbManager;
 import ai.chat2db.spi.IDbMetaData;
 import ai.chat2db.spi.IPlugin;
 import ai.chat2db.spi.model.datasource.ConnectInfo;
+import ai.chat2db.spi.model.JdbcExecutionContext;
 import ai.chat2db.spi.model.request.SqlStatementExecuteRequest;
 import ai.chat2db.spi.sql.Chat2DBContext;
 import com.alibaba.druid.DbType;
@@ -31,15 +35,18 @@ import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DefaultSQLExecutorExecutionMetricsTest {
@@ -48,6 +55,7 @@ class DefaultSQLExecutorExecutionMetricsTest {
     private static final DefaultSQLExecutor EXECUTOR = new TestSQLExecutor();
 
     private IPlugin previousPlugin;
+    private TestPlugin testPlugin;
 
     @BeforeAll
     static void setUpI18n() throws Exception {
@@ -74,7 +82,8 @@ class DefaultSQLExecutorExecutionMetricsTest {
 
     @BeforeEach
     void setUpPlugin() {
-        previousPlugin = Chat2DBContext.PLUGIN_MAP.put(TEST_DB_TYPE, new TestPlugin());
+        testPlugin = new TestPlugin();
+        previousPlugin = Chat2DBContext.PLUGIN_MAP.put(TEST_DB_TYPE, testPlugin);
     }
 
     @AfterEach
@@ -181,41 +190,131 @@ class DefaultSQLExecutorExecutionMetricsTest {
     }
 
     @Test
-    void successfulUseDatabaseSynchronizesJdbcCatalog() throws Exception {
-        String[] catalog = {"source_database"};
-        String[] schema = {"source_schema"};
-        Connection connection = contextConnection(catalog, schema);
-        SimpleSqlStatement statement = useDatabaseStatement("target_database");
+    void topLevelScriptShowsNewSchemaAfterSuccessfulSchemaSwitch() throws Exception {
+        try (Connection connection = openDatabase("top_level_schema_context")) {
+            putContext(connection);
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE SCHEMA target_schema");
+            }
 
-        ((TestSQLExecutor) EXECUTOR).synchronizeContext(statement, connection,
-                List.of(ExecuteResponse.builder().success(Boolean.TRUE).build()));
+            List<ExecuteResponse> results = EXECUTOR.execute(request(
+                    "SET SCHEMA target_schema; SELECT 1"));
 
-        assertEquals("target_database", connection.getCatalog());
-
-        catalog[0] = "source_database";
-        ((TestSQLExecutor) EXECUTOR).synchronizeContext(statement, connection,
-                List.of(ExecuteResponse.builder().success(Boolean.FALSE).build()));
-        assertEquals("source_database", connection.getCatalog());
+            assertEquals(2, results.size());
+            assertEquals("PUBLIC", results.get(0).getExecutionContext().getSchemaName());
+            assertEquals("TARGET_SCHEMA", results.get(1).getExecutionContext().getSchemaName());
+        }
     }
 
     @Test
-    void successfulSetSchemaSynchronizesOnlySingleSchemaTargets() throws Exception {
+    void movingAnObjectToAnotherSchemaDoesNotChangeExecutionContext() throws Exception {
+        try (Connection connection = openDatabase("alter_object_schema_context")) {
+            putContext(connection);
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE SCHEMA target_schema");
+            }
+
+            List<ExecuteResponse> results = EXECUTOR.execute(request(
+                    "ALTER TABLE sample SET SCHEMA target_schema; SELECT 1"));
+
+            assertEquals(2, results.size());
+            assertEquals("PUBLIC", results.get(0).getExecutionContext().getSchemaName());
+            assertEquals("PUBLIC", results.get(1).getExecutionContext().getSchemaName());
+        }
+    }
+
+    @Test
+    void successfulUseDatabaseAdvancesOutputContextWithoutMutatingConnection() throws Exception {
         String[] catalog = {"source_database"};
         String[] schema = {"source_schema"};
         Connection connection = contextConnection(catalog, schema);
+        JdbcExecutionContext.Cursor cursor = JdbcExecutionContext.cursor(connection);
+        SimpleSqlStatement statement = useDatabaseStatement("target_database");
 
-        ((TestSQLExecutor) EXECUTOR).synchronizeContext(setSchemaStatement("target_schema"), connection,
+        ((TestSQLExecutor) EXECUTOR).advanceContext(cursor, statement, connection,
                 List.of(ExecuteResponse.builder().success(Boolean.TRUE).build()));
-        assertEquals("target_schema", connection.getSchema());
 
-        schema[0] = "source_schema";
-        SimpleSqlStatement searchPath = setSchemaStatement("target_schema");
-        RefreshTarget fallbackTarget = new RefreshTarget();
-        fallbackTarget.setSchemaName("public");
-        searchPath.setRefreshTargets(List.of(searchPath.getRefreshTargets().get(0), fallbackTarget));
-        ((TestSQLExecutor) EXECUTOR).synchronizeContext(searchPath, connection,
+        assertEquals("target_database", cursor.current().getDatabaseName());
+        assertEquals("source_database", connection.getCatalog());
+
+        ((TestSQLExecutor) EXECUTOR).advanceContext(cursor, new SimpleSqlStatement("SELECT 1"), connection,
                 List.of(ExecuteResponse.builder().success(Boolean.TRUE).build()));
-        assertEquals("source_schema", connection.getSchema());
+        assertEquals("target_database", cursor.current().getDatabaseName());
+
+        JdbcExecutionContext.Cursor failedCursor = JdbcExecutionContext.cursor(connection);
+        ((TestSQLExecutor) EXECUTOR).advanceContext(failedCursor, statement, connection,
+                List.of(ExecuteResponse.builder().success(Boolean.FALSE).build()));
+        assertEquals("source_database", failedCursor.current().getDatabaseName());
+    }
+
+    @Test
+    void schemaContextUsesReadOnlyJdbcStateForLocalDefaultAndMultipleSearchPathTargets() {
+        String[] catalog = {"source_database"};
+        String[] schema = {"source_schema"};
+        Connection connection = contextConnection(catalog, schema);
+        JdbcExecutionContext.Cursor cursor = JdbcExecutionContext.cursor(connection);
+        SimpleSqlStatement statement = setSchemaStatement("ignored_parser_target");
+        ExecuteResponse success = ExecuteResponse.builder().success(Boolean.TRUE).build();
+
+        schema[0] = "local_schema";
+        ((TestSQLExecutor) EXECUTOR).advanceContext(cursor, statement, connection, List.of(success));
+        assertEquals("local_schema", cursor.current().getSchemaName());
+
+        schema[0] = "public";
+        ((TestSQLExecutor) EXECUTOR).advanceContext(cursor, statement, connection, List.of(success));
+        assertEquals("public", cursor.current().getSchemaName());
+
+        schema[0] = "first_existing_schema";
+        ((TestSQLExecutor) EXECUTOR).advanceContext(cursor, statement, connection, List.of(success));
+        assertEquals("first_existing_schema", cursor.current().getSchemaName());
+
+        schema[0] = "failed_schema";
+        ((TestSQLExecutor) EXECUTOR).advanceContext(cursor, statement, connection,
+                List.of(ExecuteResponse.builder().success(Boolean.FALSE).build()));
+        assertEquals("failed_schema", cursor.current().getSchemaName());
+
+        schema[0] = "empty_result_schema";
+        ((TestSQLExecutor) EXECUTOR).advanceContext(cursor, statement, connection, List.of());
+        assertEquals("empty_result_schema", cursor.current().getSchemaName());
+    }
+
+    @Test
+    void topLevelExecutionsAlignTheSameConnectionToTheEditorDatabase() throws Exception {
+        try (Connection connection = openDatabase("editor_alignment")) {
+            putContext(connection);
+            SqlExecuteRequest request = request("SELECT 1");
+            request.setDatabaseName("editor_database");
+
+            List<ExecuteResponse> results = EXECUTOR.execute(request);
+
+            assertEquals("editor_database", testPlugin.dbManager.databaseName);
+            assertEquals(connection, testPlugin.dbManager.connection);
+            assertEquals("editor_database", results.get(0).getExecutionContext().getDatabaseName());
+
+            testPlugin.dbManager.clear();
+            CapturingConsumer consumer = new CapturingConsumer();
+            EXECUTOR.executeStreaming(request, consumer, new NoOpStatementListener(), () -> false);
+
+            assertEquals("editor_database", testPlugin.dbManager.databaseName);
+            assertEquals(connection, testPlugin.dbManager.connection);
+            assertEquals("editor_database",
+                    consumer.finishedResults.get(0).getExecutionContext().getDatabaseName());
+        }
+    }
+
+    @Test
+    void canceledStreamingExecutionDoesNotAlignTheConnection() throws Exception {
+        try (Connection connection = openDatabase("canceled_before_alignment")) {
+            putContext(connection);
+            SqlExecuteRequest request = request("SELECT 1");
+            request.setDatabaseName("editor_database");
+
+            assertThrows(SQLException.class, () -> EXECUTOR.executeStreaming(
+                    request, new CapturingConsumer(), new NoOpStatementListener(), () -> true));
+
+            assertNull(testPlugin.dbManager.connection);
+            assertNull(testPlugin.dbManager.databaseName);
+        }
     }
 
     @Test
@@ -245,6 +344,46 @@ class DefaultSQLExecutorExecutionMetricsTest {
             assertEquals(Boolean.FALSE, result.getSuccess());
             assertEquals(1, result.getStatementSequence());
             assertNotNull(result.getDuration());
+            assertEquals("PUBLIC", result.getExecutionContext().getSchemaName());
+            assertMetrics(result, 0);
+        }
+    }
+
+    @Test
+    void failedTimingIncludesPagingAttemptAndFallback() throws Exception {
+        try (Connection connection = openDatabase("failed_paging_metrics")) {
+            putContext(connection);
+            FailingPagingExecutor executor = new FailingPagingExecutor();
+            SqlExecuteRequest request = request("SELECT * FROM missing_table");
+
+            ExecuteResponse result = executor.execute(request).get(0);
+
+            assertEquals(2, executor.attempts);
+            assertEquals(Boolean.FALSE, result.getSuccess());
+            assertTrue(result.getDuration() >= 60L);
+            assertEquals("PUBLIC", result.getExecutionContext().getSchemaName());
+            assertMetrics(result, 0);
+        }
+    }
+
+    @Test
+    void canceledContextChangingStatementKeepsStatementStartContext() throws Exception {
+        try (Connection connection = openDatabase("canceled_context")) {
+            putContext(connection);
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE SCHEMA target_schema");
+            }
+            CapturingConsumer consumer = new CapturingConsumer();
+            AtomicInteger cancellationChecks = new AtomicInteger();
+
+            EXECUTOR.executeStreaming(request("SET SCHEMA target_schema"), consumer,
+                    new NoOpStatementListener(), () -> cancellationChecks.incrementAndGet() >= 4);
+
+            assertEquals(1, consumer.finishedResults.size());
+            ExecuteResponse result = consumer.finishedResults.get(0);
+            assertEquals(Boolean.FALSE, result.getSuccess());
+            assertEquals("PUBLIC", result.getExecutionContext().getSchemaName());
+            assertEquals("TARGET_SCHEMA", connection.getSchema());
             assertMetrics(result, 0);
         }
     }
@@ -375,21 +514,14 @@ class DefaultSQLExecutorExecutionMetricsTest {
         assertNotNull(metrics.getStartedAtEpochMs());
         assertNotNull(metrics.getFinishedAtEpochMs());
         assertTrue(metrics.getFinishedAtEpochMs() >= metrics.getStartedAtEpochMs());
-        if (Boolean.TRUE.equals(result.getSuccess())) {
-            assertEquals(expectedRowCount, metrics.getFetchedRowCount());
-            assertNotNull(metrics.getTotalDurationMs());
-            assertNotNull(metrics.getExecuteDurationMs());
-            assertNotNull(metrics.getFetchDurationMs());
-            assertEquals(metrics.getTotalDurationMs(),
-                    metrics.getExecuteDurationMs() + metrics.getFetchDurationMs());
-            assertTrue(metrics.getExecuteDurationMs() >= 0L);
-            assertTrue(metrics.getFetchDurationMs() >= 0L);
-        } else {
-            assertNull(metrics.getTotalDurationMs());
-            assertNull(metrics.getExecuteDurationMs());
-            assertNull(metrics.getFetchDurationMs());
-            assertNull(metrics.getFetchedRowCount());
-        }
+        assertEquals(expectedRowCount, metrics.getFetchedRowCount());
+        assertNotNull(metrics.getTotalDurationMs());
+        assertNotNull(metrics.getExecuteDurationMs());
+        assertNotNull(metrics.getFetchDurationMs());
+        assertEquals(metrics.getTotalDurationMs(),
+                metrics.getExecuteDurationMs() + metrics.getFetchDurationMs());
+        assertTrue(metrics.getExecuteDurationMs() >= 0L);
+        assertTrue(metrics.getFetchDurationMs() >= 0L);
     }
 
     private static void putContext(Connection connection) {
@@ -446,7 +578,7 @@ class DefaultSQLExecutorExecutionMetricsTest {
         }
     }
 
-    private static final class TestSQLExecutor extends DefaultSQLExecutor {
+    private static class TestSQLExecutor extends DefaultSQLExecutor {
 
         private static long statementDuration(List<ExecuteResponse> results) {
             return maximumStatementDuration(results);
@@ -457,9 +589,9 @@ class DefaultSQLExecutorExecutionMetricsTest {
                     null, null, null);
         }
 
-        private void synchronizeContext(SimpleSqlStatement statement, Connection connection,
-                                        List<ExecuteResponse> executeResults) {
-            synchronizeExecutionContext(statement, connection, executeResults);
+        private void advanceContext(JdbcExecutionContext.Cursor cursor, SimpleSqlStatement statement,
+                                    Connection connection, List<ExecuteResponse> executeResults) {
+            advanceExecutionContext(cursor, connection, statement, executeResults);
         }
 
         @Override
@@ -473,14 +605,36 @@ class DefaultSQLExecutorExecutionMetricsTest {
         }
     }
 
+    private static final class FailingPagingExecutor extends TestSQLExecutor {
+
+        private int attempts;
+
+        @Override
+        protected List<ExecuteResponse> executeMulti(SimpleSqlStatement simpleSqlStatement, Connection connection,
+                                                     boolean limitRowSize, Integer offset, Integer count,
+                                                     Integer resultSetId, ExecutionContext executionContext)
+                throws SQLException {
+            attempts++;
+            try {
+                Thread.sleep(35L);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new SQLException("interrupted", exception);
+            }
+            throw new SQLException("controlled failure " + attempts);
+        }
+    }
+
     private static final class TestPlugin implements IPlugin {
 
         private final DBConfig dbConfig;
         private final IDbMetaData metaData = new DefaultMetaService();
+        private final TestDbManager dbManager = new TestDbManager();
 
         private TestPlugin() {
             dbConfig = new DBConfig();
             dbConfig.setDbType(TEST_DB_TYPE);
+            dbConfig.setSupportDatabase(true);
         }
 
         @Override
@@ -491,6 +645,28 @@ class DefaultSQLExecutorExecutionMetricsTest {
         @Override
         public IDbMetaData getDbMetaData() {
             return metaData;
+        }
+
+        @Override
+        public IDbManager getDbManager() {
+            return dbManager;
+        }
+    }
+
+    private static final class TestDbManager extends DefaultDBManager {
+
+        private Connection connection;
+        private String databaseName;
+
+        @Override
+        public void connectDatabase(Connection connection, String databaseName) {
+            this.connection = connection;
+            this.databaseName = databaseName;
+        }
+
+        private void clear() {
+            connection = null;
+            databaseName = null;
         }
     }
 }


### PR DESCRIPTION
## Related issue

Closes #1869

Enterprise equivalent: [OtterMind/Chat2DB-Enterprise#97](https://github.com/OtterMind/Chat2DB-Enterprise/pull/97), tracked by [Enterprise Issue #95](https://github.com/OtterMind/Chat2DB-Enterprise/issues/95).

## Summary

- Restore the database selected in the editor before each synchronous or streaming execution through the existing database-plugin abstraction and the same JDBC connection.
- Make Output context capture observational only, preserving native catalog/schema semantics such as PostgreSQL `SET LOCAL`, `DEFAULT`, and multi-target `search_path`.
- Preserve statement-start context on failure or cancellation, handle SQL Server `GO` batches correctly, bound Output record/message growth, and keep Community execution timing internally consistent.
- Prevent duplicate Desktop log events and message ID collisions without changing the SQL execution API.
- Route successful tabular Web executions to the newest result tab while keeping no-result, failed, and cancelled executions on Output. Mixed Web batches now fall back to the backend top-level `statementSequence` when structured stream metadata is absent.

## Affected surfaces

- [x] Frontend / Web
- [x] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `cd chat2db-community-server && rtk mvn -q clean test install -Dmaven.test.skip=false -DskipTests=false`: passed all 48 modules; 866 tests, 0 failures, 0 errors, 1 skipped.
  - `cd chat2db-community-client && rtk yarn test:search-result-tab-selection`: passed.
  - `cd chat2db-community-client && rtk yarn test:sql-execution-log`: passed.
  - Targeted ESLint for the five changed frontend files: passed.
  - `cd chat2db-community-client && rtk yarn run build:web:community --app_version=5.3.0`: passed.
  - `rtk git diff --check`: passed.
- Manual verification: Playwright CLI reproduced the old mixed-batch failure against local MySQL. After the correction, `SELECT / SELECT / USE / SELECT` activates the final result tab, a successful no-result `USE` activates Output, and a failed `SELECT` activates Output.
- UI evidence: Browser-verified on Community Web at the current development build; this changes active-tab routing without changing visual layout.

## Risk and compatibility

- Public API or stored data: No public API, schema, or persisted-data migration.
- Database or driver compatibility: Execution-start session alignment and SQL Server batch handling change intentionally; focused tests pass. Local MySQL Web smoke passed, while real PostgreSQL and SQL Server driver smoke remains the residual risk.
- Network, privacy, or security: N/A; no network boundary or credential handling changes.
- Community / Local / Pro boundary: This PR contains the Community implementation. Equivalent Enterprise behavior is under review in Enterprise PR #97; `enterprise-migration` is intentionally unchanged.
- Backward compatibility: Corrects session/context and result-tab behavior without a compatibility fallback or migration.

## Reviewer map

- Start here: `DefaultSQLExecutor`, `JdbcExecutionContext`, and `SqlServerExecutor`; then review `sqlExecutionLog.ts` for bounded frontend state and event deduplication. For result routing, review `SQLExecute`, `SearchResult`, `tabSelection.ts`, and `sortExecutionResults`.
- Failure condition: A statement executes outside the editor-selected database, Output reports a context different from the JDBC session, `GO` reaches the driver, final status/timing is lost when records are bounded, or a successful batch ending in a tabular result leaves Output active.
- Rollback or disable path: Revert this PR; there is no data migration or feature flag.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for implementation, regression tests, browser verification, and cross-repository review.
