### PR TITLE
fix(opengauss): preserve comments in table DDL

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/pom.xml
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/pom.xml
@@ -20,6 +20,11 @@
             <groupId>ai.chat2db</groupId>
             <artifactId>chat2db-community-postgresql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/src/main/java/ai/chat2db/plugin/opengauss/OpenGaussMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/src/main/java/ai/chat2db/plugin/opengauss/OpenGaussMetaData.java
@@ -1,6 +1,7 @@
 package ai.chat2db.plugin.opengauss;
 
 import ai.chat2db.plugin.postgresql.PostgreSQLMetaData;
+import ai.chat2db.spi.DefaultSQLExecutor;
 import ai.chat2db.spi.IDbMetaData;
 import ai.chat2db.community.domain.api.model.metadata.Database;
 import ai.chat2db.community.domain.api.model.metadata.Schema;
@@ -11,11 +12,73 @@ import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 
+import static ai.chat2db.plugin.opengauss.constant.OpenGaussMetaDataConstants.SEARCH_PATH_STATEMENT_PREFIX;
 import static ai.chat2db.plugin.opengauss.constant.OpenGaussMetaDataConstants.SYSTEM_DATABASES;
 import static ai.chat2db.plugin.opengauss.constant.OpenGaussMetaDataConstants.SYSTEM_SCHEMAS;
+import static ai.chat2db.plugin.opengauss.constant.OpenGaussMetaDataConstants.TABLE_DDL_SQL;
 
 @Slf4j
 public class OpenGaussMetaData extends PostgreSQLMetaData implements IDbMetaData {
+
+    @Override
+    public String tableDDL(Connection connection, String databaseName, String schemaName, String tableName) {
+        String ddl = DefaultSQLExecutor.getInstance().preExecute(connection, TABLE_DDL_SQL,
+                new String[]{schemaName, tableName}, resultSet -> resultSet.next() ? resultSet.getString(1) : null);
+        return stripLeadingSearchPath(ddl);
+    }
+
+    static String stripLeadingSearchPath(String ddl) {
+        if (ddl == null) {
+            return null;
+        }
+
+        int statementStart = 0;
+        while (statementStart < ddl.length() && Character.isWhitespace(ddl.charAt(statementStart))) {
+            statementStart++;
+        }
+
+        if (!ddl.regionMatches(true, statementStart, SEARCH_PATH_STATEMENT_PREFIX, 0,
+                SEARCH_PATH_STATEMENT_PREFIX.length())) {
+            return ddl;
+        }
+
+        int prefixEnd = statementStart + SEARCH_PATH_STATEMENT_PREFIX.length();
+        if (prefixEnd < ddl.length() && Character.isJavaIdentifierPart(ddl.charAt(prefixEnd))) {
+            return ddl;
+        }
+
+        int statementEnd = findStatementEnd(ddl, prefixEnd);
+        if (statementEnd < 0) {
+            return ddl;
+        }
+
+        int ddlStart = statementEnd + 1;
+        while (ddlStart < ddl.length() && Character.isWhitespace(ddl.charAt(ddlStart))) {
+            ddlStart++;
+        }
+        return ddl.substring(ddlStart);
+    }
+
+    private static int findStatementEnd(String sql, int start) {
+        char quote = 0;
+        for (int i = start; i < sql.length(); i++) {
+            char current = sql.charAt(i);
+            if (quote != 0) {
+                if (current == quote) {
+                    if (i + 1 < sql.length() && sql.charAt(i + 1) == quote) {
+                        i++;
+                    } else {
+                        quote = 0;
+                    }
+                }
+            } else if (current == '\'' || current == '"') {
+                quote = current;
+            } else if (current == ';') {
+                return i;
+            }
+        }
+        return -1;
+    }
 
     @Override
     public List<Database> databases(Connection connection) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/src/main/java/ai/chat2db/plugin/opengauss/OpenGaussMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/src/main/java/ai/chat2db/plugin/opengauss/OpenGaussMetaData.java
@@ -32,40 +32,24 @@ public class OpenGaussMetaData extends PostgreSQLMetaData implements IDbMetaData
             return null;
         }
 
-        int statementStart = 0;
-        while (statementStart < ddl.length() && Character.isWhitespace(ddl.charAt(statementStart))) {
-            statementStart++;
-        }
-
-        if (!ddl.regionMatches(true, statementStart, SEARCH_PATH_STATEMENT_PREFIX, 0,
+        String normalizedDdl = ddl.stripLeading();
+        if (!normalizedDdl.regionMatches(true, 0, SEARCH_PATH_STATEMENT_PREFIX, 0,
                 SEARCH_PATH_STATEMENT_PREFIX.length())) {
             return ddl;
         }
 
-        int prefixEnd = statementStart + SEARCH_PATH_STATEMENT_PREFIX.length();
-        if (prefixEnd < ddl.length() && Character.isJavaIdentifierPart(ddl.charAt(prefixEnd))) {
+        int prefixEnd = SEARCH_PATH_STATEMENT_PREFIX.length();
+        if (prefixEnd < normalizedDdl.length()
+                && Character.isJavaIdentifierPart(normalizedDdl.charAt(prefixEnd))) {
             return ddl;
         }
 
-        int statementEnd = findStatementEnd(ddl, prefixEnd);
-        if (statementEnd < 0) {
-            return ddl;
-        }
-
-        int ddlStart = statementEnd + 1;
-        while (ddlStart < ddl.length() && Character.isWhitespace(ddl.charAt(ddlStart))) {
-            ddlStart++;
-        }
-        return ddl.substring(ddlStart);
-    }
-
-    private static int findStatementEnd(String sql, int start) {
         char quote = 0;
-        for (int i = start; i < sql.length(); i++) {
-            char current = sql.charAt(i);
+        for (int i = prefixEnd; i < normalizedDdl.length(); i++) {
+            char current = normalizedDdl.charAt(i);
             if (quote != 0) {
                 if (current == quote) {
-                    if (i + 1 < sql.length() && sql.charAt(i + 1) == quote) {
+                    if (i + 1 < normalizedDdl.length() && normalizedDdl.charAt(i + 1) == quote) {
                         i++;
                     } else {
                         quote = 0;
@@ -74,10 +58,10 @@ public class OpenGaussMetaData extends PostgreSQLMetaData implements IDbMetaData
             } else if (current == '\'' || current == '"') {
                 quote = current;
             } else if (current == ';') {
-                return i;
+                return normalizedDdl.substring(i + 1).stripLeading();
             }
         }
-        return -1;
+        return ddl;
     }
 
     @Override

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/src/main/java/ai/chat2db/plugin/opengauss/constant/OpenGaussMetaDataConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/src/main/java/ai/chat2db/plugin/opengauss/constant/OpenGaussMetaDataConstants.java
@@ -4,6 +4,14 @@ import java.util.Set;
 
 public final class OpenGaussMetaDataConstants {
 
+    public static final String SEARCH_PATH_STATEMENT_PREFIX = "SET search_path";
+    public static final String TABLE_DDL_SQL = """
+            SELECT pg_get_tabledef(c.oid)
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = ?
+              AND c.relname = ?
+            """;
     public static final Set<String> SYSTEM_DATABASES = Set.of("template0", "template1", "template2", "template3",
             "postgres");
     public static final Set<String> SYSTEM_SCHEMAS = Set.of("blockchain", "coverage", "cstore", "db4ai",

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/src/test/java/ai/chat2db/plugin/opengauss/OpenGaussMetaDataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-opengauss/src/test/java/ai/chat2db/plugin/opengauss/OpenGaussMetaDataTest.java
@@ -1,0 +1,112 @@
+package ai.chat2db.plugin.opengauss;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+import static ai.chat2db.plugin.opengauss.constant.OpenGaussMetaDataConstants.TABLE_DDL_SQL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OpenGaussMetaDataTest {
+
+    @Test
+    void tableDdlUsesTableOidAndRemovesSearchPath() {
+        String nativeDdl = """
+                SET search_path = public;
+                CREATE TABLE app_user (id bigint);
+                COMMENT ON TABLE app_user IS 'application users';
+                COMMENT ON COLUMN app_user.id IS 'primary key';
+                """;
+        JdbcFixture fixture = new JdbcFixture(nativeDdl);
+
+        String ddl = new OpenGaussMetaData().tableDDL(fixture.connection(), "app", "public", "app_user");
+
+        assertEquals(TABLE_DDL_SQL, fixture.preparedSql);
+        assertEquals(List.of("public", "app_user"), fixture.parameters);
+        assertEquals("""
+                CREATE TABLE app_user (id bigint);
+                COMMENT ON TABLE app_user IS 'application users';
+                COMMENT ON COLUMN app_user.id IS 'primary key';
+                """, ddl);
+    }
+
+    @Test
+    void stripLeadingSearchPathHandlesQuotedSemicolon() {
+        String ddl = "SET search_path = \"tenant;one\";\r\nCREATE TABLE test_table (id bigint);";
+
+        assertEquals("CREATE TABLE test_table (id bigint);", OpenGaussMetaData.stripLeadingSearchPath(ddl));
+    }
+
+    @Test
+    void stripLeadingSearchPathLeavesOtherDdlUnchanged() {
+        String ddl = "CREATE TABLE public.test_table (id bigint);";
+
+        assertEquals(ddl, OpenGaussMetaData.stripLeadingSearchPath(ddl));
+    }
+
+    private static final class JdbcFixture {
+        private final String ddl;
+        private final List<String> parameters = new ArrayList<>();
+        private String preparedSql;
+        private boolean resultRead;
+
+        private JdbcFixture(String ddl) {
+            this.ddl = ddl;
+        }
+
+        private Connection connection() {
+            ResultSet resultSet = proxy(ResultSet.class, (proxy, method, args) -> switch (method.getName()) {
+                case "next" -> !resultRead && (resultRead = true);
+                case "getString" -> ddl;
+                default -> defaultValue(method.getReturnType());
+            });
+            PreparedStatement statement = proxy(PreparedStatement.class, (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "setString" -> {
+                        parameters.add((String) args[1]);
+                        return null;
+                    }
+                    case "execute" -> {
+                        return true;
+                    }
+                    case "getResultSet" -> {
+                        return resultSet;
+                    }
+                    default -> {
+                        return defaultValue(method.getReturnType());
+                    }
+                }
+            });
+            return proxy(Connection.class, (proxy, method, args) -> {
+                if ("prepareStatement".equals(method.getName())) {
+                    preparedSql = (String) args[0];
+                    return statement;
+                }
+                return defaultValue(method.getReturnType());
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, java.lang.reflect.InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Chat2DB.

PR title: type(scope): concise summary
Keep every section below. Use N/A when a section does not apply.
Do not include credentials, private URLs, production data, or generated build output.
-->

## Related issue

Closes #1874

<!-- Link the approved Issue that defines the problem or requirement. -->

## Summary

Use openGauss's native `pg_get_tabledef(table_oid)` path for table DDL so table and column comments are preserved. Resolve the table OID with parameterized schema and table predicates, and remove only the leading session-level `SET search_path` statement from the displayed/exported DDL.

The SQL statement is defined in `OpenGaussMetaDataConstants`; `OpenGaussMetaData` only executes the constant and post-processes the returned DDL.

## Affected surfaces

<!-- Check every surface affected by this PR. -->

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

<!--
Provide exact commands and their results, plus any manual verification.
For UI changes, attach before/after screenshots or a short recording.
-->

- Commands and results:
  - `rtk mvn -pl chat2db-community-plugins/chat2db-community-opengauss -am -Dmaven.test.skip=false -DskipTests=false -Dtest=OpenGaussMetaDataTest -Dsurefire.failIfNoSpecifiedTests=false test` from `chat2db-community-server`: 3 tests passed, 0 failures/errors/skips; reactor build successful.
  - `rtk mvn -DskipTests package`: all 48 Community backend modules built successfully.
- Manual verification: rebuilt and restarted the Community backend from this branch on port `10825`; health request returned HTTP 200. The active Community storage does not contain an openGauss datasource, so no live Community UI/database call was claimed. Issue #1874 contains the same-table openGauss 7.0.0-RC3 native-function evidence.
- UI evidence: N/A; database-plugin backend change.

## Risk and compatibility

<!-- Describe only the applicable risks. Use N/A with a short reason for the rest. -->

- Public API or stored data: N/A; no API contract or stored data changes.
- Database or driver compatibility: scoped to OpenGauss. It requires the native `pg_get_tabledef(oid)` overload. Native output can differ from the inherited PostgreSQL catalog reconstruction, including owner/grant statements; this PR intentionally follows the native OpenGauss DDL contract to preserve comments.
- Network, privacy, or security: no network behavior changes; schema and table values are bound as JDBC parameters.
- Community / Local / Pro boundary: Community plugin only. Enterprise is intentionally unchanged until the Community fix is reviewed and verified.
- Backward compatibility: other dialects are untouched. OpenGauss DDL output changes to native formatting and removes only a leading `SET search_path ...;` statement.

## Reviewer map

<!-- Point reviewers to the load-bearing change and provide an operational handoff. -->

- Start here: `OpenGaussMetaData#tableDDL`, then `OpenGaussMetaDataConstants#TABLE_DDL_SQL` and `OpenGaussMetaDataTest`.
- Failure condition: the target openGauss version lacks `pg_get_tabledef(oid)`, schema/table resolution returns no row, or the native prefix format differs from a leading semicolon-terminated `SET search_path` statement.
- Rollback or disable path: revert commit `60da0482`; OpenGauss will resume the inherited PostgreSQL DDL reconstruction path.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for source tracing, implementation, test construction, verification, and PR drafting. The resulting diff and verification output were reviewed before submission.
