### PR TITLE
fix(gaussdb): preserve comments in table DDL

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/pom.xml
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/pom.xml
@@ -21,6 +21,11 @@
             <groupId>ai.chat2db</groupId>
             <artifactId>chat2db-community-postgresql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBMetaData.java
@@ -27,40 +27,24 @@ public class GaussDBMetaData extends PostgreSQLMetaData implements IDbMetaData {
             return null;
         }
 
-        int statementStart = 0;
-        while (statementStart < ddl.length() && Character.isWhitespace(ddl.charAt(statementStart))) {
-            statementStart++;
-        }
-
-        if (!ddl.regionMatches(true, statementStart, SEARCH_PATH_STATEMENT_PREFIX, 0,
+        String normalizedDdl = ddl.stripLeading();
+        if (!normalizedDdl.regionMatches(true, 0, SEARCH_PATH_STATEMENT_PREFIX, 0,
                 SEARCH_PATH_STATEMENT_PREFIX.length())) {
             return ddl;
         }
 
-        int prefixEnd = statementStart + SEARCH_PATH_STATEMENT_PREFIX.length();
-        if (prefixEnd < ddl.length() && Character.isJavaIdentifierPart(ddl.charAt(prefixEnd))) {
+        int prefixEnd = SEARCH_PATH_STATEMENT_PREFIX.length();
+        if (prefixEnd < normalizedDdl.length()
+                && Character.isJavaIdentifierPart(normalizedDdl.charAt(prefixEnd))) {
             return ddl;
         }
 
-        int statementEnd = findStatementEnd(ddl, prefixEnd);
-        if (statementEnd < 0) {
-            return ddl;
-        }
-
-        int ddlStart = statementEnd + 1;
-        while (ddlStart < ddl.length() && Character.isWhitespace(ddl.charAt(ddlStart))) {
-            ddlStart++;
-        }
-        return ddl.substring(ddlStart);
-    }
-
-    private static int findStatementEnd(String sql, int start) {
         char quote = 0;
-        for (int i = start; i < sql.length(); i++) {
-            char current = sql.charAt(i);
+        for (int i = prefixEnd; i < normalizedDdl.length(); i++) {
+            char current = normalizedDdl.charAt(i);
             if (quote != 0) {
                 if (current == quote) {
-                    if (i + 1 < sql.length() && sql.charAt(i + 1) == quote) {
+                    if (i + 1 < normalizedDdl.length() && normalizedDdl.charAt(i + 1) == quote) {
                         i++;
                     } else {
                         quote = 0;
@@ -69,10 +53,10 @@ public class GaussDBMetaData extends PostgreSQLMetaData implements IDbMetaData {
             } else if (current == '\'' || current == '"') {
                 quote = current;
             } else if (current == ';') {
-                return i;
+                return normalizedDdl.substring(i + 1).stripLeading();
             }
         }
-        return -1;
+        return ddl;
     }
 
     @Override

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBMetaData.java
@@ -10,17 +10,69 @@ import org.apache.commons.lang3.StringUtils;
 import java.sql.Connection;
 import java.util.List;
 
+import static ai.chat2db.plugin.gaussdb.constant.GaussDBMetaDataConstants.SEARCH_PATH_STATEMENT_PREFIX;
+import static ai.chat2db.plugin.gaussdb.constant.GaussDBMetaDataConstants.TABLE_DDL_SQL;
+
 @Slf4j
 public class GaussDBMetaData extends PostgreSQLMetaData implements IDbMetaData {
     @Override
     public String tableDDL(Connection connection, String databaseName, String schemaName, String tableName) {
-        String sql = "SELECT pg_get_tabledef('" + tableName + "')";
-        return DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> {
-            if (resultSet.next()) {
-                return resultSet.getString(1);
-            }
+        String ddl = DefaultSQLExecutor.getInstance().preExecute(connection, TABLE_DDL_SQL,
+                new String[]{schemaName, tableName}, resultSet -> resultSet.next() ? resultSet.getString(1) : null);
+        return stripLeadingSearchPath(ddl);
+    }
+
+    static String stripLeadingSearchPath(String ddl) {
+        if (ddl == null) {
             return null;
-        });
+        }
+
+        int statementStart = 0;
+        while (statementStart < ddl.length() && Character.isWhitespace(ddl.charAt(statementStart))) {
+            statementStart++;
+        }
+
+        if (!ddl.regionMatches(true, statementStart, SEARCH_PATH_STATEMENT_PREFIX, 0,
+                SEARCH_PATH_STATEMENT_PREFIX.length())) {
+            return ddl;
+        }
+
+        int prefixEnd = statementStart + SEARCH_PATH_STATEMENT_PREFIX.length();
+        if (prefixEnd < ddl.length() && Character.isJavaIdentifierPart(ddl.charAt(prefixEnd))) {
+            return ddl;
+        }
+
+        int statementEnd = findStatementEnd(ddl, prefixEnd);
+        if (statementEnd < 0) {
+            return ddl;
+        }
+
+        int ddlStart = statementEnd + 1;
+        while (ddlStart < ddl.length() && Character.isWhitespace(ddl.charAt(ddlStart))) {
+            ddlStart++;
+        }
+        return ddl.substring(ddlStart);
+    }
+
+    private static int findStatementEnd(String sql, int start) {
+        char quote = 0;
+        for (int i = start; i < sql.length(); i++) {
+            char current = sql.charAt(i);
+            if (quote != 0) {
+                if (current == quote) {
+                    if (i + 1 < sql.length() && sql.charAt(i + 1) == quote) {
+                        i++;
+                    } else {
+                        quote = 0;
+                    }
+                }
+            } else if (current == '\'' || current == '"') {
+                quote = current;
+            } else if (current == ';') {
+                return i;
+            }
+        }
+        return -1;
     }
 
     @Override

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/constant/GaussDBMetaDataConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/constant/GaussDBMetaDataConstants.java
@@ -1,0 +1,16 @@
+package ai.chat2db.plugin.gaussdb.constant;
+
+public final class GaussDBMetaDataConstants {
+
+    public static final String SEARCH_PATH_STATEMENT_PREFIX = "SET search_path";
+    public static final String TABLE_DDL_SQL = """
+            SELECT pg_get_tabledef(c.oid)
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = ?
+              AND c.relname = ?
+            """;
+
+    private GaussDBMetaDataConstants() {
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/test/java/ai/chat2db/plugin/gaussdb/GaussDBMetaDataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/test/java/ai/chat2db/plugin/gaussdb/GaussDBMetaDataTest.java
@@ -1,0 +1,112 @@
+package ai.chat2db.plugin.gaussdb;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+import static ai.chat2db.plugin.gaussdb.constant.GaussDBMetaDataConstants.TABLE_DDL_SQL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GaussDBMetaDataTest {
+
+    @Test
+    void tableDdlUsesTableOidAndRemovesSearchPath() {
+        String nativeDdl = """
+                SET search_path = public;
+                CREATE TABLE chat2db_test (id bigint);
+                COMMENT ON TABLE chat2db_test IS 'GaussDB test table';
+                COMMENT ON COLUMN chat2db_test.id IS 'primary key';
+                """;
+        JdbcFixture fixture = new JdbcFixture(nativeDdl);
+
+        String ddl = new GaussDBMetaData().tableDDL(fixture.connection(), "gaussdb", "public", "chat2db_test");
+
+        assertEquals(TABLE_DDL_SQL, fixture.preparedSql);
+        assertEquals(List.of("public", "chat2db_test"), fixture.parameters);
+        assertEquals("""
+                CREATE TABLE chat2db_test (id bigint);
+                COMMENT ON TABLE chat2db_test IS 'GaussDB test table';
+                COMMENT ON COLUMN chat2db_test.id IS 'primary key';
+                """, ddl);
+    }
+
+    @Test
+    void stripLeadingSearchPathHandlesQuotedSemicolon() {
+        String ddl = "SET search_path = \"tenant;one\";\r\nCREATE TABLE test_table (id bigint);";
+
+        assertEquals("CREATE TABLE test_table (id bigint);", GaussDBMetaData.stripLeadingSearchPath(ddl));
+    }
+
+    @Test
+    void stripLeadingSearchPathLeavesOtherDdlUnchanged() {
+        String ddl = "CREATE TABLE public.test_table (id bigint);";
+
+        assertEquals(ddl, GaussDBMetaData.stripLeadingSearchPath(ddl));
+    }
+
+    private static final class JdbcFixture {
+        private final String ddl;
+        private final List<String> parameters = new ArrayList<>();
+        private String preparedSql;
+        private boolean resultRead;
+
+        private JdbcFixture(String ddl) {
+            this.ddl = ddl;
+        }
+
+        private Connection connection() {
+            ResultSet resultSet = proxy(ResultSet.class, (proxy, method, args) -> switch (method.getName()) {
+                case "next" -> !resultRead && (resultRead = true);
+                case "getString" -> ddl;
+                default -> defaultValue(method.getReturnType());
+            });
+            PreparedStatement statement = proxy(PreparedStatement.class, (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "setString" -> {
+                        parameters.add((String) args[1]);
+                        return null;
+                    }
+                    case "execute" -> {
+                        return true;
+                    }
+                    case "getResultSet" -> {
+                        return resultSet;
+                    }
+                    default -> {
+                        return defaultValue(method.getReturnType());
+                    }
+                }
+            });
+            return proxy(Connection.class, (proxy, method, args) -> {
+                if ("prepareStatement".equals(method.getName())) {
+                    preparedSql = (String) args[0];
+                    return statement;
+                }
+                return defaultValue(method.getReturnType());
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, java.lang.reflect.InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Chat2DB.

PR title: type(scope): concise summary
Keep every section below. Use N/A when a section does not apply.
Do not include credentials, private URLs, production data, or generated build output.
-->

## Related issue

Closes #1877

<!-- Link the approved Issue that defines the problem or requirement. -->

## Summary

Resolve GaussDB table DDL by schema and table using a parameterized catalog query, then call the native `pg_get_tabledef(table_oid)` overload. This preserves the native table and column comment statements while avoiding unqualified `search_path` resolution.

Remove only a leading, semicolon-terminated `SET search_path` statement from the displayed/exported DDL. The query and prefix constants live in `GaussDBMetaDataConstants`; `GaussDBMetaData` no longer contains or concatenates SQL text.

## Affected surfaces

<!-- Check every surface affected by this PR. -->

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

<!--
Provide exact commands and their results, plus any manual verification.
For UI changes, attach before/after screenshots or a short recording.
-->

- Commands and results:
  - `rtk mvn -pl chat2db-community-plugins/chat2db-community-gaussdb -am -Dmaven.test.skip=false -DskipTests=false -Dtest=GaussDBMetaDataTest -Dsurefire.failIfNoSpecifiedTests=false test` from `chat2db-community-server`: 3 tests passed, 0 failures/errors/skips; all 9 reactor modules succeeded.
  - `rtk mvn -DskipTests package` from `chat2db-community-server`: all 48 Community backend modules succeeded.
- Manual verification: Issue #1877 records the current Pro result with a leading `SET search_path` and no column comments. The active Community storage has no GaussDB datasource, so no live Community database call is claimed.
- UI evidence: N/A; database-plugin backend change. The before-state evidence is recorded in Issue #1877.

## Risk and compatibility

<!-- Describe only the applicable risks. Use N/A with a short reason for the rest. -->

- Public API or stored data: N/A; no API contract or stored data changes.
- Database or driver compatibility: scoped to GaussDB and requires the native `pg_get_tabledef(oid)` overload. Versions that only expose the table-name overload will fail this query and should retain the previous implementation until an explicit fallback is added.
- Network, privacy, or security: no network behavior changes. Schema and table names are now JDBC parameters instead of concatenated SQL.
- Community / Local / Pro boundary: Community plugin only. Enterprise remains unchanged until the Community implementation is reviewed and verified.
- Backward compatibility: other dialects are untouched. GaussDB resolution now follows the selected schema instead of the connection's current `search_path`, and only the leading session-level `SET search_path` statement is removed.

## Reviewer map

<!-- Point reviewers to the load-bearing change and provide an operational handoff. -->

- Start here: `GaussDBMetaData#tableDDL`, then `GaussDBMetaDataConstants#TABLE_DDL_SQL` and `GaussDBMetaDataTest`.
- Failure condition: the target GaussDB version lacks `pg_get_tabledef(oid)`, schema/table resolution returns no relation, or the native prefix is not a leading semicolon-terminated `SET search_path` statement.
- Rollback or disable path: revert commit `c7d0b217`; GaussDB will resume the unqualified table-name call and raw native output.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for source tracing, implementation, test construction, verification, and PR drafting. The resulting diff and verification output were reviewed before submission.
