### PR TITLE
fix(jcef): use Community native window title

### DIFF
--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/DesktopProductTitle.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/DesktopProductTitle.java
@@ -1,0 +1,17 @@
+package ai.chat2db.community.jcef.frame;
+
+final class DesktopProductTitle {
+
+    private DesktopProductTitle() {
+    }
+
+    static String resolve(boolean community, boolean localEdition) {
+        if (community) {
+            return "Chat2DB Community";
+        }
+        if (localEdition) {
+            return "Chat2DB Local";
+        }
+        return "Chat2DB Pro";
+    }
+}

--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
@@ -130,7 +130,7 @@ public class MainJFrame extends JFrame {
         return instance;
     }
     static {
-        appName = ConfigUtils.isOffline() ? "Chat2DB Local" : "Chat2DB Pro";
+        appName = DesktopProductTitle.resolve(ConfigUtils.isCommunity(), ConfigUtils.isLocalEdition());
         if (!OS.isMacintosh()) {
             JFrame.setDefaultLookAndFeelDecorated(true);
             JDialog.setDefaultLookAndFeelDecorated(true);
@@ -246,6 +246,7 @@ public class MainJFrame extends JFrame {
         setupSystemProperties();
         setupDesktopIntegration();
         Image appIcon = buildAppLogoImage();
+        this.setTitle(appName);
         if (OS.isMacintosh()) {
             setupMacSpecifics(appIcon);
         } else {
@@ -353,7 +354,6 @@ public class MainJFrame extends JFrame {
         return currentJarPath;
     }
     private void setupGenericPlatformSpecifics(Image appIcon) {
-        this.setTitle(appName);
         this.setIconImage(appIcon);
         applyTheme(ThemeEnum.DARK);
     }

--- a/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/DesktopProductTitleTest.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/DesktopProductTitleTest.java
@@ -1,0 +1,23 @@
+package ai.chat2db.community.jcef.frame;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DesktopProductTitleTest {
+
+    @Test
+    void shouldResolveCommunityTitle() {
+        assertEquals("Chat2DB Community", DesktopProductTitle.resolve(true, false));
+    }
+
+    @Test
+    void shouldResolveLocalTitle() {
+        assertEquals("Chat2DB Local", DesktopProductTitle.resolve(false, true));
+    }
+
+    @Test
+    void shouldResolveProTitle() {
+        assertEquals("Chat2DB Pro", DesktopProductTitle.resolve(false, false));
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #1883

## Summary

- Add one desktop-title resolver with explicit `Chat2DB Community`, `Chat2DB Local`, and `Chat2DB Pro` mappings.
- Set the resolved native title before the macOS versus Windows/Linux platform branch so every desktop platform follows the same title contract.
- Keep the shared application icon, renderer identity, package names, protocol registration, and updater behavior unchanged.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-jcef -am -Dmaven.test.skip=false -DskipTests=false -Dtest=DesktopProductTitleTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test` - passed; `DesktopProductTitleTest` ran 3 tests with 0 failures and 0 errors, and all four reactor modules succeeded.
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-jcef -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test` - passed; dependency modules ran 23 tests and JCEF ran 7 tests, all with 0 failures and 0 errors.
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-jcef -am -Dmaven.test.skip=true package` - passed and produced the JCEF jar; tests were intentionally skipped in this packaging command and are reported separately above.
  - `git diff --check` - passed.
- Manual verification: Reviewed the Community renderer, native package names, URL protocol registration, updater restart URI, and shared icon path; no changes were required outside native title resolution. A Windows/Linux native runtime smoke remains platform-only because this implementation was produced on macOS.
- UI evidence: The before-state Windows screenshot was supplied with the original report and is summarized in Issue #1883. No after-state Windows/Linux screenshot is available from the macOS development host.

## Risk and compatibility

- Public API or stored data: N/A; no API, serialization, or storage behavior changes.
- Database or driver compatibility: N/A; no database code changes.
- Network, privacy, or security: N/A; no network or permission behavior changes.
- Community / Local / Pro boundary: Community now resolves explicitly to `Chat2DB Community`; focused tests confirm Local remains `Chat2DB Local` and Pro remains `Chat2DB Pro`.
- Backward compatibility: The change only corrects native title text and moves title assignment before the platform branch. Existing icons and package identities remain unchanged.

## Reviewer map

- Start here: `DesktopProductTitle.resolve(...)`, then `MainJFrame.initPreProcessor()` where the resolved title is applied before platform-specific setup.
- Failure condition: Community still displays `Chat2DB Pro`, macOS does not receive a title, or Local/Pro title mappings change.
- Rollback or disable path: Revert commit `6f826fcf397854df12ce363bbc6e51c34d7deb56`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex prepared the implementation, tests, and verification under maintainer direction; the exact changes and executed checks are disclosed above.
