### PR TITLE
fix(ai): tolerate trailing /v1 in custom model base URL to avoid /v1/v1 requests

### DIFF
--- a/chat2db-community-client/src/i18n/en-US/setting.ts
+++ b/chat2db-community-client/src/i18n/en-US/setting.ts
@@ -332,7 +332,7 @@ export default {
   'setting.modelConfig.placeholder.apiKey': 'Leave blank to keep current value when editing',
   'setting.modelConfig.placeholder.baseUrl': 'e.g. https://api.openai.com/v1',
   'setting.modelConfig.baseUrlTip':
-    'OpenAI-compatible models call Base URL + /chat/completions. Include /v1, for example https://api.openai.com/v1 or https://your-domain.com/v1.',
+    'OpenAI-compatible models call Base URL + /v1/chat/completions. A trailing /v1 in the Base URL is optional and will not be duplicated, for example https://api.openai.com/v1 or https://your-domain.com.',
   'setting.modelConfig.placeholder.projectId': 'For Gemini, enter your GCP project ID',
   'setting.modelConfig.placeholder.location': 'e.g. us-central1',
   'setting.modelConfig.placeholder.temperature': 'e.g. 0.7',

--- a/chat2db-community-client/src/i18n/es-ES/setting.ts
+++ b/chat2db-community-client/src/i18n/es-ES/setting.ts
@@ -332,7 +332,7 @@ export default {
   'setting.modelConfig.placeholder.apiKey': 'Déjelo en blanco para conservar el valor actual al editar',
   'setting.modelConfig.placeholder.baseUrl': 'p. ej., https://api.openai.com/v1',
   'setting.modelConfig.baseUrlTip':
-    'Los modelos compatibles con OpenAI llaman a Base URL + /chat/completions. Incluya /v1, por ejemplo, https://api.openai.com/v1 o https://your-domain.com/v1.',
+    'Los modelos compatibles con OpenAI llaman a Base URL + /v1/chat/completions. El /v1 final de la Base URL es opcional y no se duplicará, por ejemplo, https://api.openai.com/v1 o https://your-domain.com.',
   'setting.modelConfig.placeholder.projectId': 'Para Gemini, introduzca el ID de su proyecto de GCP',
   'setting.modelConfig.placeholder.location': 'p. ej., us-central1',
   'setting.modelConfig.placeholder.temperature': 'p. ej., 0.7',

--- a/chat2db-community-client/src/i18n/ja-JP/setting.ts
+++ b/chat2db-community-client/src/i18n/ja-JP/setting.ts
@@ -334,7 +334,7 @@ export default {
   'setting.modelConfig.placeholder.apiKey': '編集中に空欄のまま保存すると現在の値を保持します',
   'setting.modelConfig.placeholder.baseUrl': '例：https://api.openai.com/v1',
   'setting.modelConfig.baseUrlTip':
-    'OpenAI 互換モデルは Base URL + /chat/completions を呼び出します。https://api.openai.com/v1 や https://your-domain.com/v1 のように /v1 まで含めて入力してください。',
+    'OpenAI 互換モデルは Base URL + /v1/chat/completions を呼び出します。Base URL 末尾の /v1 は省略可能で、入力しても重複することはありません。例：https://api.openai.com/v1 または https://your-domain.com。',
   'setting.modelConfig.placeholder.projectId': 'Gemini の場合は GCP Project ID を入力',
   'setting.modelConfig.placeholder.location': '例：us-central1',
   'setting.modelConfig.placeholder.temperature': '例：0.7',

--- a/chat2db-community-client/src/i18n/ko-KR/setting.ts
+++ b/chat2db-community-client/src/i18n/ko-KR/setting.ts
@@ -329,7 +329,7 @@ export default {
   'setting.modelConfig.placeholder.apiKey': '편집할 때 현재 값을 유지하려면 비워 두세요',
   'setting.modelConfig.placeholder.baseUrl': '예: https://api.openai.com/v1',
   'setting.modelConfig.baseUrlTip':
-    'OpenAI 호환 모델은 기본 URL + /chat/completions를 호출합니다. https://api.openai.com/v1 또는 https://your-domain.com/v1처럼 /v1을 포함하세요.',
+    'OpenAI 호환 모델은 기본 URL + /v1/chat/completions를 호출합니다. 기본 URL 끝의 /v1은 생략할 수 있으며, 입력해도 중복되지 않습니다. 예: https://api.openai.com/v1 또는 https://your-domain.com.',
   'setting.modelConfig.placeholder.projectId': 'Gemini를 사용하는 경우 GCP 프로젝트 ID를 입력하세요',
   'setting.modelConfig.placeholder.location': '예: us-central1',
   'setting.modelConfig.placeholder.temperature': '예: 0.7',

--- a/chat2db-community-client/src/i18n/zh-CN/setting.ts
+++ b/chat2db-community-client/src/i18n/zh-CN/setting.ts
@@ -326,7 +326,7 @@ export default {
   'setting.modelConfig.placeholder.apiKey': '编辑时留空则保留原值',
   'setting.modelConfig.placeholder.baseUrl': '例如：https://api.openai.com/v1',
   'setting.modelConfig.baseUrlTip':
-    'OpenAI 兼容模型会请求 Base URL + /chat/completions，请填写包含 /v1 的地址，例如 https://api.openai.com/v1 或 https://your-domain.com/v1。',
+    'OpenAI 兼容模型会请求 Base URL + /v1/chat/completions，Base URL 结尾的 /v1 可省略、填写了也不会重复拼接，例如 https://api.openai.com/v1 或 https://your-domain.com 均可。',
   'setting.modelConfig.placeholder.projectId': 'Gemini 可填写 GCP Project ID',
   'setting.modelConfig.placeholder.location': '例如：us-central1',
   'setting.modelConfig.placeholder.temperature': '例如：0.7',

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImpl.java
@@ -276,8 +276,32 @@ public class AiModelConfigServiceImpl implements IAiModelConfigService {
         runtimeModel.setMaxTokens(defaultValue(request.getMaxTokens(), baseConfig.getMaxTokens()));
 
         fillRuntimeFallback(runtimeModel);
+        normalizeRuntimeBaseUrl(runtimeModel);
         validateRuntimeModel(runtimeModel);
         return runtimeModel;
+    }
+
+    /**
+     * Spring AI's OpenAiApi and AnthropicApi append version-prefixed request paths
+     * ("/v1/chat/completions", "/v1/messages") to the configured base URL, so a base
+     * URL that already ends with "/v1" would request ".../v1/v1/..." and fail with 404.
+     * Strip the trailing "/v1" so base URLs with and without it hit the same endpoint.
+     */
+    private void normalizeRuntimeBaseUrl(AiRuntimeModel runtimeModel) {
+        AiProviderEnum provider = AiProviderEnum.from(runtimeModel.getProvider());
+        if (provider != AiProviderEnum.OPENAI && provider != AiProviderEnum.CLAUDE) {
+            return;
+        }
+        runtimeModel.setBaseUrl(stripTrailingV1(runtimeModel.getBaseUrl()));
+    }
+
+    private String stripTrailingV1(String baseUrl) {
+        if (StringUtils.isBlank(baseUrl)) {
+            return baseUrl;
+        }
+        String normalized = StringUtils.removeEnd(baseUrl.trim(), "/");
+        normalized = StringUtils.removeEnd(normalized, "/v1");
+        return StringUtils.removeEnd(normalized, "/");
     }
 
     private void fillRuntimeFallback(AiRuntimeModel runtimeModel) {
@@ -436,7 +460,7 @@ public class AiModelConfigServiceImpl implements IAiModelConfigService {
 
     private ModelConfigTestResponse testOpenAiCompatibleConfig(AiModelConfigSaveRequest request) {
         String baseUrl = StringUtils.defaultIfBlank(trimToNull(request.getBaseUrl()), DEFAULT_OPENAI_BASE_URL);
-        String endpoint = appendPath(baseUrl, "/chat/completions");
+        String endpoint = appendPath(stripTrailingV1(baseUrl), "/v1/chat/completions");
         String apiKey = resolveTestApiKey(request);
         if (StringUtils.isBlank(apiKey)) {
             return ModelConfigTestResponse.failure(endpoint, null, "API Key is required for the connection test.");

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImplBaseUrlTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImplBaseUrlTest.java
@@ -1,0 +1,53 @@
+package ai.chat2db.community.domain.core.impl.ai;
+
+import ai.chat2db.community.domain.api.model.request.ai.AiChatRuntimeResolveRequest;
+import ai.chat2db.community.domain.core.converter.AiModelConfigConverter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AiModelConfigServiceImplBaseUrlTest {
+
+    private static final long USER_ID = 42L;
+
+    @TempDir
+    Path tempDirectory;
+
+    @ParameterizedTest
+    @CsvSource({
+            "https://example.com/v1, https://example.com",
+            "https://example.com/v1/, https://example.com",
+            "https://example.com, https://example.com",
+            "https://example.com/, https://example.com",
+            "https://example.com/compatible-mode/v1, https://example.com/compatible-mode",
+            "https://example.com/v1beta, https://example.com/v1beta"
+    })
+    void openAiRuntimeBaseUrlToleratesTrailingV1(String configured, String expected) {
+        assertEquals(expected, resolveBaseUrl("OPENAI", configured));
+    }
+
+    @Test
+    void claudeRuntimeBaseUrlToleratesTrailingV1() {
+        assertEquals("https://claude.example.com", resolveBaseUrl("CLAUDE", "https://claude.example.com/v1"));
+    }
+
+    private String resolveBaseUrl(String provider, String baseUrl) {
+        AiChatRuntimeResolveRequest request = new AiChatRuntimeResolveRequest();
+        request.setProvider(provider);
+        request.setModel("gpt-test");
+        request.setApiKey("sk-test-1234567890");
+        request.setBaseUrl(baseUrl);
+        return service().resolveRuntimeModel(request).getBaseUrl();
+    }
+
+    private AiModelConfigServiceImpl service() {
+        return new AiModelConfigServiceImpl(new ObjectMapper().findAndRegisterModules(), new AiModelConfigConverter(),
+                () -> USER_ID, tempDirectory.resolve("ai-model-configs.json"), null);
+    }
+}

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/ai/AiModelFactory.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/ai/AiModelFactory.java
@@ -70,7 +70,7 @@ public class AiModelFactory {
 
     private AiChatClient openAiClient(AiRuntimeModel runtimeModel) {
         logUpstreamTarget("openai",
-                StringUtils.defaultIfBlank(runtimeModel.getBaseUrl(), OpenAiApiConstants.DEFAULT_BASE_URL) + "/chat/completions",
+                StringUtils.defaultIfBlank(runtimeModel.getBaseUrl(), OpenAiApiConstants.DEFAULT_BASE_URL) + "/v1/chat/completions",
                 buildOpenAiHeaderView(runtimeModel, null));
         OpenAiApi.Builder apiBuilder = OpenAiApi.builder().apiKey(runtimeModel.getApiKey());
         if (StringUtils.isNotBlank(runtimeModel.getBaseUrl())) {
@@ -231,7 +231,7 @@ public class AiModelFactory {
     }
 
     private static final class OpenAiApiConstants {
-        private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
+        private static final String DEFAULT_BASE_URL = "https://api.openai.com";
 
         private OpenAiApiConstants() {
         }


### PR DESCRIPTION
Fixes #1888

### What changed
- `AiModelConfigServiceImpl.resolveRuntimeModel` (the single place `AiRuntimeModel` is built, covering saved configs, request overrides, and the `OPENAI_BASE_URL`/`ANTHROPIC_BASE_URL` env fallbacks) now strips a trailing `/v1` (and trailing slashes) from the base URL for the OPENAI and CLAUDE providers.
- The connection test (`testOpenAiCompatibleConfig`) now builds the exact URL the runtime requests (`normalized base + /v1/chat/completions`), so a passing test no longer masks a failing chat request.
- The `ai upstream target` log in `AiModelFactory` now prints the URL actually requested (it previously logged `base + /chat/completions` while the real request was `base + /v1/chat/completions`).
- The Base URL hint in all five locales now says the trailing `/v1` is optional and never duplicated.
- New `AiModelConfigServiceImplBaseUrlTest` covers both providers, prefixed gateways (`.../compatible-mode/v1`), and non-`/v1` suffixes (`.../v1beta` stays untouched).

### Why
The settings UI instructs users to include `/v1` in the Base URL, and "Test connection" honors that contract (`baseUrl + "/chat/completions"`). But the actual chat request goes through Spring AI's `OpenAiApi`, whose default `completionsPath` is `/v1/chat/completions` (Spring AI 1.1.4). Following the UI hint therefore produces `.../v1/v1/chat/completions` → `404 Not Found`, while the connection test passes. `AnthropicApi` has the same trap (`/v1/messages`).

Stripping the trailing `/v1` — rather than setting `completionsPath("/chat/completions")` — was chosen deliberately: it fixes configs that follow the UI hint **without breaking configs that already work today** with a base URL that omits `/v1`, and it keeps prefixed endpoints like `https://dashscope.aliyuncs.com/compatible-mode/v1` working.

### How I tested it
- `mvn -pl :chat2db-community-domain-core -am -Dtest='AiModelConfigServiceImpl*' -Dmaven.test.skip=false -DskipTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test` → 19 tests, 0 failures (new BaseUrlTest 7 + existing StorageTest 12).
- `mvn -pl :chat2db-community-web -am ... test` → compiles clean (main + test sources).
- Manually reproduced before the fix: Base URL with `/v1` → 404 at `.../v1/v1/chat/completions`; without `/v1` → works.
- Frontend change is locale-string-only; `yarn lint` / `build:web:community` were not run locally.

### Known limitations
- An OpenAI-compatible endpoint whose path contains no `/v1` at all (e.g. a gateway exposing `/api/chat/completions`) still gets `/v1/chat/completions` appended — same behavior as before this change, so no regression.
- The Pro edition shows the same 404 and is not covered by this community fix (see #1888).
