### PR TITLE
fix(mongodb): support native result filtering and sorting

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -30,6 +30,7 @@
     "test:base-table-interaction": "tsx src/components/BaseTable/treeInteraction.test.ts",
     "test:database-object-sorting": "tsx src/blocks/NewTree/utils/sortTreeNodes.test.ts",
     "test:redis-explorer": "tsx src/blocks/RedisAllData/redisExplorer.test.ts",
+    "test:search-result-query-composer": "tsx src/blocks/SearchResult/components/ScreeningResult/queryComposer.test.ts",
     "test:search-result-tab-selection": "tsx src/blocks/SearchResult/tabSelection.test.ts",
     "test:sql-execution-log": "tsx src/service/sqlExecutionLog.test.ts",
     "test:sql-in-clipboard": "tsx src/utils/sqlInClipboard.test.ts",

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -473,6 +473,7 @@ export default memo<IProps>(
                 originalSql={props.resultData.originalSql}
                 promptWord={resultData.headerList}
                 orderByText={orderByText}
+                databaseType={resultData.executeSqlParams?.databaseType}
               />
             )}
             {showFESearch && (

--- a/chat2db-community-client/src/blocks/SearchResult/components/ScreeningResult/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ScreeningResult/index.tsx
@@ -5,6 +5,8 @@ import SingleFileMonacoEditor from '@/components/SingleFileMonacoEditor';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { useStyles } from './style';
 import { useUpdateEffect } from 'ahooks';
+import { DatabaseTypeCode } from '@/constants/common';
+import { composeResultQuery } from './queryComposer';
 
 interface IProps {
   className?: string;
@@ -12,6 +14,7 @@ interface IProps {
   onSearch?: () => void;
   originalSql: string;
   orderByText?: string;
+  databaseType?: DatabaseTypeCode;
 }
 
 export interface IScreeningResultRef {
@@ -36,9 +39,25 @@ const keywordHintList = [
   'DESC',
 ];
 
+const mongoKeywordHintList = [
+  '$and',
+  '$or',
+  '$not',
+  '$eq',
+  '$ne',
+  '$gt',
+  '$gte',
+  '$lt',
+  '$lte',
+  '$in',
+  '$nin',
+  '$exists',
+];
+
 const ScreeningResult = forwardRef((props: IProps, ref: ForwardedRef<IScreeningResultRef>) => {
-  const { promptWord, onSearch, originalSql, orderByText } = props;
+  const { promptWord, onSearch, originalSql, orderByText, databaseType } = props;
   const { styles } = useStyles();
+  const isMongoDB = databaseType === DatabaseTypeCode.MONGODB;
   const [isActive, setIsActive] = React.useState(false);
   const keywordHintRef = React.useRef<any>(null);
   const fieldHintRef = React.useRef<any>(null);
@@ -55,7 +74,7 @@ const ScreeningResult = forwardRef((props: IProps, ref: ForwardedRef<IScreeningR
       keywordHintRef.current && keywordHintRef.current.dispose();
       fieldHintRef.current && fieldHintRef.current.dispose();
     };
-  }, [promptWord, isActive]);
+  }, [promptWord, isActive, databaseType]);
 
   useUpdateEffect(() => {
     if (orderByText) {
@@ -71,9 +90,7 @@ const ScreeningResult = forwardRef((props: IProps, ref: ForwardedRef<IScreeningR
     getJointSQL: () => {
       const whereValue = whereSingleFileMonacoEditorRef.current?.getAllContent().trim() || '';
       const orderByValue = orderBySingleFileMonacoEditorRef.current?.getAllContent().trim() || '';
-      let sql = whereValue ? originalSql + ' WHERE ' + whereValue : originalSql;
-      sql = orderByValue ? sql + ' ORDER BY ' + orderByValue : sql;
-      return sql;
+      return composeResultQuery({ databaseType, filterValue: whereValue, orderByValue, originalSql });
     },
   }));
 
@@ -97,7 +114,7 @@ const ScreeningResult = forwardRef((props: IProps, ref: ForwardedRef<IScreeningR
     keywordHintRef.current = monaco.languages.registerCompletionItemProvider('sql', {
       provideCompletionItems: () => {
         return {
-          suggestions: keywordHintList.map((item) => {
+          suggestions: (isMongoDB ? mongoKeywordHintList : keywordHintList).map((item) => {
             return {
               insertText: item,
               kind: monaco.languages.CompletionItemKind.Keyword,
@@ -132,7 +149,7 @@ const ScreeningResult = forwardRef((props: IProps, ref: ForwardedRef<IScreeningR
               [styles.activeTitle]: true,
             })}
           >
-            WHERE
+            {isMongoDB ? 'FIND' : 'WHERE'}
           </div>
         </div>
         <SingleFileMonacoEditor
@@ -150,7 +167,7 @@ const ScreeningResult = forwardRef((props: IProps, ref: ForwardedRef<IScreeningR
               [styles.activeTitle]: true,
             })}
           >
-            ORDER BY
+            {isMongoDB ? 'SORT' : 'ORDER BY'}
           </div>
         </div>
         <SingleFileMonacoEditor

--- a/chat2db-community-client/src/blocks/SearchResult/components/ScreeningResult/queryComposer.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ScreeningResult/queryComposer.test.ts
@@ -1,0 +1,101 @@
+import { DatabaseTypeCode } from '@/constants/common';
+import { composeResultQuery } from './queryComposer';
+
+function assertEqual(actual: string, expected: string, message: string) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+assertEqual(
+  composeResultQuery({
+    databaseType: DatabaseTypeCode.MYSQL,
+    filterValue: 'status = 1',
+    orderByValue: 'created_at desc',
+    originalSql: 'SELECT * FROM users',
+  }),
+  'SELECT * FROM users WHERE status = 1 ORDER BY created_at desc',
+  'relational databases keep WHERE and ORDER BY composition',
+);
+
+assertEqual(
+  composeResultQuery({
+    databaseType: DatabaseTypeCode.MONGODB,
+    originalSql: 'db.users.find()',
+  }),
+  'db.users.find()',
+  'MongoDB query stays unchanged without filter or sort values',
+);
+
+assertEqual(
+  composeResultQuery({
+    databaseType: DatabaseTypeCode.MONGODB,
+    filterValue: '{ age: { $gt: 18 } }',
+    originalSql: 'db.users.find()',
+  }),
+  'db.users.find({ age: { $gt: 18 } })',
+  'MongoDB filter is placed inside find',
+);
+
+assertEqual(
+  composeResultQuery({
+    databaseType: DatabaseTypeCode.MONGODB,
+    filterValue: 'status: "ACTIVE"',
+    originalSql: 'db.users.find()',
+  }),
+  'db.users.find({ status: "ACTIVE" })',
+  'MongoDB filter shorthand is wrapped in a document',
+);
+
+assertEqual(
+  composeResultQuery({
+    databaseType: DatabaseTypeCode.MONGODB,
+    filterValue: '{ active: true }',
+    originalSql: 'db.users.find({ archived: false }, { name: 1, note: "a,b" })',
+  }),
+  'db.users.find({ active: true }, { name: 1, note: "a,b" })',
+  'MongoDB filter replacement preserves the projection argument',
+);
+
+assertEqual(
+  composeResultQuery({
+    databaseType: DatabaseTypeCode.MONGODB,
+    orderByValue: 'profile.age desc, name asc',
+    originalSql: 'db.users.find()',
+  }),
+  'db.users.find().sort({ "profile.age": -1, "name": 1 })',
+  'MongoDB converts grid order text into a sort document',
+);
+
+assertEqual(
+  composeResultQuery({
+    databaseType: DatabaseTypeCode.MONGODB,
+    orderByValue: '{ createdAt: -1 }',
+    originalSql: 'db.users.find();',
+  }),
+  'db.users.find().sort({ createdAt: -1 });',
+  'MongoDB native sort is inserted before a trailing semicolon',
+);
+
+assertEqual(
+  composeResultQuery({
+    databaseType: DatabaseTypeCode.MONGODB,
+    orderByValue: '{ name: 1 }',
+    originalSql: 'db.users.find({ active: true }).sort({ createdAt: -1 })',
+  }),
+  'db.users.find({ active: true }).sort({ name: 1 })',
+  'MongoDB sort editor replaces an existing sort call',
+);
+
+assertEqual(
+  composeResultQuery({
+    databaseType: DatabaseTypeCode.MONGODB,
+    filterValue: '{ active: true, ownerId: ObjectId("abc") }',
+    orderByValue: 'createdAt desc',
+    originalSql: 'db.users.find().limit(20);',
+  }),
+  'db.users.find({ active: true, ownerId: ObjectId("abc") }).limit(20).sort({ "createdAt": -1 });',
+  'MongoDB filter and sort preserve chained cursor operations',
+);
+
+console.log('ScreeningResult queryComposer tests passed');

--- a/chat2db-community-client/src/blocks/SearchResult/components/ScreeningResult/queryComposer.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ScreeningResult/queryComposer.ts
@@ -1,0 +1,188 @@
+import { DatabaseTypeCode } from '@/constants/common';
+
+interface IComposeResultQueryParams {
+  databaseType?: DatabaseTypeCode;
+  filterValue?: string;
+  orderByValue?: string;
+  originalSql: string;
+}
+
+interface IFunctionCallRange {
+  closeParenthesisIndex: number;
+  openParenthesisIndex: number;
+}
+
+const normalizeMongoDocument = (value: string) => {
+  const trimmedValue = value.trim();
+  if (trimmedValue.startsWith('{') && trimmedValue.endsWith('}')) {
+    return trimmedValue;
+  }
+  return `{ ${trimmedValue} }`;
+};
+
+const stripIdentifierQuotes = (identifier: string) => {
+  const trimmedIdentifier = identifier.trim();
+  const firstCharacter = trimmedIdentifier[0];
+  const lastCharacter = trimmedIdentifier[trimmedIdentifier.length - 1];
+  if (
+    (firstCharacter === '`' && lastCharacter === '`') ||
+    (firstCharacter === '"' && lastCharacter === '"') ||
+    (firstCharacter === '[' && lastCharacter === ']')
+  ) {
+    return trimmedIdentifier.slice(1, -1);
+  }
+  return trimmedIdentifier;
+};
+
+const normalizeMongoSort = (value: string) => {
+  const trimmedValue = value.trim();
+  if (trimmedValue.startsWith('{') && trimmedValue.endsWith('}')) {
+    return trimmedValue;
+  }
+
+  const orderByItems = trimmedValue.split(',').map((item) => item.trim());
+  const parsedItems = orderByItems.map((item) => item.match(/^(.+?)\s+(asc|desc)$/i));
+  if (parsedItems.every(Boolean)) {
+    const sortEntries = parsedItems.map((match) => {
+      const [, identifier, direction] = match!;
+      return `${JSON.stringify(stripIdentifierQuotes(identifier))}: ${direction.toLowerCase() === 'asc' ? 1 : -1}`;
+    });
+    return `{ ${sortEntries.join(', ')} }`;
+  }
+
+  return normalizeMongoDocument(trimmedValue);
+};
+
+// Mongo shell filters can contain nested calls and quoted parentheses, so locate the matching call boundary explicitly.
+const findFunctionCallRange = (command: string, functionName: string): IFunctionCallRange | null => {
+  const functionPattern = new RegExp(`\\.${functionName}\\s*\\(`, 'i');
+  const match = functionPattern.exec(command);
+  if (!match) {
+    return null;
+  }
+
+  const openParenthesisIndex = command.indexOf('(', match.index);
+  let depth = 0;
+  let quote = '';
+  let escaped = false;
+
+  for (let index = openParenthesisIndex; index < command.length; index += 1) {
+    const character = command[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = '';
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character;
+    } else if (character === '(') {
+      depth += 1;
+    } else if (character === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return { closeParenthesisIndex: index, openParenthesisIndex };
+      }
+    }
+  }
+
+  return null;
+};
+
+const findTopLevelComma = (value: string) => {
+  const closingCharacters = new Set(['}', ']', ')']);
+  const openingCharacters = new Set(['{', '[', '(']);
+  let depth = 0;
+  let quote = '';
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = '';
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character;
+    } else if (openingCharacters.has(character)) {
+      depth += 1;
+    } else if (closingCharacters.has(character)) {
+      depth -= 1;
+    } else if (character === ',' && depth === 0) {
+      return index;
+    }
+  }
+
+  return -1;
+};
+
+const replaceMongoFindFilter = (command: string, filterValue: string) => {
+  const findCallRange = findFunctionCallRange(command, 'find');
+  if (!findCallRange) {
+    return command;
+  }
+
+  const currentArguments = command.slice(findCallRange.openParenthesisIndex + 1, findCallRange.closeParenthesisIndex);
+  const projectionIndex = findTopLevelComma(currentArguments);
+  const projection = projectionIndex >= 0 ? currentArguments.slice(projectionIndex) : '';
+  return `${command.slice(0, findCallRange.openParenthesisIndex + 1)}${normalizeMongoDocument(
+    filterValue,
+  )}${projection}${command.slice(findCallRange.closeParenthesisIndex)}`;
+};
+
+const replaceOrAppendMongoSort = (command: string, orderByValue: string) => {
+  const sortDocument = normalizeMongoSort(orderByValue);
+  const sortCallRange = findFunctionCallRange(command, 'sort');
+  if (sortCallRange) {
+    return `${command.slice(0, sortCallRange.openParenthesisIndex + 1)}${sortDocument}${command.slice(
+      sortCallRange.closeParenthesisIndex,
+    )}`;
+  }
+
+  const trailingSemicolon = command.match(/;\s*$/);
+  if (!trailingSemicolon) {
+    return `${command}.sort(${sortDocument})`;
+  }
+  const semicolonIndex = trailingSemicolon.index!;
+  return `${command.slice(0, semicolonIndex).trimEnd()}.sort(${sortDocument})${command.slice(semicolonIndex)}`;
+};
+
+const composeMongoQuery = (originalSql: string, filterValue: string, orderByValue: string) => {
+  let command = originalSql;
+  if (filterValue) {
+    command = replaceMongoFindFilter(command, filterValue);
+  }
+  if (orderByValue) {
+    command = replaceOrAppendMongoSort(command, orderByValue);
+  }
+  return command;
+};
+
+export const composeResultQuery = ({
+  databaseType,
+  filterValue = '',
+  orderByValue = '',
+  originalSql,
+}: IComposeResultQueryParams) => {
+  const normalizedFilterValue = filterValue.trim();
+  const normalizedOrderByValue = orderByValue.trim();
+  if (databaseType === DatabaseTypeCode.MONGODB) {
+    return composeMongoQuery(originalSql, normalizedFilterValue, normalizedOrderByValue);
+  }
+
+  let sql = normalizedFilterValue ? `${originalSql} WHERE ${normalizedFilterValue}` : originalSql;
+  sql = normalizedOrderByValue ? `${sql} ORDER BY ${normalizedOrderByValue}` : sql;
+  return sql;
+};


### PR DESCRIPTION
## Related issue

Closes #1891

## Summary

- Pass the executed database type into the result filter controls.
- Compose MongoDB filters inside `find(...)` and sorting as `.sort(...)` while preserving projections, cursor chains, existing sort calls, quoted values, and trailing semicolons.
- Keep the existing relational `WHERE` / `ORDER BY` behavior unchanged.
- Show MongoDB-specific `FIND` / `SORT` labels and completion operators, with focused regression coverage for the query composer.

The MongoDB-specific string transformation is isolated in a pure query composer so the UI and relational path remain small and reviewable.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:search-result-query-composer` - passed.
  - `yarn eslint --max-warnings=0 src/blocks/SearchResult/components/ResultSet/index.tsx src/blocks/SearchResult/components/ScreeningResult/index.tsx src/blocks/SearchResult/components/ScreeningResult/queryComposer.ts src/blocks/SearchResult/components/ScreeningResult/queryComposer.test.ts` - passed with zero warnings.
  - `yarn build:web:community` - passed; Webpack compiled successfully.
  - `git diff --check` - passed.
- Manual verification: Community on port `10825` executed `db.users.find({ active: true }).sort({ age: -1 })` against a temporary MongoDB 7 instance and returned Alice (age 21), then Bob (age 17). The temporary datasource and container were removed after verification.
- UI evidence: Unavailable because the in-app browser backend had no browser instance. The production Community Web build passed.

## Risk and compatibility

- Public API or stored data: N/A; no API or storage contract changes.
- Database or driver compatibility: MongoDB result filtering and sorting now use native command syntax. No plugin or driver code changes.
- Network, privacy, or security: N/A; no new network access or data collection.
- Community / Local / Pro boundary: Community frontend only. Local and Pro are unchanged.
- Backward compatibility: Relational databases retain the existing `WHERE` / `ORDER BY` composition, covered by the focused test.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/SearchResult/components/ScreeningResult/queryComposer.ts`, then the database-type wiring in `ScreeningResult/index.tsx` and `ResultSet/index.tsx`.
- Failure condition: MongoDB result-page filters produce a command that the MongoDB executor cannot run, or relational filters stop appending `WHERE` / `ORDER BY` as before.
- Rollback or disable path: Revert commit `71a479b2c4170ea8199f63a6dbe09869cf2fe1cd`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used to implement the isolated query composer, add regression tests, and run verification. The resulting diff was reviewed and the MongoDB command was runtime-tested.
