### PR TITLE
fix(jcef): limit Community native title to Windows

### DIFF
--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/DesktopProductTitle.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/DesktopProductTitle.java
@@ -5,8 +5,8 @@ final class DesktopProductTitle {
     private DesktopProductTitle() {
     }
 
-    static String resolve(boolean community, boolean localEdition) {
-        if (community) {
+    static String resolve(boolean windows, boolean community, boolean localEdition) {
+        if (windows && community) {
             return "Chat2DB Community";
         }
         if (localEdition) {

--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
@@ -130,7 +130,7 @@ public class MainJFrame extends JFrame {
         return instance;
     }
     static {
-        appName = DesktopProductTitle.resolve(ConfigUtils.isCommunity(), ConfigUtils.isLocalEdition());
+        appName = DesktopProductTitle.resolve(OS.isWindows(), ConfigUtils.isCommunity(), ConfigUtils.isLocalEdition());
         if (!OS.isMacintosh()) {
             JFrame.setDefaultLookAndFeelDecorated(true);
             JDialog.setDefaultLookAndFeelDecorated(true);
@@ -246,7 +246,6 @@ public class MainJFrame extends JFrame {
         setupSystemProperties();
         setupDesktopIntegration();
         Image appIcon = buildAppLogoImage();
-        this.setTitle(appName);
         if (OS.isMacintosh()) {
             setupMacSpecifics(appIcon);
         } else {
@@ -354,6 +353,7 @@ public class MainJFrame extends JFrame {
         return currentJarPath;
     }
     private void setupGenericPlatformSpecifics(Image appIcon) {
+        this.setTitle(appName);
         this.setIconImage(appIcon);
         applyTheme(ThemeEnum.DARK);
     }

--- a/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/DesktopProductTitleTest.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/DesktopProductTitleTest.java
@@ -7,17 +7,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class DesktopProductTitleTest {
 
     @Test
-    void shouldResolveCommunityTitle() {
-        assertEquals("Chat2DB Community", DesktopProductTitle.resolve(true, false));
+    void shouldResolveWindowsCommunityTitle() {
+        assertEquals("Chat2DB Community", DesktopProductTitle.resolve(true, true, false));
+    }
+
+    @Test
+    void shouldKeepNonWindowsCommunityTitleUnchanged() {
+        assertEquals("Chat2DB Pro", DesktopProductTitle.resolve(false, true, false));
     }
 
     @Test
     void shouldResolveLocalTitle() {
-        assertEquals("Chat2DB Local", DesktopProductTitle.resolve(false, true));
+        assertEquals("Chat2DB Local", DesktopProductTitle.resolve(true, false, true));
     }
 
     @Test
     void shouldResolveProTitle() {
-        assertEquals("Chat2DB Pro", DesktopProductTitle.resolve(false, false));
+        assertEquals("Chat2DB Pro", DesktopProductTitle.resolve(true, false, false));
     }
 }


### PR DESCRIPTION
## Related issue

Closes #1893

## Summary

- Restore native JFrame title assignment to the existing non-macOS platform path so macOS keeps its renderer-owned title without overlap.
- Apply the edition-aware `Chat2DB Community` title correction only on Windows; Linux retains its pre-#1885 title behavior.
- Add focused coverage for the Windows-only platform boundary alongside the Community, Local, and Pro mappings.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-jcef -am -Dmaven.test.skip=false -DskipTests=false -Dtest=DesktopProductTitleTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test` - passed; 4 focused tests ran with 0 failures and 0 errors.
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-jcef -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test` - passed; dependency and JCEF modules ran 31 tests with 0 failures and 0 errors.
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-jcef -am -Dmaven.test.skip=true package` - passed and produced the JCEF jar; tests were intentionally skipped in this packaging-only command and are reported separately above.
  - `git diff --check` - passed.
- Manual verification: Reviewed `MainJFrame.initPreProcessor()` and `setupGenericPlatformSpecifics()` to confirm macOS no longer receives `setTitle(...)`, while the Windows title resolver remains edition-aware and Linux retains the prior Local/Pro fallback.
- UI evidence: The macOS before-state screenshot is recorded in Issue #1893. A post-fix native package smoke is platform-only and was not run from this source verification.

## Risk and compatibility

- Public API or stored data: N/A; no API, serialization, or storage behavior changes.
- Database or driver compatibility: N/A; no database code changes.
- Network, privacy, or security: N/A; no network or permission behavior changes.
- Community / Local / Pro boundary: Windows Community resolves to `Chat2DB Community`; Windows Local and Pro retain their existing names. macOS and Linux do not receive the broad behavior introduced by #1885.
- Backward compatibility: Restores the pre-#1885 macOS and Linux title-assignment boundary while retaining the requested Windows correction.

## Reviewer map

- Start here: `MainJFrame.initPreProcessor()` and `setupGenericPlatformSpecifics()`, then `DesktopProductTitle.resolve(...)` and its focused tests.
- Failure condition: macOS receives an explicit JFrame title again, Linux changes from its pre-#1885 behavior, or Windows Community does not display `Chat2DB Community`.
- Rollback or disable path: Revert commit `09d073c9200e7ec915f19c8a97707d6de3ccf3b9`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex prepared the implementation, tests, and verification under maintainer direction; the exact changes and executed checks are disclosed above.
