### PR TITLE
fix(ai): contain long markdown code blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Run SQL clipboard test
         run: yarn run test:sql-in-clipboard
 
+      - name: Run AI Markdown code context test
+        run: yarn run test:ai-markdown-code
+
       - name: Run BaseTable tree interaction contract
         run: yarn run test:base-table-interaction
 

--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -27,6 +27,7 @@
     "lint:eslint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
     "lint:style": "stylelint \"src/**/*.{css,less}\" --max-warnings=0",
     "test:i18n": "node ./scripts/validate-i18n.cjs",
+    "test:ai-markdown-code": "tsx src/blocks/AI/markdownCode.test.tsx",
     "test:base-table-interaction": "tsx src/components/BaseTable/treeInteraction.test.ts",
     "test:database-object-sorting": "tsx src/blocks/NewTree/utils/sortTreeNodes.test.ts",
     "test:redis-explorer": "tsx src/blocks/RedisAllData/redisExplorer.test.ts",

--- a/chat2db-community-client/src/blocks/AI/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/index.tsx
@@ -37,6 +37,7 @@ import { cx } from 'antd-style';
 import AIModelConfigModal from './components/AIModelConfigModal';
 import { listAvailableModelOptions, resolveModelRequestPayload } from '@/service/aiModelConfig';
 import { isDesktop } from '@/utils/env';
+import { MarkdownPre, resolveMarkdownCode, useIsMarkdownCodeBlock } from './markdownCode';
 
 /** detects unclosed text in flowing text ```chart block, return chart and whether there are any unfinished diagrams */
 function splitIncompleteChartBlock(text: string): { textBeforeChart: string; hasIncompleteChart: boolean } {
@@ -167,10 +168,6 @@ const TableClickContext = React.createContext<((tableName: string) => void) | nu
 /** SQL nailed to the Context of the Console */
 const PinSqlContext = React.createContext<((sql: string) => void) | null>(null);
 
-function MarkdownPre({ children }: React.ComponentProps<'pre'>) {
-  return <>{children}</>;
-}
-
 /**
  * Code block component: language=chart renders a chart, table:: renders a clickable table name,
  * and all other languages render code.
@@ -180,13 +177,13 @@ function MarkdownCodeBlock({ className, children }: { className?: string; childr
   const [copied, setCopied] = useState(false);
   const onTableClick = React.useContext(TableClickContext);
   const onPinSql = React.useContext(PinSqlContext);
-  const match = /language-(\w+)/.exec(className || '');
+  const codeKind = resolveMarkdownCode(className, useIsMarkdownCodeBlock());
 
   const submitEditorChartCallback = (data: any) => {
     console.log('Chart updated:', data);
   };
 
-  if (!match) {
+  if (codeKind.kind === 'inline') {
     // checks whether it is a clickable table name prefixed by table::
     const text = String(children).replace(/\n$/, '');
     const tableMatch = text.match(/^table::(.+)$/);
@@ -217,7 +214,7 @@ function MarkdownCodeBlock({ className, children }: { className?: string; childr
     return <code className={styles.inlineCode}>{children}</code>;
   }
 
-  const lang = match[1];
+  const lang = codeKind.language;
   const code = String(children).replace(/\n$/, '');
 
   // ── Chart rendering ──

--- a/chat2db-community-client/src/blocks/AI/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/index.tsx
@@ -167,6 +167,10 @@ const TableClickContext = React.createContext<((tableName: string) => void) | nu
 /** SQL nailed to the Context of the Console */
 const PinSqlContext = React.createContext<((sql: string) => void) | null>(null);
 
+function MarkdownPre({ children }: React.ComponentProps<'pre'>) {
+  return <>{children}</>;
+}
+
 /**
  * Code block component: language=chart renders a chart, table:: renders a clickable table name,
  * and all other languages render code.
@@ -1681,7 +1685,10 @@ export default function AI({ variant = 'page', onTableClick, onPinSql, onSession
       <PinSqlContext.Provider value={handlePinSql}>
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
-          components={{ code: MarkdownCodeBlock as React.ComponentType<React.HTMLAttributes<HTMLElement>> }}
+          components={{
+            pre: MarkdownPre,
+            code: MarkdownCodeBlock as React.ComponentType<React.HTMLAttributes<HTMLElement>>,
+          }}
         >
           {normalizeAiMarkdown(preprocessTableRefs(content))}
         </ReactMarkdown>

--- a/chat2db-community-client/src/blocks/AI/markdownCode.test.tsx
+++ b/chat2db-community-client/src/blocks/AI/markdownCode.test.tsx
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ReactMarkdown from 'react-markdown';
+import { MarkdownPre, resolveMarkdownCode, useIsMarkdownCodeBlock } from './markdownCode';
+
+function ProbeCode({ className, children }: { className?: string; children?: React.ReactNode }) {
+  const code = resolveMarkdownCode(className, useIsMarkdownCodeBlock());
+  return (
+    <code data-kind={code.kind} data-language={code.kind === 'block' ? code.language : undefined}>
+      {children}
+    </code>
+  );
+}
+
+function render(markdown: string) {
+  return renderToStaticMarkup(
+    <ReactMarkdown
+      components={{
+        pre: MarkdownPre,
+        code: ProbeCode as React.ComponentType<React.HTMLAttributes<HTMLElement>>,
+      }}
+    >
+      {markdown}
+    </ReactMarkdown>,
+  );
+}
+
+const fence = '`'.repeat(3);
+
+assert.match(render('Use `SELECT 1` here.'), /<code data-kind="inline">SELECT 1<\/code>/);
+assert.match(
+  render(`${fence}\nSELECT 1\nFROM dual\n${fence}`),
+  /^<code data-kind="block" data-language="text">SELECT 1\nFROM dual\n<\/code>$/,
+);
+assert.match(
+  render('    SELECT 1\n    FROM dual'),
+  /^<code data-kind="block" data-language="text">SELECT 1\nFROM dual\n<\/code>$/,
+);
+assert.match(
+  render(`${fence}sql\nSELECT 1\n${fence}`),
+  /^<code data-kind="block" data-language="sql">SELECT 1\n<\/code>$/,
+);
+
+console.log('AI Markdown code context tests passed');

--- a/chat2db-community-client/src/blocks/AI/markdownCode.tsx
+++ b/chat2db-community-client/src/blocks/AI/markdownCode.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const MarkdownCodeBlockContext = React.createContext(false);
+
+export function MarkdownPre({ children }: React.ComponentProps<'pre'>) {
+  return <MarkdownCodeBlockContext.Provider value>{children}</MarkdownCodeBlockContext.Provider>;
+}
+
+export function useIsMarkdownCodeBlock() {
+  return React.useContext(MarkdownCodeBlockContext);
+}
+
+export function resolveMarkdownCode(
+  className: string | undefined,
+  isBlock: boolean,
+): { kind: 'inline' } | { kind: 'block'; language: string } {
+  const language = /language-(\w+)/.exec(className || '')?.[1];
+  if (!isBlock && !language) {
+    return { kind: 'inline' };
+  }
+  return { kind: 'block', language: language || 'text' };
+}

--- a/chat2db-community-client/src/blocks/AI/style.ts
+++ b/chat2db-community-client/src/blocks/AI/style.ts
@@ -455,6 +455,10 @@ export const useStyles = createStyles(({ css, token, prefixCls }) => {
     // Code block.
     codeBlockWrap: css`
       margin: 10px 0;
+      width: 100%;
+      max-width: 100%;
+      min-width: 0;
+      box-sizing: border-box;
       border-radius: 10px;
       overflow: hidden;
       border: 1px solid ${token.colorBorderSecondary};
@@ -516,6 +520,9 @@ export const useStyles = createStyles(({ css, token, prefixCls }) => {
     codeBlockPre: css`
       margin: 0;
       padding: 14px 16px;
+      width: 100%;
+      max-width: 100%;
+      box-sizing: border-box;
       overflow-x: auto;
       background-color: ${token.colorBgContainer};
 


### PR DESCRIPTION
## Related issue

Closes #1905

## Summary

- Remove ReactMarkdown's redundant outer `pre` wrapper around the custom fenced-code renderer.
- Bound ordinary fenced-code containers to the assistant response width.
- Keep long unbroken SQL and other code lines horizontally scrollable inside the inner `pre` without widening the chat page.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn eslint src/blocks/AI/index.tsx src/blocks/AI/style.ts --max-warnings=0` - passed with zero warnings.
  - `yarn build:web:community` - production Community Web build passed.
  - `git diff --check origin/main...HEAD` - passed.
- Manual verification:
  - Used `playwright-cli` against the Community dev frontend with a mocked SSE response containing one 4705 px SQL line.
  - Checked 1440x900, 1024x768, and 800x700 viewports.
  - At every viewport, document `scrollWidth` equaled `clientWidth`, the code block fit the assistant container, and the inner `pre` retained `scrollWidth > clientWidth`.
  - Confirmed the assistant response contains one inner `pre` and no redundant direct outer `pre`.
- UI evidence:
  - Before: Issue #1905 reproduction shows the long code block expanding the chat layout.
  - After: Playwright measured a 752 px code viewport with 4705 px scrollable content while the 1440 px document remained exactly 1440 px wide.

## Risk and compatibility

- Public API or stored data: N/A - frontend rendering and layout only.
- Database or driver compatibility: N/A - no SQL execution or driver behavior changed.
- Network, privacy, or security: N/A - no request, response, or persistence behavior changed.
- Community / Local / Pro boundary: Community frontend only; no Enterprise repository changes are included.
- Backward compatibility: Inline code, SQLPreview, chart fences, copy actions, and ordinary fenced-code rendering remain intact; only the redundant wrapper and overflow sizing change.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/AI/index.tsx` at `renderMarkdown`, then `src/blocks/AI/style.ts` at `codeBlockWrap` and `codeBlockPre`.
- Failure condition: A long fenced-code line widens the document or assistant response instead of scrolling inside the code block, or fenced SQL/chart/ordinary code stops rendering.
- Rollback or disable path: Revert commit `78e1beec5dd1c729460c8219cfb1609aa6c2ecf1`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for source tracing, implementation, and Playwright verification; the resulting diff was validated with targeted ESLint, a production Community Web build, and measured browser assertions.