### PR TITLE
fix(sqlserver): use ROW_NUMBER pagination for SQL Server < 2012 (#1693)

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
@@ -258,7 +258,17 @@ public class SqlServerSqlBuilder extends DefaultSqlBuilder {
                 return sqlBuilder.toString();
             }
         }
-        return SQLConstants.EMPTY;
+        // SQL Server < 2012: use ROW_NUMBER() window function
+        int startRow = offset + 1;
+        int endRow = offset + pageSize;
+        StringBuilder sqlBuilder = new StringBuilder(sql.length() + 120);
+        sqlBuilder.append(SQL_ROW_NUMBER_PREFIX);
+        sqlBuilder.append(sql);
+        sqlBuilder.append(SQL_ROW_NUMBER_SUFFIX);
+        sqlBuilder.append(startRow);
+        sqlBuilder.append(SQL_AND);
+        sqlBuilder.append(endRow);
+        return sqlBuilder.toString();
     }
 
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerSqlBuilderConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerSqlBuilderConstants.java
@@ -61,6 +61,11 @@ public final class SqlServerSqlBuilderConstants {
     public static final String UPDATE_TABLE_COMMENT_SCRIPT = "exec sp_updateextendedproperty 'MS_Description','%s','SCHEMA','%s','TABLE','%s' \ngo\n";
     public static final String RENAME_TABLE_SCRIPT = "exec sp_rename '%s','%s','OBJECT' \ngo\n";
 
+    // ROW_NUMBER pagination for SQL Server < 2012
+    public static final String SQL_ROW_NUMBER_PREFIX = "SELECT * FROM (SELECT TMP_PAGE.*, ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) AS CAHT2DB_AUTO_ROW_ID FROM (\n";
+    public static final String SQL_ROW_NUMBER_SUFFIX = "\n) TMP_PAGE) TMP_PAGE WHERE CAHT2DB_AUTO_ROW_ID BETWEEN ";
+    public static final String SQL_AND = " AND ";
+
 
     private SqlServerSqlBuilderConstants() {
     }


### PR DESCRIPTION
When OFFSET...FETCH is unavailable (SQL Server < 2012, version < 11), fall back to ROW_NUMBER() OVER() window function, following the same pattern used by the DB2 plugin.

The generated SQL wraps the original query:


Previously, buildPageLimit returned EMPTY for old versions, causing pagination to silently return all rows.

This follows the same approach as DB2SqlBuilder which uses ROWNUMBER() OVER() with CAHT2DB_AUTO_ROW_ID.

Fixes #1693