### PR TITLE
fix(redis): fix string-key update NPE and value-edit semantics across key types

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisKeyOperations.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisKeyOperations.java
@@ -9,6 +9,7 @@ import ai.chat2db.community.domain.api.model.key.KeyScanRequest;
 import ai.chat2db.community.domain.api.model.key.KeyScanResult;
 import ai.chat2db.community.domain.api.model.key.KeyUpdate;
 import ai.chat2db.plugin.redis.converter.RedisKeyConverter;
+import ai.chat2db.plugin.redis.model.RedisKey;
 import ai.chat2db.plugin.redis.model.RedisKeyScanResult;
 import ai.chat2db.spi.DefaultSQLExecutor;
 import ai.chat2db.spi.IKeyOperations;
@@ -61,14 +62,19 @@ public class RedisKeyOperations implements IKeyOperations {
     @Override
     public KeyEntry create(Connection connection, KeyCreate command) {
         RedisScriptExecutor.getInstance().createRedisKey(redisKeyConverter.keyCreate2redisKey(command));
-        return redisKeyConverter.redisKey2keyEntry(RedisScriptExecutor.getInstance().getKey(command.getName()));
+        return redisKeyConverter.redisKey2keyEntry(redisMetaData.keyDetail(command.getName()));
     }
 
     @Override
     public KeyEntry update(Connection connection, KeyUpdate command) {
-        RedisScriptExecutor.getInstance().update(redisKeyConverter.keyEntry2redisKey(command.getOldKey()),
-                redisKeyConverter.keyEntry2redisKey(command.getNewKey()));
-        return redisKeyConverter.redisKey2keyEntry(RedisScriptExecutor.getInstance().getKey(command.getNewKey().getName()));
+        RedisKey oldKey = command.getOldKey() == null ? null : redisKeyConverter.keyEntry2redisKey(command.getOldKey());
+        RedisKey newKey = command.getNewKey() == null ? null : redisKeyConverter.keyEntry2redisKey(command.getNewKey());
+        RedisScriptExecutor.getInstance().update(oldKey, newKey);
+        String resultName = newKey != null ? newKey.getName() : oldKey != null ? oldKey.getName() : null;
+        if (resultName == null) {
+            return null;
+        }
+        return redisKeyConverter.redisKey2keyEntry(redisMetaData.keyDetail(resultName));
     }
 
     @Override

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisMetaData.java
@@ -315,7 +315,7 @@ public class RedisMetaData extends DefaultMetaService implements IDbMetaData {
             return super.tables(connection, databaseName, schemaName, tableName, pageNo, pageSize);
         } else {
             List<Table> result = DefaultSQLExecutor.getInstance().execute(connection,
-                    String.format(RedisConstants.COMMAND_EXISTS_KEY, tableName), resultSet -> {
+                    String.format(RedisConstants.COMMAND_EXISTS_KEY, RedisValueUtils.getRedisValue(tableName)), resultSet -> {
                 List<Table> tables = new ArrayList<>();
                 while (resultSet.next()) {
                     if (resultSet.getInt(1) == 1) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisScriptExecutor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisScriptExecutor.java
@@ -279,39 +279,36 @@ public class RedisScriptExecutor extends DefaultSQLExecutor {
 
 
     public ExecuteResponse update(RedisKey oldKey, RedisKey newKey) {
+        if (oldKey == null && newKey == null) {
+            return new ExecuteResponse();
+        }
         List<String> scripts = new ArrayList<>();
-        if (oldKey != null && newKey != null) {
-            if (!oldKey.getType().equals(newKey.getType())) {
-                ITypeScript typeScript = RedisDataType.fromCode(oldKey.getType()).getScript();
-                List<String> script = typeScript.updateKey(oldKey, null);
-                if (CollectionUtils.isNotEmpty(script)) {
-                    scripts.addAll(script);
-                }
-                typeScript = RedisDataType.fromCode(newKey.getType()).getScript();
-                List<String> addScript = typeScript.createKey(newKey);
-                if (CollectionUtils.isNotEmpty(addScript)) {
-                    scripts.addAll(addScript);
-                }
-                ExecuteResponse executeResult = new ExecuteResponse();
-                for (String s : scripts) {
-                    if (StringUtils.isNotBlank(s)) {
-                        executeResult = executeUpdate(s);
-                    }
-                }
-                return executeResult;
+        boolean typeChanged = oldKey != null && newKey != null && !oldKey.getType().equals(newKey.getType());
+        if (typeChanged) {
+            ITypeScript typeScript = RedisDataType.fromCode(oldKey.getType()).getScript();
+            List<String> script = typeScript.updateKey(oldKey, null);
+            if (CollectionUtils.isNotEmpty(script)) {
+                scripts.addAll(script);
             }
-            if (!oldKey.getName().equals(newKey.getName())) {
+            typeScript = RedisDataType.fromCode(newKey.getType()).getScript();
+            List<String> addScript = typeScript.createKey(newKey);
+            if (CollectionUtils.isNotEmpty(addScript)) {
+                scripts.addAll(addScript);
+            }
+        } else {
+            if (oldKey != null && newKey != null && !oldKey.getName().equals(newKey.getName())) {
                 StringBuilder stringBuilder = new StringBuilder();
                 stringBuilder.append(RedisConstants.SQL_RENAME_KEY_PREFIX).append(getRedisValue(oldKey.getName()))
                         .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(getRedisValue(newKey.getName()))
                         .append(RedisConstants.COMMAND_LINE_SEPARATOR);
                 scripts.add(stringBuilder.toString());
             }
-        }
-        ITypeScript typeScript = RedisDataType.fromCode(oldKey.getType()).getScript();
-        List<String> script = typeScript.updateKey(oldKey, newKey);
-        if (CollectionUtils.isNotEmpty(script)) {
-            scripts.addAll(script);
+            RedisKey typeSource = oldKey != null ? oldKey : newKey;
+            ITypeScript typeScript = RedisDataType.fromCode(typeSource.getType()).getScript();
+            List<String> script = typeScript.updateKey(oldKey, newKey);
+            if (CollectionUtils.isNotEmpty(script)) {
+                scripts.addAll(script);
+            }
         }
         if (newKey != null && newKey.getTtl() != null && newKey.getTtl() > 0) {
             StringBuilder stringBuilder = new StringBuilder();

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisScriptExecutor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisScriptExecutor.java
@@ -285,16 +285,17 @@ public class RedisScriptExecutor extends DefaultSQLExecutor {
         List<String> scripts = new ArrayList<>();
         boolean typeChanged = oldKey != null && newKey != null && !oldKey.getType().equals(newKey.getType());
         if (typeChanged) {
+            List<String> addScript = RedisDataType.fromCode(newKey.getType()).getScript().createKey(newKey);
+            if (CollectionUtils.isEmpty(addScript)) {
+                // Nothing to write for the new type; abort instead of deleting the old key.
+                return new ExecuteResponse();
+            }
             ITypeScript typeScript = RedisDataType.fromCode(oldKey.getType()).getScript();
             List<String> script = typeScript.updateKey(oldKey, null);
             if (CollectionUtils.isNotEmpty(script)) {
                 scripts.addAll(script);
             }
-            typeScript = RedisDataType.fromCode(newKey.getType()).getScript();
-            List<String> addScript = typeScript.createKey(newKey);
-            if (CollectionUtils.isNotEmpty(addScript)) {
-                scripts.addAll(addScript);
-            }
+            scripts.addAll(addScript);
         } else {
             if (oldKey != null && newKey != null && !oldKey.getName().equals(newKey.getName())) {
                 StringBuilder stringBuilder = new StringBuilder();

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/constant/RedisConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/constant/RedisConstants.java
@@ -21,6 +21,7 @@ public final class RedisConstants {
     public static final String COMMAND_LIST_INSERT_AFTER_FRAGMENT = " AFTER ";
     public static final String COMMAND_LIST_INSERT_PREFIX = "LINSERT ";
     public static final String COMMAND_LIST_PUSH_PREFIX = "LPUSH ";
+    public static final String COMMAND_LIST_RIGHT_PUSH_PREFIX = "RPUSH ";
     public static final String COMMAND_LIST_RANGE_ALL_SUFFIX = " 0 -1";
     public static final String COMMAND_LIST_RANGE_PREFIX = "LRANGE ";
     public static final String COMMAND_LIST_REMOVE_ONE_FRAGMENT = " 1 ";
@@ -42,7 +43,7 @@ public final class RedisConstants {
     public static final String COMMAND_TYPE_KEY = "type %s";
     public static final String COMMAND_ZSET_ADD_PREFIX = "ZADD ";
     public static final String COMMAND_ZSET_RANGE_PREFIX = "ZRANGE ";
-    public static final String COMMAND_ZSET_RANGE_WITH_SCORES_SUFFIX = " 0 1001 WITHSCORES";
+    public static final String COMMAND_ZSET_RANGE_WITH_SCORES_SUFFIX = " 0 -1 WITHSCORES";
     public static final String COMMAND_ZSET_REMOVE_PREFIX = "ZREM ";
     public static final String JDBC_REDIS_URL_PREFIX = "jdbc:redis://";
     public static final String CONFIG_GET_PERMISSION_ERROR = "config|get";

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/HashTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/HashTypeScript.java
@@ -12,7 +12,9 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static ai.chat2db.plugin.redis.util.RedisValueUtils.getRedisValue;
@@ -26,7 +28,8 @@ public class HashTypeScript extends BaseTypeScript implements ITypeScript {
                     .append(RedisConstants.COMMAND_LINE_SEPARATOR);
         } else {
             script.append(RedisConstants.COMMAND_HASH_GET_PREFIX).append(getRedisValue(redisKey.getName()))
-                    .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(redisKey.getHashValues().get(0).getField())
+                    .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR)
+                    .append(getRedisValue(redisKey.getHashValues().get(0).getField()))
                     .append(RedisConstants.COMMAND_LINE_SEPARATOR);
         }
         return script.toString();
@@ -81,35 +84,54 @@ public class HashTypeScript extends BaseTypeScript implements ITypeScript {
         if (newKey == null) {
             String delete = delete(oldKey.getName());
             return Lists.newArrayList(delete);
-        } else {
-            List<String> script = new ArrayList<>();
-            if (CollectionUtils.isNotEmpty(newKey.getHashValues())) {
-                for (HashValue field : newKey.getHashValues()) {
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.DELETE.equals(field.getAction())) {
-                        String s = deleteItem(newKey.getName(), field.getField());
-                        script.add(s);
-                    }
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.CREATE.equals(field.getAction())) {
-                        String s = createItem(newKey.getName(), field);
-                        script.add(s);
-                    }
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.UPDATE.equals(field.getAction())) {
-                        String s = deleteItem(newKey.getName(), field.getField());
-                        script.add(s);
-                        s = createItem(newKey.getName(), field);
-                        script.add(s);
-                    }
-                }
-            }
-            return script;
         }
+        // The editor drops removed rows from the payload instead of flagging them,
+        // so reconcile against the full old field list.
+        Map<String, String> desired = fieldValues(newKey.getHashValues(), true);
+        if (desired.isEmpty()) {
+            return new ArrayList<>();
+        }
+        Map<String, String> existing = fieldValues(oldKey.getHashValues(), false);
+        List<String> scripts = new ArrayList<>();
+        List<String> removed = existing.keySet().stream().filter(field -> !desired.containsKey(field)).toList();
+        if (!removed.isEmpty()) {
+            StringBuilder script = new StringBuilder();
+            script.append(RedisConstants.COMMAND_HASH_DELETE_PREFIX).append(getRedisValue(newKey.getName()))
+                    .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+            for (String field : removed) {
+                script.append(getRedisValue(field)).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+            }
+            scripts.add(script.toString());
+        }
+        StringBuilder upserts = new StringBuilder();
+        for (Map.Entry<String, String> entry : desired.entrySet()) {
+            if (!existing.containsKey(entry.getKey()) || !Objects.equals(existing.get(entry.getKey()), entry.getValue())) {
+                upserts.append(getRedisValue(entry.getKey())).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR)
+                        .append(getRedisValue(entry.getValue())).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+            }
+        }
+        if (upserts.length() > 0) {
+            scripts.add(RedisConstants.COMMAND_HASH_SET_PREFIX + getRedisValue(newKey.getName())
+                    + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + upserts);
+        }
+        return scripts;
     }
 
-    private String createItem(String name, HashValue hashValue) {
-        return RedisConstants.COMMAND_HASH_SET_PREFIX + getRedisValue(name)
-                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(hashValue.getField())
-                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(hashValue.getValue())
-                + RedisConstants.COMMAND_LINE_SEPARATOR;
+    private Map<String, String> fieldValues(List<HashValue> values, boolean skipDeleted) {
+        Map<String, String> fields = new LinkedHashMap<>();
+        if (CollectionUtils.isEmpty(values)) {
+            return fields;
+        }
+        for (HashValue value : values) {
+            if (value.getField() == null) {
+                continue;
+            }
+            if (skipDeleted && ai.chat2db.plugin.redis.constant.ActionConstants.DELETE.equals(value.getAction())) {
+                continue;
+            }
+            fields.put(value.getField(), StringUtils.defaultString(value.getValue()));
+        }
+        return fields;
     }
 
     private List<String> addItem(RedisKey redisKey) {
@@ -135,12 +157,6 @@ public class HashTypeScript extends BaseTypeScript implements ITypeScript {
             scripts.add(script.toString());
         }
         return scripts;
-    }
-
-    private String deleteItem(String keyName, String filedName) {
-        return RedisConstants.COMMAND_HASH_DELETE_PREFIX + getRedisValue(keyName)
-                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(filedName)
-                + RedisConstants.COMMAND_LINE_SEPARATOR;
     }
 
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ListTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ListTypeScript.java
@@ -58,18 +58,14 @@ public class ListTypeScript extends BaseTypeScript implements ITypeScript {
         if(redisKey == null || CollectionUtils.isEmpty(redisKey.getListValues())) {
             return Lists.newArrayList();
         }
-        List<String> scripts = new ArrayList<>();
-        StringBuilder script = new StringBuilder();
-        script.append(RedisConstants.COMMAND_LIST_PUSH_PREFIX).append(getRedisValue(redisKey.getName()))
-                .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
-        List<ListValue> valueList = redisKey.getListValues();
-        for (ListValue value : valueList) {
-            script.append(getRedisValue(value.getValue())).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+        List<ListValue> desired = desiredValues(redisKey);
+        if (desired.isEmpty()) {
+            return Lists.newArrayList();
         }
-        scripts.add(script.toString());
-        script = new StringBuilder();
-
+        List<String> scripts = new ArrayList<>();
+        scripts.add(pushAll(redisKey.getName(), desired));
         if (redisKey.getTtl() != null && redisKey.getTtl() > 0) {
+            StringBuilder script = new StringBuilder();
             script.append(RedisConstants.COMMAND_EXPIRE_KEY_PREFIX).append(getRedisValue(redisKey.getName()))
                     .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(redisKey.getTtl())
                     .append(RedisConstants.COMMAND_LINE_SEPARATOR);
@@ -89,49 +85,38 @@ public class ListTypeScript extends BaseTypeScript implements ITypeScript {
         if (newKey == null) {
             String delete = delete(oldKey.getName());
             return List.of(delete);
-        } else {
-            List<String> script = new ArrayList<>();
-            if (CollectionUtils.isNotEmpty(newKey.getListValues())) {
-                String before = null;
-                for (ListValue field : newKey.getListValues()) {
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.DELETE.equals(field.getAction())) {
-                        String s = deleteItem(newKey.getName(), field.getValue());
-                        script.add(s);
-                    }
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.CREATE.equals(field.getAction())) {
-                        String s = createItem(newKey.getName(), before, field);
-                        script.add(s);
-                    }
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.UPDATE.equals(field.getAction())) {
-                        String s = deleteItem(newKey.getName(), field.getValue());
-                        script.add(s);
-                        s = createItem(newKey.getName(), before, field);
-                        script.add(s);
-                    }
-                    before = field.getValue();
-                }
-            }
-            return script;
         }
+        // The editor submits the full desired list (rows flagged delete excluded),
+        // so rewrite the key to match it. Element edits carry only the new value,
+        // which makes value-based LREM/LINSERT reconciliation unsafe.
+        List<ListValue> desired = desiredValues(newKey);
+        if (desired.isEmpty()) {
+            return Lists.newArrayList();
+        }
+        List<String> scripts = new ArrayList<>();
+        scripts.add(delete(newKey.getName()));
+        scripts.add(pushAll(newKey.getName(), desired));
+        return scripts;
     }
 
-    private String createItem(String name, String before, ListValue field) {
-        if (before == null) {
-            return RedisConstants.COMMAND_LIST_PUSH_PREFIX + getRedisValue(name)
-                    + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(field.getValue())
-                    + RedisConstants.COMMAND_LINE_SEPARATOR;
-        } else {
-            return RedisConstants.COMMAND_LIST_INSERT_PREFIX + getRedisValue(name)
-                    + RedisConstants.COMMAND_LIST_INSERT_AFTER_FRAGMENT + getRedisValue(before)
-                    + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(field.getValue())
-                    + RedisConstants.COMMAND_LINE_SEPARATOR;
+    private List<ListValue> desiredValues(RedisKey redisKey) {
+        if (CollectionUtils.isEmpty(redisKey.getListValues())) {
+            return Lists.newArrayList();
         }
+        return redisKey.getListValues().stream()
+                .filter(value -> !ai.chat2db.plugin.redis.constant.ActionConstants.DELETE.equals(value.getAction()))
+                .collect(java.util.stream.Collectors.toList());
     }
 
-    private String deleteItem(String name, String value) {
-        return RedisConstants.COMMAND_LIST_REMOVE_PREFIX + getRedisValue(name)
-                + RedisConstants.COMMAND_LIST_REMOVE_ONE_FRAGMENT + getRedisValue(value)
-                + RedisConstants.COMMAND_LINE_SEPARATOR;
+    private String pushAll(String name, List<ListValue> values) {
+        StringBuilder script = new StringBuilder();
+        script.append(RedisConstants.COMMAND_LIST_RIGHT_PUSH_PREFIX).append(getRedisValue(name))
+                .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+        for (ListValue value : values) {
+            script.append(getRedisValue(StringUtils.defaultString(value.getValue())))
+                    .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+        }
+        return script.toString();
     }
 
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/SetTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/SetTypeScript.java
@@ -12,6 +12,7 @@ import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static ai.chat2db.plugin.redis.util.RedisValueUtils.getRedisValue;
 
@@ -90,40 +91,47 @@ public class SetTypeScript extends BaseTypeScript implements ITypeScript {
         if (newKey == null) {
             String delete = delete(oldKey.getName());
             return List.of(delete);
-        } else {
-            List<String> script = new ArrayList<>();
-            if (CollectionUtils.isNotEmpty(newKey.getValues())) {
-                for (SetValue field : newKey.getValues()) {
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.DELETE.equals(field.getAction())) {
-                        String s = deleteItem(newKey.getName(), field.getValue());
-                        script.add(s);
-                    }
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.CREATE.equals(field.getAction())) {
-                        String s = createItem(newKey.getName(), field.getValue());
-                        script.add(s);
-                    }
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.UPDATE.equals(field.getAction())) {
-                        String s = deleteItem(newKey.getName(), field.getValue());
-                        script.add(s);
-                        s = createItem(newKey.getName(), field.getValue());
-                        script.add(s);
-                    }
-                }
-            }
-            return script;
         }
+        // Member edits carry only the new value, so reconcile against the full
+        // old member list instead of trusting per-row action flags.
+        Set<String> desired = memberSet(newKey.getValues(), true);
+        if (desired.isEmpty()) {
+            return new ArrayList<>();
+        }
+        Set<String> existing = memberSet(oldKey.getValues(), false);
+        List<String> scripts = new ArrayList<>();
+        List<String> removed = existing.stream().filter(value -> !desired.contains(value)).toList();
+        if (!removed.isEmpty()) {
+            scripts.add(membersCommand(RedisConstants.COMMAND_SET_REMOVE_PREFIX, newKey.getName(), removed));
+        }
+        List<String> added = desired.stream().filter(value -> !existing.contains(value)).toList();
+        if (!added.isEmpty()) {
+            scripts.add(membersCommand(RedisConstants.COMMAND_SET_ADD_PREFIX, newKey.getName(), added));
+        }
+        return scripts;
     }
 
-    private String createItem(String name, String value) {
-        return RedisConstants.COMMAND_SET_ADD_PREFIX + getRedisValue(name)
-                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(value)
-                + RedisConstants.COMMAND_LINE_SEPARATOR;
+    private Set<String> memberSet(List<SetValue> values, boolean skipDeleted) {
+        Set<String> members = new java.util.LinkedHashSet<>();
+        if (CollectionUtils.isEmpty(values)) {
+            return members;
+        }
+        for (SetValue value : values) {
+            if (skipDeleted && ai.chat2db.plugin.redis.constant.ActionConstants.DELETE.equals(value.getAction())) {
+                continue;
+            }
+            members.add(StringUtils.defaultString(value.getValue()));
+        }
+        return members;
     }
 
-    private String deleteItem(String name, String value) {
-        return RedisConstants.COMMAND_SET_REMOVE_PREFIX + getRedisValue(name)
-                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(value)
-                + RedisConstants.COMMAND_LINE_SEPARATOR;
+    private String membersCommand(String commandPrefix, String name, List<String> members) {
+        StringBuilder script = new StringBuilder();
+        script.append(commandPrefix).append(getRedisValue(name)).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+        for (String member : members) {
+            script.append(getRedisValue(member)).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+        }
+        return script.toString();
     }
 
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/StreamTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/StreamTypeScript.java
@@ -130,7 +130,8 @@ public class StreamTypeScript extends BaseTypeScript implements ITypeScript {
         StringBuilder script = new StringBuilder();
         script.append(RedisConstants.COMMAND_STREAM_ADD_PREFIX).append(getRedisValue(name))
                 .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
-        script.append(field.getId()).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+        String id = StringUtils.isBlank(field.getId()) ? "*" : field.getId();
+        script.append(id).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
         for (KeyValue entry : field.getValues()) {
             if (StringUtils.isNotBlank(entry.getKey()) && StringUtils.isNotBlank(entry.getValue())) {
                 script.append(getRedisValue(entry.getKey())).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR)

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/StringTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/StringTypeScript.java
@@ -48,6 +48,9 @@ public class StringTypeScript extends BaseTypeScript implements ITypeScript {
 
     @Override
     public List<String> createKey(RedisKey redisKey) {
+        if (redisKey == null || redisKey.getValue() == null) {
+            return List.of();
+        }
         StringBuilder script = new StringBuilder();
         script.append(RedisConstants.COMMAND_SET_KEY_PREFIX).append(getRedisValue(redisKey.getName()))
                 .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(getRedisValue(redisKey.getValue()));

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/StringTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/StringTypeScript.java
@@ -69,7 +69,10 @@ public class StringTypeScript extends BaseTypeScript implements ITypeScript {
             String del = RedisConstants.COMMAND_DELETE_KEY_PREFIX + getRedisValue(oldKey.getName());
             return List.of(del);
         }
-        if (oldKey.getValue().equals(newKey.getValue())) {
+        if (Objects.equals(oldKey.getValue(), newKey.getValue())) {
+            return null;
+        }
+        if (newKey.getValue() == null) {
             return null;
         }
         String s = RedisConstants.COMMAND_SET_KEY_PREFIX + getRedisValue(newKey.getName())

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ZSetTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ZSetTypeScript.java
@@ -12,7 +12,9 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static ai.chat2db.plugin.redis.util.RedisValueUtils.getRedisValue;
@@ -73,41 +75,51 @@ public class ZSetTypeScript extends BaseTypeScript implements ITypeScript {
         if (newKey == null) {
             String del = delete(oldKey.getName());
             return List.of(del);
-        } else {
-            List<String> script = new ArrayList<>();
-            if (CollectionUtils.isNotEmpty(newKey.getZsValues())) {
-                for (ZSetValue field : newKey.getZsValues()) {
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.DELETE.equals(field.getAction())) {
-                        String s = deleteItem(newKey.getName(), field);
-                        script.add(s);
-                    }
-                    if (ai.chat2db.plugin.redis.constant.ActionConstants.CREATE.equals(field.getAction())) {
-                        String s = createItem(newKey.getName(), field);
-                        script.add(s);
-                    }
-                    if(ai.chat2db.plugin.redis.constant.ActionConstants.UPDATE.equals(field.getAction())){
-                        String s = deleteItem(newKey.getName(), field);
-                        script.add(s);
-                        s = createItem(newKey.getName(),field);
-                        script.add(s);
-                    }
-                }
-            }
-            return script;
         }
+        // Member edits carry only the new value, so reconcile against the full
+        // old member list instead of trusting per-row action flags.
+        Map<String, Double> desired = memberScores(newKey.getZsValues(), true);
+        if (desired.isEmpty()) {
+            return new ArrayList<>();
+        }
+        Map<String, Double> existing = memberScores(oldKey.getZsValues(), false);
+        List<String> scripts = new ArrayList<>();
+        List<String> removed = existing.keySet().stream().filter(value -> !desired.containsKey(value)).toList();
+        if (!removed.isEmpty()) {
+            StringBuilder script = new StringBuilder();
+            script.append(RedisConstants.COMMAND_ZSET_REMOVE_PREFIX).append(getRedisValue(newKey.getName()))
+                    .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+            for (String member : removed) {
+                script.append(getRedisValue(member)).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+            }
+            scripts.add(script.toString());
+        }
+        StringBuilder upserts = new StringBuilder();
+        for (Map.Entry<String, Double> entry : desired.entrySet()) {
+            if (!Objects.equals(existing.get(entry.getKey()), entry.getValue())) {
+                upserts.append(entry.getValue()).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR)
+                        .append(getRedisValue(entry.getKey())).append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR);
+            }
+        }
+        if (upserts.length() > 0) {
+            scripts.add(RedisConstants.COMMAND_ZSET_ADD_PREFIX + getRedisValue(newKey.getName())
+                    + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + upserts);
+        }
+        return scripts;
     }
 
-    private String createItem(String name, ZSetValue field) {
-        return RedisConstants.COMMAND_ZSET_ADD_PREFIX + getRedisValue(name)
-                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + field.getScore()
-                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(field.getValue())
-                + RedisConstants.COMMAND_LINE_SEPARATOR;
-    }
-
-    private String deleteItem(String keyName, ZSetValue value) {
-        return RedisConstants.COMMAND_ZSET_REMOVE_PREFIX + getRedisValue(keyName)
-                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(value.getValue())
-                + RedisConstants.COMMAND_LINE_SEPARATOR;
+    private Map<String, Double> memberScores(List<ZSetValue> values, boolean skipDeleted) {
+        Map<String, Double> members = new LinkedHashMap<>();
+        if (CollectionUtils.isEmpty(values)) {
+            return members;
+        }
+        for (ZSetValue value : values) {
+            if (skipDeleted && ai.chat2db.plugin.redis.constant.ActionConstants.DELETE.equals(value.getAction())) {
+                continue;
+            }
+            members.put(StringUtils.defaultString(value.getValue()), value.getScore());
+        }
+        return members;
     }
 
     private List<String> addItem(RedisKey newKey) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/util/RedisValueUtils.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/util/RedisValueUtils.java
@@ -6,6 +6,9 @@ public class RedisValueUtils {
         if(value == null) {
             return null;
         }
+        if(value.contains("\\")) {
+            value = value.replace("\\", "\\\\");
+        }
         if(value.contains("'")) {
             value = value.replace("'", "\\'");
         }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisScriptExecutorUpdateTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisScriptExecutorUpdateTest.java
@@ -1,0 +1,27 @@
+package ai.chat2db.plugin.redis;
+
+import ai.chat2db.plugin.redis.model.RedisKey;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Covers update() paths that must return before touching a connection.
+ * These tests run without a Chat2DBContext, so reaching command execution
+ * would fail, which is exactly the regression they guard against.
+ */
+class RedisScriptExecutorUpdateTest {
+
+    @Test
+    void updateReturnsEmptyResponseWhenBothKeysAreNull() {
+        assertNotNull(RedisScriptExecutor.getInstance().update(null, null));
+    }
+
+    @Test
+    void typeChangeAbortsInsteadOfDeletingWhenNewTypeHasNothingToWrite() {
+        RedisKey oldKey = RedisKey.builder().name("k").type("list").build();
+        RedisKey newKey = RedisKey.builder().name("k").type("string").value(null).build();
+
+        assertNotNull(RedisScriptExecutor.getInstance().update(oldKey, newKey));
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/HashTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/HashTypeScriptTest.java
@@ -1,0 +1,53 @@
+package ai.chat2db.plugin.redis.type;
+
+import ai.chat2db.plugin.redis.constant.ActionConstants;
+import ai.chat2db.plugin.redis.model.HashValue;
+import ai.chat2db.plugin.redis.model.RedisKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HashTypeScriptTest {
+
+    private final HashTypeScript typeScript = new HashTypeScript();
+
+    private HashValue entry(String field, String value, String action) {
+        HashValue hashValue = new HashValue();
+        hashValue.setField(field);
+        hashValue.setValue(value);
+        hashValue.setAction(action);
+        return hashValue;
+    }
+
+    private RedisKey key(String name, HashValue... values) {
+        return RedisKey.builder().name(name).type("HASH").hashValues(Arrays.asList(values)).build();
+    }
+
+    @Test
+    void updateKeyDeletesFieldsMissingFromDesiredState() {
+        RedisKey oldKey = key("k", entry("f1", "v1", null), entry("f2", "v2", null));
+        RedisKey newKey = key("k", entry("f1", "v1", "original"), entry("f3", "v3", ActionConstants.CREATE));
+
+        assertEquals(List.of("HDEL 'k' 'f2' ", "HSET 'k' 'f3' 'v3' "), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeyOverwritesChangedFieldValue() {
+        RedisKey oldKey = key("k", entry("f1", "v1", null));
+        RedisKey newKey = key("k", entry("f1", "v9", ActionConstants.UPDATE));
+
+        assertEquals(List.of("HSET 'k' 'f1' 'v9' "), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeyEmitsNothingWhenFieldsAreUnchanged() {
+        RedisKey oldKey = key("k", entry("f1", "v1", null));
+        RedisKey newKey = key("k", entry("f1", "v1", "original"));
+
+        assertTrue(typeScript.updateKey(oldKey, newKey).isEmpty());
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ListTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ListTypeScriptTest.java
@@ -1,0 +1,67 @@
+package ai.chat2db.plugin.redis.type;
+
+import ai.chat2db.plugin.redis.constant.ActionConstants;
+import ai.chat2db.plugin.redis.model.ListValue;
+import ai.chat2db.plugin.redis.model.RedisKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ListTypeScriptTest {
+
+    private final ListTypeScript typeScript = new ListTypeScript();
+
+    private ListValue item(String value, String action) {
+        ListValue listValue = new ListValue();
+        listValue.setValue(value);
+        listValue.setAction(action);
+        return listValue;
+    }
+
+    private RedisKey key(String name, ListValue... values) {
+        return RedisKey.builder().name(name).type("LIST").listValues(Arrays.asList(values)).build();
+    }
+
+    @Test
+    void createKeyPreservesInsertionOrder() {
+        List<String> scripts = typeScript.createKey(key("k", item("v1", ActionConstants.CREATE),
+                item("v2", ActionConstants.CREATE)));
+
+        assertEquals(List.of("RPUSH 'k' 'v1' 'v2' "), scripts);
+    }
+
+    @Test
+    void updateKeyRewritesKeyToDesiredState() {
+        RedisKey oldKey = key("k", item("a", null), item("b", null));
+        RedisKey newKey = key("k", item("a", "original"), item("edited", ActionConstants.UPDATE),
+                item("b", ActionConstants.DELETE));
+
+        List<String> scripts = typeScript.updateKey(oldKey, newKey);
+
+        assertEquals(List.of("DEL 'k'\n", "RPUSH 'k' 'a' 'edited' "), scripts);
+    }
+
+    @Test
+    void updateKeySkipsRewriteWhenNoDesiredValues() {
+        RedisKey oldKey = key("k", item("a", null));
+        RedisKey newKey = RedisKey.builder().name("k").type("LIST").build();
+
+        assertTrue(typeScript.updateKey(oldKey, newKey).isEmpty());
+    }
+
+    @Test
+    void updateKeyDeletesKeyWhenNewKeyIsNull() {
+        assertEquals(List.of("DEL 'k'\n"), typeScript.updateKey(key("k", item("a", null)), null));
+    }
+
+    @Test
+    void updateKeyCreatesKeyWhenOldKeyIsNull() {
+        List<String> scripts = typeScript.updateKey(null, key("k", item("v", ActionConstants.CREATE)));
+
+        assertEquals(List.of("RPUSH 'k' 'v' "), scripts);
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/SetTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/SetTypeScriptTest.java
@@ -1,0 +1,70 @@
+package ai.chat2db.plugin.redis.type;
+
+import ai.chat2db.plugin.redis.constant.ActionConstants;
+import ai.chat2db.plugin.redis.model.RedisKey;
+import ai.chat2db.plugin.redis.model.SetValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SetTypeScriptTest {
+
+    private final SetTypeScript typeScript = new SetTypeScript();
+
+    private SetValue member(String value, String action) {
+        SetValue setValue = new SetValue();
+        setValue.setValue(value);
+        setValue.setAction(action);
+        return setValue;
+    }
+
+    private RedisKey key(String name, SetValue... values) {
+        return RedisKey.builder().name(name).type("SET").values(Arrays.asList(values)).build();
+    }
+
+    @Test
+    void updateKeyRemovesOldMemberWhenValueIsEdited() {
+        RedisKey oldKey = key("k", member("a", null), member("b", null));
+        RedisKey newKey = key("k", member("a", "original"), member("c", ActionConstants.UPDATE));
+
+        List<String> scripts = typeScript.updateKey(oldKey, newKey);
+
+        assertEquals(List.of("SREM 'k' 'b' ", "SADD 'k' 'c' "), scripts);
+    }
+
+    @Test
+    void updateKeyRemovesMembersMissingFromDesiredState() {
+        RedisKey oldKey = key("k", member("a", null), member("b", null));
+        RedisKey newKey = key("k", member("a", "original"));
+
+        assertEquals(List.of("SREM 'k' 'b' "), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeyEmitsNothingWhenMembersAreUnchanged() {
+        RedisKey oldKey = key("k", member("a", null));
+        RedisKey newKey = key("k", member("a", "original"));
+
+        assertTrue(typeScript.updateKey(oldKey, newKey).isEmpty());
+    }
+
+    @Test
+    void updateKeyOnlyAddsWhenOldMembersAreUnknown() {
+        RedisKey oldKey = RedisKey.builder().name("k").type("SET").build();
+        RedisKey newKey = key("k", member("a", ActionConstants.CREATE));
+
+        assertEquals(List.of("SADD 'k' 'a' "), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeySkipsWhenDesiredStateIsEmpty() {
+        RedisKey oldKey = key("k", member("a", null));
+        RedisKey newKey = RedisKey.builder().name("k").type("SET").build();
+
+        assertTrue(typeScript.updateKey(oldKey, newKey).isEmpty());
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/StreamTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/StreamTypeScriptTest.java
@@ -1,0 +1,35 @@
+package ai.chat2db.plugin.redis.type;
+
+import ai.chat2db.plugin.redis.model.RedisKey;
+import ai.chat2db.plugin.redis.model.StreamValue;
+import ai.chat2db.community.domain.api.model.datasource.KeyValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StreamTypeScriptTest {
+
+    private final StreamTypeScript typeScript = new StreamTypeScript();
+
+    private RedisKey key(String name, String entryId) {
+        KeyValue keyValue = new KeyValue();
+        keyValue.setKey("f");
+        keyValue.setValue("v");
+        StreamValue streamValue = new StreamValue();
+        streamValue.setId(entryId);
+        streamValue.setValues(List.of(keyValue));
+        return RedisKey.builder().name(name).type("STREAM").streamValues(List.of(streamValue)).build();
+    }
+
+    @Test
+    void createKeyDefaultsBlankEntryIdToAutoGenerate() {
+        assertEquals(List.of("XADD 'k' * 'f' 'v' \n"), typeScript.createKey(key("k", "")));
+    }
+
+    @Test
+    void createKeyKeepsExplicitEntryId() {
+        assertEquals(List.of("XADD 'k' 1-1 'f' 'v' \n"), typeScript.createKey(key("k", "1-1")));
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/StringTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/StringTypeScriptTest.java
@@ -1,0 +1,43 @@
+package ai.chat2db.plugin.redis.type;
+
+import ai.chat2db.plugin.redis.model.RedisKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class StringTypeScriptTest {
+
+    private final StringTypeScript typeScript = new StringTypeScript();
+
+    private RedisKey key(String name, String value) {
+        return RedisKey.builder().name(name).type("STRING").value(value).build();
+    }
+
+    @Test
+    void updateKeyGeneratesSetScriptWhenOldValueIsNull() {
+        List<String> scripts = typeScript.updateKey(key("k", null), key("k", "v"));
+
+        assertEquals(List.of("SET 'k' 'v' XX \n"), scripts);
+    }
+
+    @Test
+    void updateKeySkipsValueWriteWhenNewValueIsNull() {
+        assertNull(typeScript.updateKey(key("k", "v"), key("renamed", null)));
+    }
+
+    @Test
+    void updateKeyReturnsNullWhenValuesAreUnchanged() {
+        assertNull(typeScript.updateKey(key("k", "v"), key("k", "v")));
+        assertNull(typeScript.updateKey(key("k", null), key("k", null)));
+    }
+
+    @Test
+    void updateKeyGeneratesSetScriptWhenValueChanges() {
+        List<String> scripts = typeScript.updateKey(key("k", "old"), key("k", "new"));
+
+        assertEquals(List.of("SET 'k' 'new' XX \n"), scripts);
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/StringTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/StringTypeScriptTest.java
@@ -40,4 +40,14 @@ class StringTypeScriptTest {
 
         assertEquals(List.of("SET 'k' 'new' XX \n"), scripts);
     }
+
+    @Test
+    void createKeySkipsWriteWhenValueIsNull() {
+        assertEquals(List.of(), typeScript.createKey(key("k", null)));
+    }
+
+    @Test
+    void createKeyGeneratesSetScript() {
+        assertEquals(List.of("SET 'k' 'v'"), typeScript.createKey(key("k", "v")));
+    }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ZSetTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ZSetTypeScriptTest.java
@@ -1,0 +1,53 @@
+package ai.chat2db.plugin.redis.type;
+
+import ai.chat2db.plugin.redis.constant.ActionConstants;
+import ai.chat2db.plugin.redis.model.RedisKey;
+import ai.chat2db.plugin.redis.model.ZSetValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ZSetTypeScriptTest {
+
+    private final ZSetTypeScript typeScript = new ZSetTypeScript();
+
+    private ZSetValue member(String value, double score, String action) {
+        ZSetValue zSetValue = new ZSetValue();
+        zSetValue.setValue(value);
+        zSetValue.setScore(score);
+        zSetValue.setAction(action);
+        return zSetValue;
+    }
+
+    private RedisKey key(String name, ZSetValue... values) {
+        return RedisKey.builder().name(name).type("ZSET").zsValues(Arrays.asList(values)).build();
+    }
+
+    @Test
+    void updateKeyOverwritesScoreWithoutRemoval() {
+        RedisKey oldKey = key("k", member("a", 1.0, null), member("b", 2.0, null));
+        RedisKey newKey = key("k", member("a", 1.0, "original"), member("b", 3.0, ActionConstants.UPDATE));
+
+        assertEquals(List.of("ZADD 'k' 3.0 'b' "), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeyRemovesOldMemberWhenValueIsEdited() {
+        RedisKey oldKey = key("k", member("a", 1.0, null));
+        RedisKey newKey = key("k", member("b", 1.0, ActionConstants.UPDATE));
+
+        assertEquals(List.of("ZREM 'k' 'a' ", "ZADD 'k' 1.0 'b' "), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeyEmitsNothingWhenMembersAreUnchanged() {
+        RedisKey oldKey = key("k", member("a", 1.0, null));
+        RedisKey newKey = key("k", member("a", 1.0, "original"));
+
+        assertTrue(typeScript.updateKey(oldKey, newKey).isEmpty());
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/util/RedisValueUtilsTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/util/RedisValueUtilsTest.java
@@ -1,0 +1,31 @@
+package ai.chat2db.plugin.redis.util;
+
+import org.junit.jupiter.api.Test;
+
+import static ai.chat2db.plugin.redis.util.RedisValueUtils.getRedisValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RedisValueUtilsTest {
+
+    @Test
+    void wrapsPlainValueInSingleQuotes() {
+        assertEquals("'abc'", getRedisValue("abc"));
+    }
+
+    @Test
+    void escapesBackslashBeforeQuotes() {
+        assertEquals("'a\\\\'", getRedisValue("a\\"));
+        assertEquals("'a\\\\\\'b'", getRedisValue("a\\'b"));
+    }
+
+    @Test
+    void escapesSingleQuote() {
+        assertEquals("'a\\'b'", getRedisValue("a'b"));
+    }
+
+    @Test
+    void returnsNullForNullInput() {
+        assertNull(getRedisValue(null));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1909 and a series of related defects found while auditing the Redis plugin's key-edit path, plus a self-review pass over the changes themselves.

### Fix for #1909 (string key update NPE)

- `StringTypeScript.updateKey` called `equals` directly on `oldKey.getValue()`, which is legitimately null when renaming or changing only the TTL — every such update threw `NullPointerException`.
- A null new value also generated `SET <key> null` via string concatenation, silently overwriting the stored value with the literal text `"null"` — matching the "Data loss" impact reported in the issue.
- Values are now compared with `Objects.equals`, and the value-write script is skipped entirely when the new value is absent.

### Value-edit semantics across collection types

The key editor submits the full old state and the full desired state, but the backend applied per-row action flags that only carry the new value. This produced wrong commands in several ways:

- **List**: creation used `LPUSH`, storing entries in reverse order; element edits issued `LREM` against the *new* value, deleting an unrelated element while leaving the old one in place. Lists are now created with `RPUSH`, and updates rewrite the key (`DEL` + `RPUSH`) to the submitted desired state, which also fixes row reordering (move up/down).
- **Set / ZSet / Hash**: edits deleted by the *new* value, so the old member survived every value edit; additionally the editor drops removed rows from the payload entirely, so deletions never reached Redis at all. Updates now reconcile the desired state against the full old member list (`SREM`/`SADD`, `ZREM`/`ZADD`, `HDEL`/`HSET` diffs), fixing residue, wrong deletes, and silently-lost deletions in one pass.

### Robustness and correctness fixes

- `RedisScriptExecutor.update`: null-key guards (previously dereferenced `oldKey` outside its guard), and the type-change branch no longer returns early — a TTL requested together with a type change was silently dropped.
- **Type change is aborted when the new type has nothing to write** (e.g. switching to string without entering a value): the create script is built first and an empty result returns before any delete, so a type change can never destroy data it cannot replace. Guard tests run without a `Chat2DBContext`, so they fail if these paths ever try to execute a command.
- Create/update readback passed a null key into the converter when the key did not exist (empty member list, short TTL); now reuses the `keyDetail` NONE-key fallback.
- `getRedisValue` escapes backslashes (a trailing backslash previously swallowed the closing quote).
- ZSET detail no longer truncates silently at 1002 members (`ZRANGE 0 -1`, consistent with other types).
- Quoted two command builders that interpolated key/field names raw (`EXISTS` in paged tables, `HGET` field).
- Blank stream entry ids default to `*` instead of producing malformed `XADD`.

### Tests

26 new unit cases across `StringTypeScriptTest`, `ListTypeScriptTest`, `SetTypeScriptTest`, `ZSetTypeScriptTest`, `HashTypeScriptTest`, `StreamTypeScriptTest`, `RedisValueUtilsTest`, and `RedisScriptExecutorUpdateTest`, covering the NPE scenarios, diff reconciliation (edit / delete / no-change / unknown-old-state), order preservation, escaping, and the type-change abort guard. Full redis module suite (34 tests) plus upstream module tests pass with Surefire explicitly enabled per AGENTS.md.

### Notes for reviewers

- The list rewrite (`DEL` + `RPUSH`) is not atomic; it is the only correct option given the payload carries no stable per-row identity. The editor semantic is "save the state I see".
- The frontend defect of dropping removed Set/ZSet/Hash rows from the payload is worked around by backend reconciliation; the frontend itself is unchanged.
- The backslash escaping assumes the bundled `redis-jdbc-driver` follows redis-cli quoting rules for `\\` (the pre-existing `\'` escaping already relies on the same assumption). Unit tests assert generated command text only; a manual round-trip against a live Redis with values containing `\` and `'` is recommended before release.
- `ZRANGE 0 -1` trades the silent 1002-member truncation for full retrieval, matching the existing unbounded `LRANGE`/`SMEMBERS`/`HGETALL` behavior; pagination for huge keys is a separate improvement.

Fixes #1909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnXg7Gt8C6npMjGBSSp8bG