### PR TITLE
fix(spi): harden SQL execution and connection lifecycle

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/enums/type/MysqlColumnTypeEnum.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/enums/type/MysqlColumnTypeEnum.java
@@ -299,7 +299,7 @@ public enum MysqlColumnTypeEnum implements IColumnBuilder {
         if (!type.columnType.isSupportExtent() || StringUtils.isEmpty(column.getExtent())) {
             return "";
         }
-        return column.getComment();
+        return column.getExtent();
     }
 
     private String buildDefaultValue(TableColumn column, MysqlColumnTypeEnum type) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/builder/MysqlSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/builder/MysqlSqlBuilderTest.java
@@ -14,6 +14,7 @@ import ai.chat2db.community.domain.api.model.result.QueryResponse;
 import ai.chat2db.community.domain.api.model.result.ResultOperation;
 import ai.chat2db.spi.model.datasource.ConnectInfo;
 import ai.chat2db.spi.sql.Chat2DBContext;
+import ai.chat2db.plugin.mysql.enums.type.MysqlColumnTypeEnum;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -23,6 +24,20 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MysqlSqlBuilderTest {
+
+    @Test
+    void shouldUseEnumExtentInsteadOfColumnComment() {
+        TableColumn column = TableColumn.builder()
+                .name("status")
+                .columnType("ENUM")
+                .extent("('draft','published')")
+                .comment("workflow status")
+                .build();
+
+        String sql = MysqlColumnTypeEnum.ENUM.buildCreateColumnSql(column);
+
+        assertTrue(sql.contains("('draft','published')"), sql);
+    }
 
     @Test
     void shouldBuildCreateDatabaseWithCharsetAndCollation() {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
@@ -292,7 +292,7 @@ public class SqlServerSqlBuilder extends DefaultSqlBuilder {
         if (StringUtils.isNotBlank(databaseName)) {
             script.append(SQLConstants.OPEN_SQUARE_BRACKET).append(databaseName).append(SQLConstants.CLOSE_SQUARE_BRACKET).append('.');
         }
-        if (StringUtils.isNotBlank(databaseName)) {
+        if (StringUtils.isNotBlank(schemaName)) {
             script.append(SQLConstants.OPEN_SQUARE_BRACKET).append(schemaName).append(SQLConstants.CLOSE_SQUARE_BRACKET).append('.');
         }
         if (!(tableName.startsWith(SQLConstants.OPEN_SQUARE_BRACKET) && tableName.endsWith(SQLConstants.CLOSE_SQUARE_BRACKET))) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
@@ -27,4 +27,20 @@ class SqlServerSqlBuilderTest {
         assertEquals("UPDATE TOP (1) [t] set [a] = 1" + where,
                 builder.appendSingleRowLimit("UPDATE", "[t]", where, "UPDATE [t] set [a] = 1" + where));
     }
+
+    @Test
+    void shouldIncludeSchemaWhenDatabaseNameIsBlank() {
+        ExposedSqlServerSqlBuilder builder = new ExposedSqlServerSqlBuilder();
+
+        assertEquals("[dbo].[orders]", builder.tableName(null, "dbo", "orders"));
+        assertEquals("[analytics].[dbo].[orders]", builder.tableName("analytics", "dbo", "orders"));
+    }
+
+    private static final class ExposedSqlServerSqlBuilder extends SqlServerSqlBuilder {
+        private String tableName(String databaseName, String schemaName, String tableName) {
+            StringBuilder script = new StringBuilder();
+            buildTableName(databaseName, schemaName, tableName, script);
+            return script.toString();
+        }
+    }
 }

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultDBManager.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultDBManager.java
@@ -126,12 +126,14 @@ public class DefaultDBManager implements IDbManager {
                 try {
                     connection.setCatalog(connectInfo.getDatabaseName());
                 } catch (SQLException e) {
+                    log.warn("Failed to set catalog to '{}': {}", connectInfo.getDatabaseName(), e.getMessage());
                 }
             }
             if (StringUtils.isNotBlank(connectInfo.getSchemaName())) {
                 try {
                     connection.setSchema(connectInfo.getSchemaName());
                 } catch (SQLException e) {
+                    log.warn("Failed to set schema to '{}': {}", connectInfo.getSchemaName(), e.getMessage());
                 }
             }
         }

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
@@ -1482,13 +1482,24 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         )) {
             connection.setAutoCommit(false);
             stmt.setFetchSize(batchSize);
-            ResultSet rs = stmt.executeQuery();
-            consumer.accept(rs);
+            try (ResultSet rs = stmt.executeQuery()) {
+                consumer.accept(rs);
+            }
             connection.commit();
-            connection.setAutoCommit(true);
         } catch (Exception e) {
             log.error("Failed to fetch table records. Query: {}", sql, e);
+            try {
+                connection.rollback();
+            } catch (SQLException rollbackEx) {
+                log.warn("Failed to rollback after error", rollbackEx);
+            }
             throw new RuntimeException(e);
+        } finally {
+            try {
+                connection.setAutoCommit(true);
+            } catch (SQLException ex) {
+                log.warn("Failed to restore autoCommit", ex);
+            }
         }
     }
 

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
@@ -1477,6 +1477,12 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         String sql = request.getSql();
         int batchSize = request.getBatchSize();
         IResultSetConsumer consumer = request.getConsumer();
+        boolean originalAutoCommit = true;
+        try {
+            originalAutoCommit = connection.getAutoCommit();
+        } catch (SQLException ex) {
+            log.warn("Failed to read original autoCommit", ex);
+        }
         try (PreparedStatement stmt = connection.prepareStatement(sql,
                 ResultSet.TYPE_FORWARD_ONLY,
                 ResultSet.CONCUR_READ_ONLY
@@ -1497,7 +1503,7 @@ public class DefaultSQLExecutor implements ICommandExecutor {
             throw new RuntimeException(e);
         } finally {
             try {
-                connection.setAutoCommit(true);
+                connection.setAutoCommit(originalAutoCommit);
             } catch (SQLException ex) {
                 log.warn("Failed to restore autoCommit", ex);
             }

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
@@ -280,9 +280,10 @@ public class DefaultSQLExecutor implements ICommandExecutor {
             boolean query = stmt.execute();
             if (query) {
                 long n = 0;
-                ResultSet rs = stmt.getResultSet();
-                while (rs.next()) {
-                    n++;
+                try (ResultSet rs = stmt.getResultSet()) {
+                    while (rs.next()) {
+                        n++;
+                    }
                 }
                 return n;
             } else {

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
@@ -1477,35 +1477,81 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         String sql = request.getSql();
         int batchSize = request.getBatchSize();
         IResultSetConsumer consumer = request.getConsumer();
-        boolean originalAutoCommit = true;
+        final boolean manageTransaction;
         try {
-            originalAutoCommit = connection.getAutoCommit();
+            manageTransaction = connection.getAutoCommit();
         } catch (SQLException ex) {
-            log.warn("Failed to read original autoCommit", ex);
+            throw new RuntimeException("Failed to read original autoCommit", ex);
         }
+        boolean transactionStarted = false;
+        boolean transactionResolved = false;
+        boolean discardRequired = false;
+        Exception failure = null;
         try (PreparedStatement stmt = connection.prepareStatement(sql,
                 ResultSet.TYPE_FORWARD_ONLY,
                 ResultSet.CONCUR_READ_ONLY
         )) {
-            connection.setAutoCommit(false);
+            if (manageTransaction) {
+                transactionStarted = true;
+                connection.setAutoCommit(false);
+            }
             stmt.setFetchSize(batchSize);
             try (ResultSet rs = stmt.executeQuery()) {
                 consumer.accept(rs);
             }
-            connection.commit();
+            if (transactionStarted) {
+                connection.commit();
+                transactionResolved = true;
+            }
         } catch (Exception e) {
-            log.error("Failed to fetch table records. Query: {}", sql, e);
+            failure = e;
+        }
+
+        if (failure != null && transactionStarted && !transactionResolved) {
             try {
                 connection.rollback();
-            } catch (SQLException rollbackEx) {
-                log.warn("Failed to rollback after error", rollbackEx);
+                transactionResolved = true;
+            } catch (Exception rollbackEx) {
+                failure.addSuppressed(rollbackEx);
+                discardRequired = true;
             }
-            throw new RuntimeException(e);
-        } finally {
+        }
+
+        if (transactionStarted && !discardRequired) {
             try {
-                connection.setAutoCommit(originalAutoCommit);
-            } catch (SQLException ex) {
-                log.warn("Failed to restore autoCommit", ex);
+                connection.setAutoCommit(true);
+            } catch (Exception restoreEx) {
+                if (failure == null) {
+                    failure = restoreEx;
+                } else {
+                    failure.addSuppressed(restoreEx);
+                }
+                discardRequired = true;
+            }
+        }
+
+        if (discardRequired) {
+            discardConnection(connection, failure);
+        }
+        if (failure != null) {
+            log.error("Failed to fetch table records. Query: {}", sql, failure);
+            throw new RuntimeException(failure);
+        }
+    }
+
+    private void discardConnection(Connection connection, Throwable failure) {
+        ConnectInfo connectInfo = Chat2DBContext.getConnectInfo();
+        if (connectInfo != null && connectInfo.getConnection() == connection) {
+            connectInfo.setConnection(null);
+        }
+        try {
+            connection.close();
+        } catch (Exception closeEx) {
+            failure.addSuppressed(closeEx);
+            try {
+                connection.abort(Runnable::run);
+            } catch (Exception abortEx) {
+                failure.addSuppressed(abortEx);
             }
         }
     }

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
@@ -46,6 +46,7 @@ import org.springframework.util.Assert;
 
 import java.sql.*;
 import java.util.*;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -56,6 +57,8 @@ import java.util.stream.Collectors;
 public class DefaultSQLExecutor implements ICommandExecutor {
 
     private static final int STREAMING_ROW_BATCH_SIZE = 200;
+
+    private static final Executor DIRECT_ABORT_EXECUTOR = Runnable::run;
 
 
     private static final DefaultSQLExecutor INSTANCE = new DefaultSQLExecutor();
@@ -1545,14 +1548,15 @@ public class DefaultSQLExecutor implements ICommandExecutor {
             connectInfo.setConnection(null);
         }
         try {
+            connection.abort(DIRECT_ABORT_EXECUTOR);
+            return;
+        } catch (Exception abortEx) {
+            failure.addSuppressed(abortEx);
+        }
+        try {
             connection.close();
         } catch (Exception closeEx) {
             failure.addSuppressed(closeEx);
-            try {
-                connection.abort(Runnable::run);
-            } catch (Exception abortEx) {
-                failure.addSuppressed(abortEx);
-            }
         }
     }
 

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/model/datasource/ConnectInfo.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/model/datasource/ConnectInfo.java
@@ -213,7 +213,7 @@ public class ConnectInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(dataSourceId, consoleId, databaseName);
+        return Objects.hash(dataSourceId, gmtModified);
     }
 
     public Long getDataSourceId() {

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/model/datasource/ConnectInfo.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/model/datasource/ConnectInfo.java
@@ -139,6 +139,9 @@ public class ConnectInfo {
 
     private Date lastAccessTime;
 
+    // Runtime-only marker used to reject leases created before a pool invalidation.
+    private transient volatile Long poolGeneration;
+
 
     public String getDbVersion() {
         return dbVersion;
@@ -488,6 +491,14 @@ public class ConnectInfo {
 
     public void setLastAccessTime(Date lastAccessTime) {
         this.lastAccessTime = lastAccessTime;
+    }
+
+    public Long poolGeneration() {
+        return poolGeneration;
+    }
+
+    public void updatePoolGeneration(Long poolGeneration) {
+        this.poolGeneration = poolGeneration;
     }
 
     private AtomicBoolean inUse = new AtomicBoolean(false);

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/Chat2DBContext.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/Chat2DBContext.java
@@ -48,12 +48,20 @@ public class Chat2DBContext {
         }
     }
 
+    private static IPlugin getPlugin(String dbType) {
+        IPlugin plugin = PLUGIN_MAP.get(dbType);
+        if (plugin == null) {
+            throw new IllegalArgumentException("Unsupported database type: " + dbType + ". Registered types: " + PLUGIN_MAP.keySet());
+        }
+        return plugin;
+    }
+
     public static DriverConfig getDefaultDriverConfig(String dbType) {
-        return PLUGIN_MAP.get(dbType).getDBConfig().getDefaultDriverConfig();
+        return getPlugin(dbType).getDBConfig().getDefaultDriverConfig();
     }
 
     public static ISqlBuilder getSqlBuilder() {
-        return PLUGIN_MAP.get(getConnectInfo().getDbType()).getDbMetaData().getSqlBuilder();
+        return getPlugin(getConnectInfo().getDbType()).getDbMetaData().getSqlBuilder();
     }
 
 
@@ -62,18 +70,18 @@ public class Chat2DBContext {
     }
 
     public static IDbMetaData getDbMetaData() {
-        return PLUGIN_MAP.get(getConnectInfo().getDbType()).getDbMetaData();
+        return getPlugin(getConnectInfo().getDbType()).getDbMetaData();
     }
 
     public static IDbMetaData getDbMetaData(String dbType) {
         if (StringUtils.isBlank(dbType)) {
             return getDbMetaData();
         }
-        return PLUGIN_MAP.get(dbType).getDbMetaData();
+        return getPlugin(dbType).getDbMetaData();
     }
 
     public static DBConfig getDBConfig(String dbType) {
-        return PLUGIN_MAP.get(dbType).getDBConfig();
+        return getPlugin(dbType).getDBConfig();
     }
 
     public static DBConfig getDBConfig() {
@@ -81,15 +89,15 @@ public class Chat2DBContext {
         if (connectInfo == null) {
             return null;
         }
-        return PLUGIN_MAP.get(connectInfo.getDbType()).getDBConfig();
+        return getPlugin(connectInfo.getDbType()).getDBConfig();
     }
 
     public static IDbManager getDbManager() {
-        return PLUGIN_MAP.get(getConnectInfo().getDbType()).getDbManager();
+        return getPlugin(getConnectInfo().getDbType()).getDbManager();
     }
 
     public static IDbManager getDbManager(String dbType) {
-        return PLUGIN_MAP.get(dbType).getDbManager();
+        return getPlugin(dbType).getDbManager();
     }
 
     public static IAccountManager getAccountManager() {

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/Chat2DBContext.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/Chat2DBContext.java
@@ -49,6 +49,9 @@ public class Chat2DBContext {
     }
 
     private static IPlugin getPlugin(String dbType) {
+        if (StringUtils.isBlank(dbType)) {
+            throw new IllegalArgumentException("Database type must not be blank. Registered types: " + PLUGIN_MAP.keySet());
+        }
         IPlugin plugin = PLUGIN_MAP.get(dbType);
         if (plugin == null) {
             throw new IllegalArgumentException("Unsupported database type: " + dbType + ". Registered types: " + PLUGIN_MAP.keySet());

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
@@ -54,8 +54,10 @@ public class ConnectionPool {
                                     try {
                                         if (connectInfo.getLastAccessTime().getTime() + 1000 * 60 * 30 < System.currentTimeMillis()) {
                                             closeQuietly(connectInfo);
+                                            iterator.remove();
                                         } else if (!checkConnectionIsActive(connectInfo)) {
                                             closeQuietly(connectInfo);
+                                            iterator.remove();
                                         }
                                     } finally {
                                         connectInfo.releaseInUse();
@@ -166,6 +168,9 @@ public class ConnectionPool {
                     return createNewConnection(connectInfo);
                 }
             } else {
+                if (c != null) {
+                    queue.offer(c);
+                }
                 return createNewConnection(connectInfo);
             }
         } else {

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
@@ -28,6 +28,8 @@ public class ConnectionPool {
 
     private static ConcurrentHashMap<Long, ConcurrentHashMap<String, LinkedBlockingQueue<ConnectInfo>>> CONNECTION_MAP = new ConcurrentHashMap<>();
 
+    private static final ConcurrentHashMap<Long, Long> CONNECTION_GENERATIONS = new ConcurrentHashMap<>();
+
 
     static {
         new Thread(() -> {
@@ -97,6 +99,13 @@ public class ConnectionPool {
 
     static LinkedBlockingQueue<ConnectInfo> newConnectionQueue() {
         return new LinkedBlockingQueue<>(MAX_CONNECTIONS);
+    }
+
+    static LinkedBlockingQueue<ConnectInfo> getOrCreateConnectionQueue(Long datasourceId,
+                                                                        String connectionKey) {
+        ConcurrentHashMap<String, LinkedBlockingQueue<ConnectInfo>> map =
+                CONNECTION_MAP.computeIfAbsent(datasourceId, key -> new ConcurrentHashMap<>());
+        return map.computeIfAbsent(connectionKey, key -> newConnectionQueue());
     }
 
     static void offerOrClose(LinkedBlockingQueue<ConnectInfo> queue, ConnectInfo connectInfo) {
@@ -198,10 +207,19 @@ public class ConnectionPool {
         return null;
     }
 
+    static long currentGeneration(Long datasourceId) {
+        return datasourceId == null ? 0L : CONNECTION_GENERATIONS.getOrDefault(datasourceId, 0L);
+    }
+
     public static Connection createNewConnection(ConnectInfo connectInfo) {
+        return createNewConnection(connectInfo, currentGeneration(connectInfo.getDataSourceId()));
+    }
+
+    private static Connection createNewConnection(ConnectInfo connectInfo, long generation) {
         log.info("Creating new individual connection");
         Connection connection = Chat2DBContext.getDbManager(connectInfo.getDbType()).getConnection(connectInfo);
         connectInfo.setConnection(connection);
+        connectInfo.updatePoolGeneration(generation);
         return connection;
     }
 
@@ -210,27 +228,28 @@ public class ConnectionPool {
         if (connection != null) {
             return connection;
         }
-        ConcurrentHashMap<String, LinkedBlockingQueue<ConnectInfo>> map = CONNECTION_MAP.get(connectInfo.getDataSourceId());
-        if (map == null) {
+        Long datasourceId = connectInfo.getDataSourceId();
+        if (datasourceId == null) {
             return createNewConnection(connectInfo);
         }
-        LinkedBlockingQueue<ConnectInfo> queue = map.get(connectInfo.getKey());
-        if (queue != null) {
-            Connection pooledConnection = tryBorrowConnection(connectInfo, connectInfo.getDataSourceId(),
-                    connectInfo.getKey(), queue);
-            if (pooledConnection != null) {
-                return pooledConnection;
-            }
+        long acquisitionGeneration = currentGeneration(datasourceId);
+        LinkedBlockingQueue<ConnectInfo> queue =
+                getOrCreateConnectionQueue(datasourceId, connectInfo.getKey());
+        Connection pooledConnection = tryBorrowConnection(connectInfo, datasourceId,
+                connectInfo.getKey(), queue, acquisitionGeneration);
+        if (pooledConnection != null) {
+            return pooledConnection;
         }
-        return createNewConnection(connectInfo);
+        return createNewConnection(connectInfo, acquisitionGeneration);
     }
 
     static Connection tryBorrowConnection(ConnectInfo connectInfo, LinkedBlockingQueue<ConnectInfo> queue) {
-        return tryBorrowConnection(connectInfo, null, null, queue);
+        return tryBorrowConnection(connectInfo, null, null, queue, 0L);
     }
 
     private static Connection tryBorrowConnection(ConnectInfo connectInfo, Long datasourceId, String connectionKey,
-                                                   LinkedBlockingQueue<ConnectInfo> queue) {
+                                                   LinkedBlockingQueue<ConnectInfo> queue,
+                                                   long acquisitionGeneration) {
         ConnectInfo pooledConnectInfo = queue.poll();
         if (pooledConnectInfo == null) {
             return null;
@@ -240,10 +259,16 @@ public class ConnectionPool {
             returnToQueue(datasourceId, connectionKey, queue, pooledConnectInfo, false);
             return null;
         }
+        if (datasourceId != null
+                && !Objects.equals(pooledConnectInfo.poolGeneration(), acquisitionGeneration)) {
+            closeQuietly(pooledConnectInfo);
+            return null;
+        }
         Connection connection = tryGetExistingConnection(pooledConnectInfo);
         if (connection != null
                 && (isRecentlyUsed(lastAccessTime) || checkConnectionIsActive(pooledConnectInfo))) {
             connectInfo.setConnection(connection);
+            connectInfo.updatePoolGeneration(pooledConnectInfo.poolGeneration());
             log.info("Got connection from pool");
             return connection;
         }
@@ -252,6 +277,10 @@ public class ConnectionPool {
     }
 
     public static void removeConnection(Long datasourceId) {
+        if (datasourceId == null) {
+            return;
+        }
+        CONNECTION_GENERATIONS.merge(datasourceId, 1L, Long::sum);
         CONNECTION_MAP.computeIfPresent(datasourceId, (key, keyMap) -> {
             for (Map.Entry<String, LinkedBlockingQueue<ConnectInfo>> entry : keyMap.entrySet()) {
                 LinkedBlockingQueue<ConnectInfo> queue = entry.getValue();
@@ -303,10 +332,31 @@ public class ConnectionPool {
             return;
         }
 
-        String key = connectInfo.getKey();
-        ConcurrentHashMap<String, LinkedBlockingQueue<ConnectInfo>> map = CONNECTION_MAP.computeIfAbsent(connectInfo.getDataSourceId(), k -> new ConcurrentHashMap<>());
-        LinkedBlockingQueue<ConnectInfo> queue = map.computeIfAbsent(key, k -> newConnectionQueue());
-        offerOrClose(queue, connectInfo);
+        Long datasourceId = connectInfo.getDataSourceId();
+        if (datasourceId == null) {
+            closeQuietly(connectInfo);
+            return;
+        }
+        Long leaseGeneration = connectInfo.poolGeneration();
+        if (leaseGeneration == null) {
+            closeQuietly(connectInfo);
+            return;
+        }
+        long expectedGeneration = leaseGeneration;
+        String connectionKey = connectInfo.getKey();
+        CONNECTION_MAP.compute(datasourceId, (key, keyMap) -> {
+            if (expectedGeneration != currentGeneration(datasourceId) || keyMap == null) {
+                closeQuietly(connectInfo);
+                return keyMap;
+            }
+            LinkedBlockingQueue<ConnectInfo> queue = keyMap.get(connectionKey);
+            if (queue == null) {
+                closeQuietly(connectInfo);
+            } else {
+                offerOrClose(queue, connectInfo);
+            }
+            return keyMap;
+        });
     }
 
 }

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
@@ -75,7 +75,7 @@ public class ConnectionPool {
             log.info("check connection:{},usage:{}", connectInfo.getKey(), connectInfo.isInUse());
             Date lastAccessTime = connectInfo.getLastAccessTime();
             if (!connectInfo.trySetInUse()) {
-                returnToQueueOrClose(datasourceId, connectionKey, queue, connectInfo);
+                returnToQueue(datasourceId, connectionKey, queue, connectInfo, false);
                 continue;
             }
             boolean reusable = true;
@@ -89,7 +89,7 @@ public class ConnectionPool {
             } finally {
                 connectInfo.releaseInUse();
                 if (reusable) {
-                    returnToQueueOrClose(datasourceId, connectionKey, queue, connectInfo);
+                    returnToQueue(datasourceId, connectionKey, queue, connectInfo, true);
                 }
             }
         }
@@ -105,11 +105,13 @@ public class ConnectionPool {
         }
     }
 
-    private static void returnToQueueOrClose(Long datasourceId, String connectionKey,
-                                             LinkedBlockingQueue<ConnectInfo> queue,
-                                             ConnectInfo connectInfo) {
+    private static void returnToQueue(Long datasourceId, String connectionKey,
+                                      LinkedBlockingQueue<ConnectInfo> queue,
+                                      ConnectInfo connectInfo, boolean closeIfRejected) {
         if (datasourceId == null) {
-            offerOrClose(queue, connectInfo);
+            if (!queue.offer(connectInfo)) {
+                handleRejectedReturn(connectInfo, closeIfRejected);
+            }
             return;
         }
         boolean[] returnedToCurrentQueue = {false};
@@ -120,7 +122,15 @@ public class ConnectionPool {
             return keyMap;
         });
         if (!returnedToCurrentQueue[0]) {
+            handleRejectedReturn(connectInfo, closeIfRejected);
+        }
+    }
+
+    private static void handleRejectedReturn(ConnectInfo connectInfo, boolean closeIfRejected) {
+        if (closeIfRejected) {
             closeQuietly(connectInfo);
+        } else {
+            log.warn("Dropped duplicate pooled connection reference for {}", connectInfo.getKey());
         }
     }
 
@@ -227,7 +237,7 @@ public class ConnectionPool {
         }
         Date lastAccessTime = pooledConnectInfo.getLastAccessTime();
         if (!pooledConnectInfo.trySetInUse()) {
-            returnToQueueOrClose(datasourceId, connectionKey, queue, pooledConnectInfo);
+            returnToQueue(datasourceId, connectionKey, queue, pooledConnectInfo, false);
             return null;
         }
         Connection connection = tryGetExistingConnection(pooledConnectInfo);

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
@@ -46,24 +46,7 @@ public class ConnectionPool {
                                 continue;
                             }
                             log.info(e.getKey() + " queue size:{}", queue.size());
-                            Iterator<ConnectInfo> iterator = queue.iterator();
-                            while (iterator.hasNext()) {
-                                ConnectInfo connectInfo = iterator.next();
-                                log.info("check connection:{},usage:{}", connectInfo.getKey(), connectInfo.isInUse());
-                                if (connectInfo.trySetInUse()) {
-                                    try {
-                                        if (connectInfo.getLastAccessTime().getTime() + 1000 * 60 * 30 < System.currentTimeMillis()) {
-                                            closeQuietly(connectInfo);
-                                            iterator.remove();
-                                        } else if (!checkConnectionIsActive(connectInfo)) {
-                                            closeQuietly(connectInfo);
-                                            iterator.remove();
-                                        }
-                                    } finally {
-                                        connectInfo.releaseInUse();
-                                    }
-                                }
-                            }
+                            cleanupQueue(queue);
                         }
                     }
                 } catch (Exception e) {
@@ -71,6 +54,46 @@ public class ConnectionPool {
                 }
             }
         }).start();
+    }
+
+    static void cleanupQueue(LinkedBlockingQueue<ConnectInfo> queue) {
+        int connectionsToCheck = queue.size();
+        for (int i = 0; i < connectionsToCheck; i++) {
+            ConnectInfo connectInfo = queue.poll();
+            if (connectInfo == null) {
+                return;
+            }
+            log.info("check connection:{},usage:{}", connectInfo.getKey(), connectInfo.isInUse());
+            Date lastAccessTime = connectInfo.getLastAccessTime();
+            if (!connectInfo.trySetInUse()) {
+                queue.offer(connectInfo);
+                continue;
+            }
+            boolean reusable = true;
+            try {
+                boolean expired = lastAccessTime != null
+                        && lastAccessTime.getTime() + 1000 * 60 * 30 < System.currentTimeMillis();
+                if (expired || !checkConnectionIsActive(connectInfo)) {
+                    closeQuietly(connectInfo);
+                    reusable = false;
+                }
+            } finally {
+                connectInfo.releaseInUse();
+                if (reusable) {
+                    offerOrClose(queue, connectInfo);
+                }
+            }
+        }
+    }
+
+    static LinkedBlockingQueue<ConnectInfo> newConnectionQueue() {
+        return new LinkedBlockingQueue<>(MAX_CONNECTIONS);
+    }
+
+    static void offerOrClose(LinkedBlockingQueue<ConnectInfo> queue, ConnectInfo connectInfo) {
+        if (!queue.offer(connectInfo)) {
+            closeQuietly(connectInfo);
+        }
     }
 
     private static boolean checkConnectionIsActive(ConnectInfo connectInfo) {
@@ -156,26 +179,32 @@ public class ConnectionPool {
         }
         LinkedBlockingQueue<ConnectInfo> queue = map.get(connectInfo.getKey());
         if (queue != null) {
-            ConnectInfo c = queue.poll();
-            if (c != null && c.trySetInUse()) {
-                Connection conn = tryGetExistingConnection(c);
-                if (conn != null && (isRecentlyUsed(c) || checkConnectionIsActive(c))) {
-                    connectInfo.setConnection(conn);
-                    log.info("Got connection from pool");
-                    return conn;
-                } else {
-                    closeQuietly(c);
-                    return createNewConnection(connectInfo);
-                }
-            } else {
-                if (c != null) {
-                    queue.offer(c);
-                }
-                return createNewConnection(connectInfo);
+            Connection pooledConnection = tryBorrowConnection(connectInfo, queue);
+            if (pooledConnection != null) {
+                return pooledConnection;
             }
-        } else {
-            return createNewConnection(connectInfo);
         }
+        return createNewConnection(connectInfo);
+    }
+
+    static Connection tryBorrowConnection(ConnectInfo connectInfo, LinkedBlockingQueue<ConnectInfo> queue) {
+        ConnectInfo pooledConnectInfo = queue.poll();
+        if (pooledConnectInfo == null) {
+            return null;
+        }
+        if (!pooledConnectInfo.trySetInUse()) {
+            queue.offer(pooledConnectInfo);
+            return null;
+        }
+        Connection connection = tryGetExistingConnection(pooledConnectInfo);
+        if (connection != null
+                && (isRecentlyUsed(pooledConnectInfo) || checkConnectionIsActive(pooledConnectInfo))) {
+            connectInfo.setConnection(connection);
+            log.info("Got connection from pool");
+            return connection;
+        }
+        closeQuietly(pooledConnectInfo);
+        return null;
     }
 
     public static void removeConnection(Long datasourceId) {
@@ -232,12 +261,8 @@ public class ConnectionPool {
 
         String key = connectInfo.getKey();
         ConcurrentHashMap<String, LinkedBlockingQueue<ConnectInfo>> map = CONNECTION_MAP.computeIfAbsent(connectInfo.getDataSourceId(), k -> new ConcurrentHashMap<>());
-        LinkedBlockingQueue<ConnectInfo> queue = map.computeIfAbsent(key, k -> new LinkedBlockingQueue<>());
-        if (queue.size() < MAX_CONNECTIONS) {
-            queue.offer(connectInfo);
-        } else {
-            closeQuietly(connectInfo);
-        }
+        LinkedBlockingQueue<ConnectInfo> queue = map.computeIfAbsent(key, k -> newConnectionQueue());
+        offerOrClose(queue, connectInfo);
     }
 
 }

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
@@ -142,8 +142,7 @@ public class ConnectionPool {
     }
 
 
-    private static boolean isRecentlyUsed(ConnectInfo connectInfo) {
-        Date lastAccessTime = connectInfo.getLastAccessTime();
+    private static boolean isRecentlyUsed(Date lastAccessTime) {
         return lastAccessTime != null
                 && System.currentTimeMillis() - lastAccessTime.getTime() < SKIP_VALIDATION_IF_RECENTLY_USED_MS;
     }
@@ -192,13 +191,14 @@ public class ConnectionPool {
         if (pooledConnectInfo == null) {
             return null;
         }
+        Date lastAccessTime = pooledConnectInfo.getLastAccessTime();
         if (!pooledConnectInfo.trySetInUse()) {
             queue.offer(pooledConnectInfo);
             return null;
         }
         Connection connection = tryGetExistingConnection(pooledConnectInfo);
         if (connection != null
-                && (isRecentlyUsed(pooledConnectInfo) || checkConnectionIsActive(pooledConnectInfo))) {
+                && (isRecentlyUsed(lastAccessTime) || checkConnectionIsActive(pooledConnectInfo))) {
             connectInfo.setConnection(connection);
             log.info("Got connection from pool");
             return connection;

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/ConnectionPool.java
@@ -34,21 +34,7 @@ public class ConnectionPool {
             while (true) {
                 try {
                     Thread.sleep(1000 * 60 * 1);
-                    log.info("CONNECTION_MAP size:{}", CONNECTION_MAP.size());
-                    for (Map.Entry<Long, ConcurrentHashMap<String, LinkedBlockingQueue<ConnectInfo>>> entry : CONNECTION_MAP.entrySet()) {
-                        ConcurrentHashMap<String, LinkedBlockingQueue<ConnectInfo>> map = entry.getValue();
-                        if (map == null) {
-                            continue;
-                        }
-                        for (Map.Entry<String, LinkedBlockingQueue<ConnectInfo>> e : map.entrySet()) {
-                            LinkedBlockingQueue<ConnectInfo> queue = e.getValue();
-                            if (queue == null) {
-                                continue;
-                            }
-                            log.info(e.getKey() + " queue size:{}", queue.size());
-                            cleanupQueue(queue);
-                        }
-                    }
+                    cleanupConnections();
                 } catch (Exception e) {
                     log.error("close connection error", e);
                 }
@@ -56,7 +42,30 @@ public class ConnectionPool {
         }).start();
     }
 
+    static void cleanupConnections() {
+        log.info("CONNECTION_MAP size:{}", CONNECTION_MAP.size());
+        for (Map.Entry<Long, ConcurrentHashMap<String, LinkedBlockingQueue<ConnectInfo>>> entry : CONNECTION_MAP.entrySet()) {
+            ConcurrentHashMap<String, LinkedBlockingQueue<ConnectInfo>> map = entry.getValue();
+            if (map == null) {
+                continue;
+            }
+            for (Map.Entry<String, LinkedBlockingQueue<ConnectInfo>> queueEntry : map.entrySet()) {
+                LinkedBlockingQueue<ConnectInfo> queue = queueEntry.getValue();
+                if (queue == null) {
+                    continue;
+                }
+                log.info(queueEntry.getKey() + " queue size:{}", queue.size());
+                cleanupQueue(entry.getKey(), queueEntry.getKey(), queue);
+            }
+        }
+    }
+
     static void cleanupQueue(LinkedBlockingQueue<ConnectInfo> queue) {
+        cleanupQueue(null, null, queue);
+    }
+
+    private static void cleanupQueue(Long datasourceId, String connectionKey,
+                                     LinkedBlockingQueue<ConnectInfo> queue) {
         int connectionsToCheck = queue.size();
         for (int i = 0; i < connectionsToCheck; i++) {
             ConnectInfo connectInfo = queue.poll();
@@ -66,7 +75,7 @@ public class ConnectionPool {
             log.info("check connection:{},usage:{}", connectInfo.getKey(), connectInfo.isInUse());
             Date lastAccessTime = connectInfo.getLastAccessTime();
             if (!connectInfo.trySetInUse()) {
-                queue.offer(connectInfo);
+                returnToQueueOrClose(datasourceId, connectionKey, queue, connectInfo);
                 continue;
             }
             boolean reusable = true;
@@ -80,7 +89,7 @@ public class ConnectionPool {
             } finally {
                 connectInfo.releaseInUse();
                 if (reusable) {
-                    offerOrClose(queue, connectInfo);
+                    returnToQueueOrClose(datasourceId, connectionKey, queue, connectInfo);
                 }
             }
         }
@@ -92,6 +101,25 @@ public class ConnectionPool {
 
     static void offerOrClose(LinkedBlockingQueue<ConnectInfo> queue, ConnectInfo connectInfo) {
         if (!queue.offer(connectInfo)) {
+            closeQuietly(connectInfo);
+        }
+    }
+
+    private static void returnToQueueOrClose(Long datasourceId, String connectionKey,
+                                             LinkedBlockingQueue<ConnectInfo> queue,
+                                             ConnectInfo connectInfo) {
+        if (datasourceId == null) {
+            offerOrClose(queue, connectInfo);
+            return;
+        }
+        boolean[] returnedToCurrentQueue = {false};
+        CONNECTION_MAP.computeIfPresent(datasourceId, (key, keyMap) -> {
+            if (keyMap.get(connectionKey) == queue) {
+                returnedToCurrentQueue[0] = queue.offer(connectInfo);
+            }
+            return keyMap;
+        });
+        if (!returnedToCurrentQueue[0]) {
             closeQuietly(connectInfo);
         }
     }
@@ -178,7 +206,8 @@ public class ConnectionPool {
         }
         LinkedBlockingQueue<ConnectInfo> queue = map.get(connectInfo.getKey());
         if (queue != null) {
-            Connection pooledConnection = tryBorrowConnection(connectInfo, queue);
+            Connection pooledConnection = tryBorrowConnection(connectInfo, connectInfo.getDataSourceId(),
+                    connectInfo.getKey(), queue);
             if (pooledConnection != null) {
                 return pooledConnection;
             }
@@ -187,13 +216,18 @@ public class ConnectionPool {
     }
 
     static Connection tryBorrowConnection(ConnectInfo connectInfo, LinkedBlockingQueue<ConnectInfo> queue) {
+        return tryBorrowConnection(connectInfo, null, null, queue);
+    }
+
+    private static Connection tryBorrowConnection(ConnectInfo connectInfo, Long datasourceId, String connectionKey,
+                                                   LinkedBlockingQueue<ConnectInfo> queue) {
         ConnectInfo pooledConnectInfo = queue.poll();
         if (pooledConnectInfo == null) {
             return null;
         }
         Date lastAccessTime = pooledConnectInfo.getLastAccessTime();
         if (!pooledConnectInfo.trySetInUse()) {
-            queue.offer(pooledConnectInfo);
+            returnToQueueOrClose(datasourceId, connectionKey, queue, pooledConnectInfo);
             return null;
         }
         Connection connection = tryGetExistingConnection(pooledConnectInfo);

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/sql/DefaultSQLExecutorTransactionTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/sql/DefaultSQLExecutorTransactionTest.java
@@ -1,0 +1,211 @@
+package ai.chat2db.community.test.spi.sql;
+
+import ai.chat2db.community.domain.api.config.DriverConfig;
+import ai.chat2db.spi.DefaultSQLExecutor;
+import ai.chat2db.spi.model.datasource.ConnectInfo;
+import ai.chat2db.spi.model.request.FetchAllTableRecordsRequest;
+import ai.chat2db.spi.sql.Chat2DBContext;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultSQLExecutorTransactionTest {
+
+    @Test
+    void shouldNotCommitCallerManagedTransaction() throws Exception {
+        String url = "jdbc:h2:mem:fetch_records_caller_commit;DB_CLOSE_DELAY=-1";
+        try (Connection connection = DriverManager.getConnection(url);
+             Connection observer = DriverManager.getConnection(url)) {
+            createTable(connection);
+            connection.setAutoCommit(false);
+            executeUpdate(connection, "INSERT INTO records VALUES (1)");
+            AtomicReference<ResultSet> resultSet = new AtomicReference<>();
+
+            DefaultSQLExecutor.getInstance().fetchAllTableRecords(request(connection, rs -> {
+                resultSet.set(rs);
+                while (rs.next()) {
+                }
+            }));
+
+            assertFalse(connection.getAutoCommit());
+            assertTrue(resultSet.get().isClosed());
+            assertEquals(0, countRows(observer));
+            connection.rollback();
+        }
+    }
+
+    @Test
+    void shouldNotRollbackCallerManagedTransaction() throws Exception {
+        String url = "jdbc:h2:mem:fetch_records_caller_rollback;DB_CLOSE_DELAY=-1";
+        try (Connection connection = DriverManager.getConnection(url);
+             Connection observer = DriverManager.getConnection(url)) {
+            createTable(connection);
+            connection.setAutoCommit(false);
+            executeUpdate(connection, "INSERT INTO records VALUES (1)");
+
+            assertThrows(RuntimeException.class, () -> DefaultSQLExecutor.getInstance()
+                    .fetchAllTableRecords(request(connection, rs -> {
+                        throw new IllegalStateException("consumer failed");
+                    })));
+
+            assertFalse(connection.getAutoCommit());
+            connection.commit();
+            assertEquals(1, countRows(observer));
+        }
+    }
+
+    @Test
+    void shouldRollbackAndRestoreTransactionStartedByExecutor() throws Exception {
+        String url = "jdbc:h2:mem:fetch_records_executor_rollback;DB_CLOSE_DELAY=-1";
+        try (Connection connection = DriverManager.getConnection(url);
+             Connection observer = DriverManager.getConnection(url)) {
+            createTable(connection);
+
+            assertThrows(RuntimeException.class, () -> DefaultSQLExecutor.getInstance()
+                    .fetchAllTableRecords(request(connection, rs -> {
+                        executeUpdate(connection, "INSERT INTO records VALUES (1)");
+                        throw new IllegalStateException("consumer failed");
+                    })));
+
+            assertTrue(connection.getAutoCommit());
+            assertEquals(0, countRows(observer));
+        }
+    }
+
+    @Test
+    void shouldDiscardConnectionAndPreserveRollbackFailure() throws Exception {
+        String url = "jdbc:h2:mem:fetch_records_rollback_failure;DB_CLOSE_DELAY=-1";
+        try (Connection delegate = DriverManager.getConnection(url);
+             Connection observer = DriverManager.getConnection(url)) {
+            createTable(delegate);
+            Connection connection = proxyConnection(delegate, true, false);
+            ConnectInfo connectInfo = putContext(connection);
+            IllegalStateException consumerFailure = new IllegalStateException("consumer failed");
+            try {
+                RuntimeException thrown = assertThrows(RuntimeException.class,
+                        () -> DefaultSQLExecutor.getInstance().fetchAllTableRecords(request(connection, rs -> {
+                            executeUpdate(connection, "INSERT INTO records VALUES (1)");
+                            throw consumerFailure;
+                        })));
+
+                assertSame(consumerFailure, thrown.getCause());
+                assertEquals(1, consumerFailure.getSuppressed().length);
+                assertEquals("rollback failed", consumerFailure.getSuppressed()[0].getMessage());
+                assertTrue(connection.isClosed());
+                assertNull(connectInfo.getConnection());
+                assertEquals(0, countRows(observer));
+            } finally {
+                Chat2DBContext.removeContext();
+            }
+        }
+    }
+
+    @Test
+    void shouldDiscardConnectionWhenAutoCommitRestorationFails() throws Exception {
+        String url = "jdbc:h2:mem:fetch_records_restore_failure;DB_CLOSE_DELAY=-1";
+        try (Connection delegate = DriverManager.getConnection(url)) {
+            createTable(delegate);
+            Connection connection = proxyConnection(delegate, false, true);
+            ConnectInfo connectInfo = putContext(connection);
+            try {
+                RuntimeException thrown = assertThrows(RuntimeException.class,
+                        () -> DefaultSQLExecutor.getInstance().fetchAllTableRecords(request(connection, rs -> {
+                            while (rs.next()) {
+                            }
+                        })));
+
+                assertTrue(thrown.getCause() instanceof SQLException);
+                assertEquals("restore autoCommit failed", thrown.getCause().getMessage());
+                assertTrue(connection.isClosed());
+                assertNull(connectInfo.getConnection());
+            } finally {
+                Chat2DBContext.removeContext();
+            }
+        }
+    }
+
+    private static FetchAllTableRecordsRequest request(
+            Connection connection, ai.chat2db.spi.IResultSetConsumer consumer) {
+        return FetchAllTableRecordsRequest.builder()
+                .connection(connection)
+                .sql("SELECT * FROM records")
+                .batchSize(10)
+                .consumer(consumer)
+                .build();
+    }
+
+    private static void createTable(Connection connection) throws java.sql.SQLException {
+        executeUpdate(connection, "CREATE TABLE records (id INT PRIMARY KEY)");
+    }
+
+    private static void executeUpdate(Connection connection, String sql) throws java.sql.SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate(sql);
+        }
+    }
+
+    private static int countRows(Connection connection) throws java.sql.SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM records")) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+
+    private static ConnectInfo putContext(Connection connection) {
+        ConnectInfo connectInfo = new ConnectInfo();
+        connectInfo.setConnection(connection);
+        connectInfo.setDriverConfig(new DriverConfig());
+        Chat2DBContext.putContext(connectInfo);
+        return connectInfo;
+    }
+
+    private static Connection proxyConnection(
+            Connection delegate, boolean failRollback, boolean failAutoCommitRestore) {
+        AtomicBoolean autoCommitDisabled = new AtomicBoolean();
+        return (Connection) Proxy.newProxyInstance(
+                DefaultSQLExecutorTransactionTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    if (failRollback && "rollback".equals(method.getName())) {
+                        throw new SQLException("rollback failed");
+                    }
+                    if (failAutoCommitRestore && "setAutoCommit".equals(method.getName())) {
+                        boolean autoCommit = (Boolean) args[0];
+                        if (autoCommit && autoCommitDisabled.get()) {
+                            throw new SQLException("restore autoCommit failed");
+                        }
+                        Object result = invoke(delegate, method, args);
+                        if (!autoCommit) {
+                            autoCommitDisabled.set(true);
+                        }
+                        return result;
+                    }
+                    return invoke(delegate, method, args);
+                });
+    }
+
+    private static Object invoke(Connection delegate, Method method, Object[] args) throws Throwable {
+        try {
+            return method.invoke(delegate, args);
+        } catch (InvocationTargetException ex) {
+            throw ex.getCause();
+        }
+    }
+}

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/sql/DefaultSQLExecutorTransactionTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/sql/DefaultSQLExecutorTransactionTest.java
@@ -15,6 +15,9 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -94,7 +97,10 @@ class DefaultSQLExecutorTransactionTest {
         try (Connection delegate = DriverManager.getConnection(url);
              Connection observer = DriverManager.getConnection(url)) {
             createTable(delegate);
-            Connection connection = proxyConnection(delegate, true, false);
+            List<String> lifecycleCalls = new ArrayList<>();
+            AtomicBoolean abortExecutorCompleted = new AtomicBoolean();
+            Connection connection = proxyConnection(delegate, true, false, false, false,
+                    lifecycleCalls, abortExecutorCompleted);
             ConnectInfo connectInfo = putContext(connection);
             IllegalStateException consumerFailure = new IllegalStateException("consumer failed");
             try {
@@ -107,6 +113,8 @@ class DefaultSQLExecutorTransactionTest {
                 assertSame(consumerFailure, thrown.getCause());
                 assertEquals(1, consumerFailure.getSuppressed().length);
                 assertEquals("rollback failed", consumerFailure.getSuppressed()[0].getMessage());
+                assertEquals(List.of("rollback", "abort"), lifecycleCalls);
+                assertTrue(abortExecutorCompleted.get());
                 assertTrue(connection.isClosed());
                 assertNull(connectInfo.getConnection());
                 assertEquals(0, countRows(observer));
@@ -121,7 +129,10 @@ class DefaultSQLExecutorTransactionTest {
         String url = "jdbc:h2:mem:fetch_records_restore_failure;DB_CLOSE_DELAY=-1";
         try (Connection delegate = DriverManager.getConnection(url)) {
             createTable(delegate);
-            Connection connection = proxyConnection(delegate, false, true);
+            List<String> lifecycleCalls = new ArrayList<>();
+            AtomicBoolean abortExecutorCompleted = new AtomicBoolean();
+            Connection connection = proxyConnection(delegate, false, true, false, false,
+                    lifecycleCalls, abortExecutorCompleted);
             ConnectInfo connectInfo = putContext(connection);
             try {
                 RuntimeException thrown = assertThrows(RuntimeException.class,
@@ -132,7 +143,71 @@ class DefaultSQLExecutorTransactionTest {
 
                 assertTrue(thrown.getCause() instanceof SQLException);
                 assertEquals("restore autoCommit failed", thrown.getCause().getMessage());
+                assertEquals(List.of("abort"), lifecycleCalls);
+                assertTrue(abortExecutorCompleted.get());
                 assertTrue(connection.isClosed());
+                assertNull(connectInfo.getConnection());
+            } finally {
+                Chat2DBContext.removeContext();
+            }
+        }
+    }
+
+    @Test
+    void shouldFallBackToCloseWhenAbortFails() throws Exception {
+        String url = "jdbc:h2:mem:fetch_records_abort_failure;DB_CLOSE_DELAY=-1";
+        try (Connection delegate = DriverManager.getConnection(url)) {
+            createTable(delegate);
+            List<String> lifecycleCalls = new ArrayList<>();
+            AtomicBoolean abortExecutorCompleted = new AtomicBoolean();
+            Connection connection = proxyConnection(delegate, true, false, true, false,
+                    lifecycleCalls, abortExecutorCompleted);
+            ConnectInfo connectInfo = putContext(connection);
+            IllegalStateException consumerFailure = new IllegalStateException("consumer failed");
+            try {
+                RuntimeException thrown = assertThrows(RuntimeException.class,
+                        () -> DefaultSQLExecutor.getInstance().fetchAllTableRecords(request(connection, rs -> {
+                            throw consumerFailure;
+                        })));
+
+                assertSame(consumerFailure, thrown.getCause());
+                assertEquals(List.of("rollback", "abort", "close"), lifecycleCalls);
+                assertEquals(2, consumerFailure.getSuppressed().length);
+                assertEquals("rollback failed", consumerFailure.getSuppressed()[0].getMessage());
+                assertEquals("abort failed", consumerFailure.getSuppressed()[1].getMessage());
+                assertTrue(abortExecutorCompleted.get());
+                assertTrue(connection.isClosed());
+                assertNull(connectInfo.getConnection());
+            } finally {
+                Chat2DBContext.removeContext();
+            }
+        }
+    }
+
+    @Test
+    void shouldPreserveAbortAndCloseFailuresWhenDiscardCannotComplete() throws Exception {
+        String url = "jdbc:h2:mem:fetch_records_abort_close_failure;DB_CLOSE_DELAY=-1";
+        try (Connection delegate = DriverManager.getConnection(url)) {
+            createTable(delegate);
+            List<String> lifecycleCalls = new ArrayList<>();
+            AtomicBoolean abortExecutorCompleted = new AtomicBoolean();
+            Connection connection = proxyConnection(delegate, true, false, true, true,
+                    lifecycleCalls, abortExecutorCompleted);
+            ConnectInfo connectInfo = putContext(connection);
+            IllegalStateException consumerFailure = new IllegalStateException("consumer failed");
+            try {
+                RuntimeException thrown = assertThrows(RuntimeException.class,
+                        () -> DefaultSQLExecutor.getInstance().fetchAllTableRecords(request(connection, rs -> {
+                            throw consumerFailure;
+                        })));
+
+                assertSame(consumerFailure, thrown.getCause());
+                assertEquals(List.of("rollback", "abort", "close"), lifecycleCalls);
+                assertEquals(3, consumerFailure.getSuppressed().length);
+                assertEquals("rollback failed", consumerFailure.getSuppressed()[0].getMessage());
+                assertEquals("abort failed", consumerFailure.getSuppressed()[1].getMessage());
+                assertEquals("close failed", consumerFailure.getSuppressed()[2].getMessage());
+                assertTrue(abortExecutorCompleted.get());
                 assertNull(connectInfo.getConnection());
             } finally {
                 Chat2DBContext.removeContext();
@@ -178,13 +253,41 @@ class DefaultSQLExecutorTransactionTest {
 
     private static Connection proxyConnection(
             Connection delegate, boolean failRollback, boolean failAutoCommitRestore) {
+        return proxyConnection(delegate, failRollback, failAutoCommitRestore, false, false,
+                new ArrayList<>(), new AtomicBoolean());
+    }
+
+    private static Connection proxyConnection(
+            Connection delegate, boolean failRollback, boolean failAutoCommitRestore,
+            boolean failAbort, boolean failClose, List<String> lifecycleCalls,
+            AtomicBoolean abortExecutorCompleted) {
         AtomicBoolean autoCommitDisabled = new AtomicBoolean();
         return (Connection) Proxy.newProxyInstance(
                 DefaultSQLExecutorTransactionTest.class.getClassLoader(),
                 new Class<?>[]{Connection.class},
                 (proxy, method, args) -> {
-                    if (failRollback && "rollback".equals(method.getName())) {
-                        throw new SQLException("rollback failed");
+                    if ("rollback".equals(method.getName())) {
+                        lifecycleCalls.add("rollback");
+                        if (failRollback) {
+                            throw new SQLException("rollback failed");
+                        }
+                    }
+                    if ("abort".equals(method.getName())) {
+                        lifecycleCalls.add("abort");
+                        AtomicBoolean taskCompleted = new AtomicBoolean();
+                        ((Executor) args[0]).execute(() -> taskCompleted.set(true));
+                        abortExecutorCompleted.set(taskCompleted.get());
+                        if (failAbort) {
+                            throw new SQLException("abort failed");
+                        }
+                        delegate.close();
+                        return null;
+                    }
+                    if ("close".equals(method.getName())) {
+                        lifecycleCalls.add("close");
+                        if (failClose) {
+                            throw new SQLException("close failed");
+                        }
                     }
                     if (failAutoCommitRestore && "setAutoCommit".equals(method.getName())) {
                         boolean autoCommit = (Boolean) args[0];

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/model/datasource/ConnectInfoTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/model/datasource/ConnectInfoTest.java
@@ -1,0 +1,28 @@
+package ai.chat2db.spi.model.datasource;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConnectInfoTest {
+
+    @Test
+    void equalInstancesShouldHaveEqualHashCodes() {
+        LocalDateTime modifiedAt = LocalDateTime.of(2026, 7, 25, 12, 0);
+        ConnectInfo first = new ConnectInfo();
+        first.setDataSourceId(42L);
+        first.setGmtModified(modifiedAt);
+        first.setConsoleId(1L);
+        first.setDatabaseName("first_database");
+        ConnectInfo second = new ConnectInfo();
+        second.setDataSourceId(42L);
+        second.setGmtModified(modifiedAt);
+        second.setConsoleId(2L);
+        second.setDatabaseName("second_database");
+
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+}

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/Chat2DBContextTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/Chat2DBContextTest.java
@@ -1,0 +1,25 @@
+package ai.chat2db.spi.sql;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Chat2DBContextTest {
+
+    @Test
+    void shouldDescribeUnsupportedDatabaseType() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> Chat2DBContext.getDBConfig("NOT_REGISTERED_FOR_TEST"));
+
+        assertTrue(exception.getMessage().contains("Unsupported database type: NOT_REGISTERED_FOR_TEST"));
+    }
+
+    @Test
+    void shouldRejectBlankDatabaseType() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> Chat2DBContext.getDBConfig(" "));
+
+        assertTrue(exception.getMessage().contains("Database type must not be blank"));
+    }
+}

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -82,6 +83,34 @@ class ConnectionPoolTest {
     }
 
     @Test
+    void failedBorrowShouldCloseConnectionWhenQueueRefillsBeforeReturn() {
+        AtomicBoolean pooledClosed = new AtomicBoolean();
+        ConnectInfo pooled = connectInfo(connection(true, pooledClosed));
+        ConnectInfo replacement = connectInfo(connection(true, new AtomicBoolean()));
+        assertTrue(pooled.trySetInUse());
+        LinkedBlockingQueue<ConnectInfo> queue = new LinkedBlockingQueue<>(1) {
+            private boolean refillAfterPoll = true;
+
+            @Override
+            public ConnectInfo poll() {
+                ConnectInfo result = super.poll();
+                if (refillAfterPoll) {
+                    refillAfterPoll = false;
+                    assertTrue(super.offer(replacement));
+                }
+                return result;
+            }
+        };
+        queue.offer(pooled);
+
+        assertNull(ConnectionPool.tryBorrowConnection(new ConnectInfo(), queue));
+
+        assertSame(replacement, queue.peek());
+        assertTrue(pooledClosed.get());
+        assertNull(pooled.getConnection());
+    }
+
+    @Test
     void staleConnectionShouldBeValidatedBeforeBorrow() {
         AtomicBoolean closed = new AtomicBoolean();
         AtomicInteger validationCalls = new AtomicInteger();
@@ -140,6 +169,34 @@ class ConnectionPoolTest {
         }
     }
 
+    @Test
+    void cleanupShouldCloseConnectionWhenDatasourceIsRemovedDuringValidation() throws Exception {
+        long datasourceId = -1924L;
+        AtomicBoolean closed = new AtomicBoolean();
+        CountDownLatch validationStarted = new CountDownLatch(1);
+        CountDownLatch finishValidation = new CountDownLatch(1);
+        ConnectInfo connectInfo = connectInfo(blockingValidationConnection(
+                closed, validationStarted, finishValidation));
+        connectInfo.setDataSourceId(datasourceId);
+        ConnectionPool.close(connectInfo);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> cleanup = executor.submit(ConnectionPool::cleanupConnections);
+        try {
+            assertTrue(validationStarted.await(5, TimeUnit.SECONDS));
+            ConnectionPool.removeConnection(datasourceId);
+            finishValidation.countDown();
+            cleanup.get(5, TimeUnit.SECONDS);
+
+            assertTrue(closed.get());
+            assertNull(connectInfo.getConnection());
+        } finally {
+            finishValidation.countDown();
+            ConnectionPool.removeConnection(datasourceId);
+            executor.shutdownNow();
+        }
+    }
+
     private static ConnectInfo connectInfo(Connection connection) {
         ConnectInfo connectInfo = new ConnectInfo();
         connectInfo.setConnection(connection);
@@ -167,6 +224,33 @@ class ConnectionPoolTest {
                             return null;
                         case "toString":
                             return "TestConnection";
+                        default:
+                            return defaultValue(method.getReturnType());
+                    }
+                });
+    }
+
+    private static Connection blockingValidationConnection(AtomicBoolean closed,
+                                                           CountDownLatch validationStarted,
+                                                           CountDownLatch finishValidation) {
+        return (Connection) Proxy.newProxyInstance(
+                ConnectionPoolTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "isClosed":
+                            return closed.get();
+                        case "isValid":
+                            validationStarted.countDown();
+                            if (!finishValidation.await(5, TimeUnit.SECONDS)) {
+                                throw new SQLException("Timed out waiting to finish validation");
+                            }
+                            return true;
+                        case "close":
+                            closed.set(true);
+                            return null;
+                        case "toString":
+                            return "BlockingValidationConnection";
                         default:
                             return defaultValue(method.getReturnType());
                     }

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -83,7 +85,7 @@ class ConnectionPoolTest {
     }
 
     @Test
-    void failedBorrowShouldCloseConnectionWhenQueueRefillsBeforeReturn() {
+    void failedBorrowShouldNotCloseConnectionOwnedByAnotherThreadWhenQueueRefills() {
         AtomicBoolean pooledClosed = new AtomicBoolean();
         ConnectInfo pooled = connectInfo(connection(true, pooledClosed));
         ConnectInfo replacement = connectInfo(connection(true, new AtomicBoolean()));
@@ -106,8 +108,9 @@ class ConnectionPoolTest {
         assertNull(ConnectionPool.tryBorrowConnection(new ConnectInfo(), queue));
 
         assertSame(replacement, queue.peek());
-        assertTrue(pooledClosed.get());
-        assertNull(pooled.getConnection());
+        assertFalse(pooledClosed.get());
+        assertNotNull(pooled.getConnection());
+        pooled.releaseInUse();
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
@@ -181,7 +181,10 @@ class ConnectionPoolTest {
         ConnectInfo connectInfo = connectInfo(blockingValidationConnection(
                 closed, validationStarted, finishValidation));
         connectInfo.setDataSourceId(datasourceId);
-        ConnectionPool.close(connectInfo);
+        connectInfo.updatePoolGeneration(ConnectionPool.currentGeneration(datasourceId));
+        LinkedBlockingQueue<ConnectInfo> queue =
+                ConnectionPool.getOrCreateConnectionQueue(datasourceId, connectInfo.getKey());
+        assertTrue(queue.offer(connectInfo));
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Future<?> cleanup = executor.submit(ConnectionPool::cleanupConnections);
@@ -198,6 +201,39 @@ class ConnectionPoolTest {
             ConnectionPool.removeConnection(datasourceId);
             executor.shutdownNow();
         }
+    }
+
+    @Test
+    void returnedLeaseShouldCloseWhenDatasourceWasRemovedAndPoolWasRecreated() {
+        long datasourceId = -1925L;
+        AtomicBoolean oldClosed = new AtomicBoolean();
+        ConnectInfo pooled = connectInfo(connection(true, oldClosed));
+        pooled.setDataSourceId(datasourceId);
+        pooled.updatePoolGeneration(ConnectionPool.currentGeneration(datasourceId));
+        LinkedBlockingQueue<ConnectInfo> oldQueue =
+                ConnectionPool.getOrCreateConnectionQueue(datasourceId, pooled.getKey());
+        assertTrue(oldQueue.offer(pooled));
+
+        ConnectInfo oldLease = new ConnectInfo();
+        oldLease.setDataSourceId(datasourceId);
+        assertNotNull(ConnectionPool.getConnection(oldLease));
+
+        ConnectionPool.removeConnection(datasourceId);
+
+        AtomicBoolean replacementClosed = new AtomicBoolean();
+        ConnectInfo replacement = connectInfo(connection(true, replacementClosed));
+        replacement.setDataSourceId(datasourceId);
+        LinkedBlockingQueue<ConnectInfo> replacementQueue =
+                ConnectionPool.getOrCreateConnectionQueue(datasourceId, replacement.getKey());
+        assertTrue(replacementQueue.offer(replacement));
+        ConnectionPool.close(oldLease);
+
+        assertTrue(oldClosed.get());
+        assertNull(oldLease.getConnection());
+        assertFalse(replacementClosed.get());
+        assertSame(replacement, replacementQueue.peek());
+        ConnectionPool.removeConnection(datasourceId);
+        assertTrue(replacementClosed.get());
     }
 
     private static ConnectInfo connectInfo(Connection connection) {

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
@@ -1,0 +1,166 @@
+package ai.chat2db.spi.sql;
+
+import ai.chat2db.spi.model.datasource.ConnectInfo;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConnectionPoolTest {
+
+    @Test
+    void cleanupShouldCloseAndRemoveInvalidIdleConnection() {
+        AtomicBoolean closed = new AtomicBoolean();
+        ConnectInfo connectInfo = connectInfo(connection(false, closed));
+        LinkedBlockingQueue<ConnectInfo> queue = new LinkedBlockingQueue<>();
+        queue.offer(connectInfo);
+
+        ConnectionPool.cleanupQueue(queue);
+
+        assertTrue(queue.isEmpty());
+        assertTrue(closed.get());
+        assertNull(connectInfo.getConnection());
+    }
+
+    @Test
+    void cleanupShouldCloseExpiredConnectionEvenWhenItIsValid() {
+        AtomicBoolean closed = new AtomicBoolean();
+        ConnectInfo connectInfo = connectInfo(connection(true, closed));
+        connectInfo.setLastAccessTime(new Date(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(31)));
+        LinkedBlockingQueue<ConnectInfo> queue = ConnectionPool.newConnectionQueue();
+        queue.offer(connectInfo);
+
+        ConnectionPool.cleanupQueue(queue);
+
+        assertTrue(queue.isEmpty());
+        assertTrue(closed.get());
+        assertNull(connectInfo.getConnection());
+    }
+
+    @Test
+    void cleanupShouldLeaveBorrowedConnectionInQueue() {
+        ConnectInfo connectInfo = connectInfo(connection(true, new AtomicBoolean()));
+        assertTrue(connectInfo.trySetInUse());
+        LinkedBlockingQueue<ConnectInfo> queue = new LinkedBlockingQueue<>();
+        queue.offer(connectInfo);
+
+        ConnectionPool.cleanupQueue(queue);
+
+        assertSame(connectInfo, queue.peek());
+        connectInfo.releaseInUse();
+    }
+
+    @Test
+    void failedBorrowShouldReturnConnectionInfoToQueue() {
+        ConnectInfo pooled = connectInfo(connection(true, new AtomicBoolean()));
+        assertTrue(pooled.trySetInUse());
+        LinkedBlockingQueue<ConnectInfo> queue = new LinkedBlockingQueue<>();
+        queue.offer(pooled);
+
+        assertNull(ConnectionPool.tryBorrowConnection(new ConnectInfo(), queue));
+        assertSame(pooled, queue.peek());
+        pooled.releaseInUse();
+    }
+
+    @Test
+    void concurrentReturnsShouldKeepQueueBoundedAndCloseOverflowConnections() throws Exception {
+        int connectionCount = 32;
+        LinkedBlockingQueue<ConnectInfo> queue = ConnectionPool.newConnectionQueue();
+        List<ConnectInfo> connectInfos = new ArrayList<>(connectionCount);
+        List<AtomicBoolean> closedConnections = new ArrayList<>(connectionCount);
+        for (int i = 0; i < connectionCount; i++) {
+            AtomicBoolean closed = new AtomicBoolean();
+            closedConnections.add(closed);
+            connectInfos.add(connectInfo(connection(true, closed)));
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(connectionCount);
+        CountDownLatch ready = new CountDownLatch(connectionCount);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<?>> futures = new ArrayList<>(connectionCount);
+            for (ConnectInfo connectInfo : connectInfos) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    assertTrue(start.await(5, TimeUnit.SECONDS));
+                    ConnectionPool.offerOrClose(queue, connectInfo);
+                    return null;
+                }));
+            }
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            start.countDown();
+            for (Future<?> future : futures) {
+                future.get(5, TimeUnit.SECONDS);
+            }
+
+            assertEquals(2, queue.size());
+            Set<ConnectInfo> retained = Collections.newSetFromMap(new IdentityHashMap<>());
+            retained.addAll(queue);
+            for (int i = 0; i < connectionCount; i++) {
+                assertEquals(!retained.contains(connectInfos.get(i)), closedConnections.get(i).get());
+            }
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private static ConnectInfo connectInfo(Connection connection) {
+        ConnectInfo connectInfo = new ConnectInfo();
+        connectInfo.setConnection(connection);
+        connectInfo.setLastAccessTime(new Date());
+        return connectInfo;
+    }
+
+    private static Connection connection(boolean valid, AtomicBoolean closed) {
+        return (Connection) Proxy.newProxyInstance(
+                ConnectionPoolTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "isClosed":
+                            return closed.get();
+                        case "isValid":
+                            return valid;
+                        case "close":
+                            closed.set(true);
+                            return null;
+                        case "toString":
+                            return "TestConnection";
+                        default:
+                            return defaultValue(method.getReturnType());
+                    }
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+}

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/sql/ConnectionPoolTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -81,6 +82,22 @@ class ConnectionPoolTest {
     }
 
     @Test
+    void staleConnectionShouldBeValidatedBeforeBorrow() {
+        AtomicBoolean closed = new AtomicBoolean();
+        AtomicInteger validationCalls = new AtomicInteger();
+        ConnectInfo pooled = connectInfo(connection(false, closed, validationCalls));
+        pooled.setLastAccessTime(new Date(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(1)));
+        LinkedBlockingQueue<ConnectInfo> queue = ConnectionPool.newConnectionQueue();
+        queue.offer(pooled);
+
+        assertNull(ConnectionPool.tryBorrowConnection(new ConnectInfo(), queue));
+
+        assertEquals(1, validationCalls.get());
+        assertTrue(closed.get());
+        assertNull(pooled.getConnection());
+    }
+
+    @Test
     void concurrentReturnsShouldKeepQueueBoundedAndCloseOverflowConnections() throws Exception {
         int connectionCount = 32;
         LinkedBlockingQueue<ConnectInfo> queue = ConnectionPool.newConnectionQueue();
@@ -131,6 +148,10 @@ class ConnectionPoolTest {
     }
 
     private static Connection connection(boolean valid, AtomicBoolean closed) {
+        return connection(valid, closed, new AtomicInteger());
+    }
+
+    private static Connection connection(boolean valid, AtomicBoolean closed, AtomicInteger validationCalls) {
         return (Connection) Proxy.newProxyInstance(
                 ConnectionPoolTest.class.getClassLoader(),
                 new Class<?>[]{Connection.class},
@@ -139,6 +160,7 @@ class ConnectionPoolTest {
                         case "isClosed":
                             return closed.get();
                         case "isValid":
+                            validationCalls.incrementAndGet();
                             return valid;
                         case "close":
                             closed.set(true);


### PR DESCRIPTION
## Related issue

N/A - this is a contributor maintenance PR without a separately tracked issue.

## Summary

Hardens Community SPI SQL execution and pooled-connection lifecycle behavior, while retaining several focused correctness fixes from the original contribution.

The final change:

- preserves caller transaction ownership in `fetchAllTableRecords`, rolls back failures, restores the original `autoCommit` state, and forcibly aborts a connection when rollback cannot be completed safely;
- closes the `ResultSet` used by `count()`;
- prevents dead, duplicate, full-queue, removed-pool, and stale-generation connections from being leaked or returned to the wrong pool;
- invalidates outstanding connection leases when a datasource pool is removed;
- aligns `ConnectInfo.hashCode()` with `equals()` while keeping pool-generation state runtime-only;
- reports an explicit error for an unregistered `dbType` and logs failures from `setCatalog()` / `setSchema()`;
- returns the MySQL column extent value correctly and checks the SQL Server schema name when building qualified table names.

Maintainer follow-up commits add transaction-ownership, rollback/abort, bounded-queue, cleanup-race, stale-lease, and generation-invalidation coverage.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `rtk mvn -pl chat2db-community-plugins/chat2db-community-mysql,chat2db-community-plugins/chat2db-community-sqlserver -am test -Dmaven.test.skip=false` from `chat2db-community-server`: `BUILD SUCCESS`; Tools 26, SPI 73, MySQL 607, SQL Server 38; 744 tests total, 0 failures, 0 errors, 0 skipped.
  - `rtk git diff --check origin/main...HEAD`: passed.
- Manual verification: N/A - lifecycle and SQL-builder behavior is covered by automated unit and concurrency tests.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or stored-data format changes.
- Database or driver compatibility: Corrects MySQL extent and SQL Server qualified-name generation; transaction cleanup now follows the connection's original ownership state.
- Network, privacy, or security: No network or privacy contract changes. Failed rollback paths now abort the physical connection before fallback close so an indeterminate transaction is never reused.
- Community / Local / Pro boundary: Community server SPI and Community MySQL / SQL Server plugins only.
- Backward compatibility: Existing method signatures are unchanged. Stale or orphaned pooled connections are now closed instead of being reused or leaked.

## Reviewer map

- Start here: `ConnectionPool`, then `DefaultSQLExecutor.fetchAllTableRecords`; focused tests are `ConnectionPoolTest` and `DefaultSQLExecutorTransactionTest`.
- Failure condition: a removed datasource generation can accept an old lease, a full queue can leak a connection, or rollback/restore failure can return an unsafe connection to the pool.
- Rollback or disable path: revert this PR; no data migration or feature flag is involved.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A - no separate issue was filed for this maintenance batch.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex materially assisted the maintainer review, follow-up fixes, and test additions.
