### PR TITLE
fix(plugins): view quoting, SQL injection, pagination, and misc SQL fixes

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/OracleMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/OracleMetaData.java
@@ -137,7 +137,7 @@ public class OracleMetaData extends DefaultMetaService implements IDbMetaData {
     public List<Table> tables(Connection connection, String databaseName, String schemaName, String tableName) {
         String sql = String.format(SELECT_TABLE_SQL, schemaName);
         if (StringUtils.isNotBlank(tableName)) {
-            sql = sql + " and A.TABLE_NAME = '" + tableName + "'";
+            sql = sql + " and A.TABLE_NAME = '" + tableName.replace("'", "''") + "'";
         }
         return DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> {
             List<Table> tables = new ArrayList<>();

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilder.java
@@ -213,23 +213,15 @@ public class OracleSqlBuilder extends DefaultSqlBuilder {
         int startRow = offset;
         int endRow = offset + pageSize;
         StringBuilder sqlBuilder = new StringBuilder(sql.length() + 120);
-        if (startRow > 0) {
-            sqlBuilder.append(SQL_SELECT);
-        }
-        if (endRow > 0) {
-            sqlBuilder.append(SQL_SELECT_TMP_PAGE_ROWNUM_CAHT2DB);
-        }
+        sqlBuilder.append(SQL_SELECT);
+        sqlBuilder.append(SQL_SELECT_TMP_PAGE_ROWNUM_CAHT2DB);
         sqlBuilder.append(SQLConstants.LINE_SEPARATOR);
         sqlBuilder.append(sql);
         sqlBuilder.append(SQLConstants.LINE_SEPARATOR);
-        if (endRow > 0) {
-            sqlBuilder.append(SQL_CLOSE_PAREN_TMP_PAGE_WHERE_ROWNUM_EQUAL);
-            sqlBuilder.append(endRow);
-        }
-        if (startRow > 0) {
-            sqlBuilder.append(SQL_CLOSE_PAREN_WHERE_CAHT2DB_AUTO_ROW_ID);
-            sqlBuilder.append(startRow);
-        }
+        sqlBuilder.append(SQL_CLOSE_PAREN_TMP_PAGE_WHERE_ROWNUM_EQUAL);
+        sqlBuilder.append(endRow);
+        sqlBuilder.append(SQL_CLOSE_PAREN_WHERE_CAHT2DB_AUTO_ROW_ID);
+        sqlBuilder.append(startRow);
         return sqlBuilder.toString();
     }
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilder.java
@@ -322,6 +322,7 @@ public class OracleSqlBuilder extends DefaultSqlBuilder {
             createViewSqlBuilder.append(SQLConstants.LINE_SEPARATOR);
             createViewSqlBuilder.append(SQL_COMMENT_TABLE)
                     .append(SQLConstants.DOUBLE_QUOTE).append(schemaName).append(SQLConstants.DOUBLE_QUOTE)
+                    .append(SQLConstants.DOT)
                     .append(SQLConstants.DOUBLE_QUOTE).append(viewName).append(SQLConstants.DOUBLE_QUOTE)
                     .append(SQLConstants.SQL_IS_LOWER)
                     .append(comment).append(SQLConstants.SEMICOLON);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/builder/PostgreSQLSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/builder/PostgreSQLSqlBuilder.java
@@ -441,7 +441,7 @@ public class PostgreSQLSqlBuilder extends DefaultSqlBuilder {
         }
         String viewName = modifyView.getViewName();
         if (StringUtils.isNotBlank(viewName)) {
-            createViewSqlBuilder.append(SQLConstants.BACK_QUOTE).append(viewName).append(SQLConstants.BACK_QUOTE);
+            createViewSqlBuilder.append(SQLConstants.DOUBLE_QUOTE).append(viewName).append(SQLConstants.DOUBLE_QUOTE);
         } else {
             createViewSqlBuilder.append(UNDEFINED_KEYWORD);
         }
@@ -460,6 +460,7 @@ public class PostgreSQLSqlBuilder extends DefaultSqlBuilder {
             createViewSqlBuilder.append(SQLConstants.LINE_SEPARATOR);
             createViewSqlBuilder.append(SQL_COMMENT_VIEW)
                     .append(SQLConstants.DOUBLE_QUOTE).append(schemaName).append(SQLConstants.DOUBLE_QUOTE)
+                    .append(SQLConstants.DOT)
                     .append(SQLConstants.DOUBLE_QUOTE).append(viewName).append(SQLConstants.DOUBLE_QUOTE)
                     .append(SQLConstants.SQL_IS_LOWER)
                     .append(comment).append(SQLConstants.SEMICOLON);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
@@ -343,7 +343,7 @@ public class SqlServerSqlBuilder extends DefaultSqlBuilder {
         }
         String viewName = modifyView.getViewName();
         if (StringUtils.isNotBlank(viewName)) {
-            createViewSqlBuilder.append(SQLConstants.BACK_QUOTE).append(viewName).append(SQLConstants.BACK_QUOTE);
+            createViewSqlBuilder.append(SQLConstants.OPEN_SQUARE_BRACKET).append(viewName).append(SQLConstants.CLOSE_SQUARE_BRACKET);
         } else {
             createViewSqlBuilder.append(UNDEFINED_KEYWORD);
         }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerColumnTypeEnumConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerColumnTypeEnumConstants.java
@@ -21,7 +21,7 @@ public final class SqlServerColumnTypeEnumConstants {
     public static final String SQL_DROP_COLUMN = "DROP COLUMN ";
     public static final String SQL_DROP_CONSTRAINT = "DROP CONSTRAINT ";
 
-    public static final String RENAME_COLUMN_SCRIPT = "exec sp_rename '%s.%s','%s','COLUMN' \ngo";
+    public static final String RENAME_COLUMN_SCRIPT = "exec sp_rename '[%s].[%s]','[%s]','COLUMN' \ngo\n";
     public static final String COLUMN_MODIFY_COMMENT_SCRIPT = "IF ((SELECT COUNT(*) FROM ::fn_listextendedproperty('MS_Description',\n" +
             "'SCHEMA', N'%s',\n" +
             "'TABLE', N'%s',\n" +
@@ -36,7 +36,7 @@ public final class SqlServerColumnTypeEnumConstants {
             "'MS_Description', N'%s',\n" +
             "'SCHEMA', N'%s',\n" +
             "'TABLE', N'%s',\n" +
-            "'COLUMN', N'%s'\n go";
+            "'COLUMN', N'%s'\n go\n";
 
 
     private SqlServerColumnTypeEnumConstants() {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
@@ -291,7 +291,7 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
             return script.toString();
         }
 
-        if (Arrays.asList().contains(type)) {
+        if (Arrays.asList("TIMESTAMP").contains(type)) {
             StringBuilder script = new StringBuilder();
             if (column.getColumnSize() == null) {
                 script.append(columnType);


### PR DESCRIPTION
## Summary

Fixes 6 verified bugs across PostgreSQL, SQL Server, and Oracle database plugins.

### Fixes included:
- **PostgreSQL view quoting**: backticks → double quotes (PG syntax)
- **PostgreSQL view comment**: added DOT separator between schema and view name
- **SQL Server view quoting**: backticks → square brackets (SQL Server syntax)
- **Oracle view comment**: added DOT separator between schema and view name
- **Oracle SQL injection**: escapes single quotes in table name via `replace("'", "''")`
- **Oracle pagination**: always applies outer SELECT wrapper to prevent CAHT2DB_AUTO_ROW_ID column leak on first page
- **SQL Server misc**: fixes TIMESTAMP dead code (`Arrays.asList()` → `Arrays.asList("TIMESTAMP")`), GO separator trailing newline, rename script bracket quoting