### PR TITLE
feat(frontend): add SQL output ordering and explicit follow mode

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -29,6 +29,7 @@
     "test:i18n": "node ./scripts/validate-i18n.cjs",
     "test:base-table-interaction": "tsx src/components/BaseTable/treeInteraction.test.ts",
     "test:database-object-sorting": "tsx src/blocks/NewTree/utils/sortTreeNodes.test.ts",
+    "test:execution-console": "tsx src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.test.ts",
     "test:redis-explorer": "tsx src/blocks/RedisAllData/redisExplorer.test.ts",
     "test:search-result-query-composer": "tsx src/blocks/SearchResult/components/ScreeningResult/queryComposer.test.ts",
     "test:search-result-tab-selection": "tsx src/blocks/SearchResult/tabSelection.test.ts",

--- a/chat2db-community-client/scripts/i18n-source-hashes.json
+++ b/chat2db-community-client/scripts/i18n-source-hashes.json
@@ -5,7 +5,7 @@
     "es-ES": {
       "ai.ts": "391a6e14c58d8401bf3bc245eca5bdd4b66efd8225a877bfbbcae01a1c1c019a",
       "chat.ts": "0cbe009eacbaa95a9a29bbc69588cb547e90b563667c53edec3e54ee64f5667b",
-      "common.ts": "a7609e98f3debb2d0215d0ad6ce8c569829228f57ee887f010ced6fe7ca9deac",
+      "common.ts": "763183d95e5e842282e6821818507e02621200c42dc61b562443c6f08b6608c8",
       "connection.ts": "41d07fd10c9550ae51995620cc998de5e99add35edb31c2bb592864c76c13688",
       "dashboard.ts": "b217bbe260c7674d4efad1dd1b61136653858884f5b9b2134cfdf7d1de5a44ee",
       "editTable.ts": "0f7a808f50053cd52b183d156bb4fd46bb125b8058f8774deb61c7f02894a350",
@@ -32,7 +32,7 @@
     "ko-KR": {
       "ai.ts": "391a6e14c58d8401bf3bc245eca5bdd4b66efd8225a877bfbbcae01a1c1c019a",
       "chat.ts": "0cbe009eacbaa95a9a29bbc69588cb547e90b563667c53edec3e54ee64f5667b",
-      "common.ts": "a7609e98f3debb2d0215d0ad6ce8c569829228f57ee887f010ced6fe7ca9deac",
+      "common.ts": "763183d95e5e842282e6821818507e02621200c42dc61b562443c6f08b6608c8",
       "connection.ts": "41d07fd10c9550ae51995620cc998de5e99add35edb31c2bb592864c76c13688",
       "dashboard.ts": "b217bbe260c7674d4efad1dd1b61136653858884f5b9b2134cfdf7d1de5a44ee",
       "editTable.ts": "0f7a808f50053cd52b183d156bb4fd46bb125b8058f8774deb61c7f02894a350",

--- a/chat2db-community-client/scripts/i18n-source-hashes.json
+++ b/chat2db-community-client/scripts/i18n-source-hashes.json
@@ -5,7 +5,7 @@
     "es-ES": {
       "ai.ts": "391a6e14c58d8401bf3bc245eca5bdd4b66efd8225a877bfbbcae01a1c1c019a",
       "chat.ts": "0cbe009eacbaa95a9a29bbc69588cb547e90b563667c53edec3e54ee64f5667b",
-      "common.ts": "763183d95e5e842282e6821818507e02621200c42dc61b562443c6f08b6608c8",
+      "common.ts": "91dad744d8a1a7b829c61e0dc47e6912953f106f2c96bab1ad0d9858278badcd",
       "connection.ts": "41d07fd10c9550ae51995620cc998de5e99add35edb31c2bb592864c76c13688",
       "dashboard.ts": "b217bbe260c7674d4efad1dd1b61136653858884f5b9b2134cfdf7d1de5a44ee",
       "editTable.ts": "0f7a808f50053cd52b183d156bb4fd46bb125b8058f8774deb61c7f02894a350",
@@ -32,7 +32,7 @@
     "ko-KR": {
       "ai.ts": "391a6e14c58d8401bf3bc245eca5bdd4b66efd8225a877bfbbcae01a1c1c019a",
       "chat.ts": "0cbe009eacbaa95a9a29bbc69588cb547e90b563667c53edec3e54ee64f5667b",
-      "common.ts": "763183d95e5e842282e6821818507e02621200c42dc61b562443c6f08b6608c8",
+      "common.ts": "91dad744d8a1a7b829c61e0dc47e6912953f106f2c96bab1ad0d9858278badcd",
       "connection.ts": "41d07fd10c9550ae51995620cc998de5e99add35edb31c2bb592864c76c13688",
       "dashboard.ts": "b217bbe260c7674d4efad1dd1b61136653858884f5b9b2134cfdf7d1de5a44ee",
       "editTable.ts": "0f7a808f50053cd52b183d156bb4fd46bb125b8058f8774deb61c7f02894a350",

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.test.ts
@@ -3,7 +3,6 @@ import type { SqlExecutionLogRecord } from '@/service/sqlExecutionLog';
 import {
   createExecutionConsoleOrderStorageKey,
   getLatestExecutionEdgeScrollTop,
-  isAtLatestExecutionEdge,
   orderExecutionLogRecords,
   persistExecutionConsoleOrder,
   readExecutionConsoleOrder,
@@ -94,10 +93,6 @@ assert.deepEqual(
   'ordering does not mutate reducer state',
 );
 
-assert.equal(isAtLatestExecutionEdge({ scrollTop: 0, scrollHeight: 500, clientHeight: 100 }, 'newest-first'), true);
-assert.equal(isAtLatestExecutionEdge({ scrollTop: 30, scrollHeight: 500, clientHeight: 100 }, 'newest-first'), false);
-assert.equal(isAtLatestExecutionEdge({ scrollTop: 380, scrollHeight: 500, clientHeight: 100 }, 'oldest-first'), true);
-assert.equal(isAtLatestExecutionEdge({ scrollTop: 350, scrollHeight: 500, clientHeight: 100 }, 'oldest-first'), false);
 assert.equal(getLatestExecutionEdgeScrollTop(500, 'newest-first'), 0);
 assert.equal(getLatestExecutionEdgeScrollTop(500, 'oldest-first'), 500);
 

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import type { SqlExecutionLogRecord } from '@/service/sqlExecutionLog';
+import {
+  createExecutionConsoleOrderStorageKey,
+  getLatestExecutionEdgeScrollTop,
+  isAtLatestExecutionEdge,
+  orderExecutionLogRecords,
+  persistExecutionConsoleOrder,
+  readExecutionConsoleOrder,
+} from './executionConsolePreferences';
+
+function record(id: string, executionId: string, statementSequence: number): SqlExecutionLogRecord {
+  return {
+    id,
+    executionId,
+    statementSequence,
+    startedAtEpochMs: statementSequence,
+    status: 'success',
+    sql: `select ${statementSequence}`,
+    context: {},
+    outputs: [],
+    pendingRowCounts: {},
+  };
+}
+
+const storageKey = createExecutionConsoleOrderStorageKey('community', 'community');
+const values = new Map<string, string>();
+const storage = {
+  getItem: (key: string) => values.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    values.set(key, value);
+  },
+};
+
+assert.equal(storageKey, 'chat2db.community.community.execution-console.order.v1');
+assert.notEqual(
+  storageKey,
+  createExecutionConsoleOrderStorageKey('community', 'desktop'),
+  'runtime modes keep independent preferences',
+);
+assert.equal(readExecutionConsoleOrder(undefined, storageKey), 'oldest-first');
+assert.equal(readExecutionConsoleOrder(storage, storageKey), 'oldest-first');
+
+values.set(storageKey, 'invalid');
+assert.equal(readExecutionConsoleOrder(storage, storageKey), 'oldest-first');
+values.set(storageKey, 'newest-first');
+assert.equal(readExecutionConsoleOrder(storage, storageKey), 'newest-first');
+persistExecutionConsoleOrder(storage, storageKey, 'oldest-first');
+assert.equal(values.get(storageKey), 'oldest-first');
+
+const unavailableStorage = {
+  getItem: () => {
+    throw new Error('unavailable');
+  },
+  setItem: () => {
+    throw new Error('unavailable');
+  },
+};
+assert.equal(readExecutionConsoleOrder(unavailableStorage, storageKey), 'oldest-first');
+assert.doesNotThrow(() => persistExecutionConsoleOrder(unavailableStorage, storageKey, 'newest-first'));
+
+const records = [
+  record('execution-1-statement-1', 'execution-1', 1),
+  record('execution-1-statement-2', 'execution-1', 2),
+  record('execution-2-statement-1', 'execution-2', 1),
+  record('execution-3-statement-1', 'execution-3', 1),
+  record('execution-3-statement-2', 'execution-3', 2),
+];
+
+assert.deepEqual(
+  orderExecutionLogRecords(records, 'oldest-first').map((item) => item.id),
+  records.map((item) => item.id),
+);
+assert.deepEqual(
+  orderExecutionLogRecords(records, 'newest-first').map((item) => item.id),
+  [
+    'execution-3-statement-1',
+    'execution-3-statement-2',
+    'execution-2-statement-1',
+    'execution-1-statement-1',
+    'execution-1-statement-2',
+  ],
+  'newest-first reverses execution groups without reversing statements inside a group',
+);
+assert.deepEqual(
+  records.map((item) => item.id),
+  [
+    'execution-1-statement-1',
+    'execution-1-statement-2',
+    'execution-2-statement-1',
+    'execution-3-statement-1',
+    'execution-3-statement-2',
+  ],
+  'ordering does not mutate reducer state',
+);
+
+assert.equal(isAtLatestExecutionEdge({ scrollTop: 0, scrollHeight: 500, clientHeight: 100 }, 'newest-first'), true);
+assert.equal(isAtLatestExecutionEdge({ scrollTop: 30, scrollHeight: 500, clientHeight: 100 }, 'newest-first'), false);
+assert.equal(isAtLatestExecutionEdge({ scrollTop: 380, scrollHeight: 500, clientHeight: 100 }, 'oldest-first'), true);
+assert.equal(isAtLatestExecutionEdge({ scrollTop: 350, scrollHeight: 500, clientHeight: 100 }, 'oldest-first'), false);
+assert.equal(getLatestExecutionEdgeScrollTop(500, 'newest-first'), 0);
+assert.equal(getLatestExecutionEdgeScrollTop(500, 'oldest-first'), 500);
+
+console.log('Execution console preference tests passed');

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.ts
@@ -1,0 +1,88 @@
+import type { SqlExecutionLogRecord } from '@/service/sqlExecutionLog';
+
+export type ExecutionConsoleOrder = 'oldest-first' | 'newest-first';
+
+interface ExecutionConsolePreferenceStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+interface ScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+export const DEFAULT_EXECUTION_CONSOLE_ORDER: ExecutionConsoleOrder = 'oldest-first';
+
+export function createExecutionConsoleOrderStorageKey(clientEdition: string, runtimeEnv: string) {
+  return `chat2db.${clientEdition}.${runtimeEnv}.execution-console.order.v1`;
+}
+
+export function getExecutionConsolePreferenceStorage(): ExecutionConsolePreferenceStorage | undefined {
+  try {
+    return typeof window === 'undefined' ? undefined : window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readExecutionConsoleOrder(
+  storage: ExecutionConsolePreferenceStorage | undefined,
+  storageKey: string,
+): ExecutionConsoleOrder {
+  try {
+    const storedValue = storage?.getItem(storageKey);
+    return storedValue === 'oldest-first' || storedValue === 'newest-first'
+      ? storedValue
+      : DEFAULT_EXECUTION_CONSOLE_ORDER;
+  } catch {
+    return DEFAULT_EXECUTION_CONSOLE_ORDER;
+  }
+}
+
+export function persistExecutionConsoleOrder(
+  storage: ExecutionConsolePreferenceStorage | undefined,
+  storageKey: string,
+  order: ExecutionConsoleOrder,
+) {
+  try {
+    storage?.setItem(storageKey, order);
+  } catch {
+    // Storage can be unavailable in restricted browser contexts.
+  }
+}
+
+export function orderExecutionLogRecords(
+  records: readonly SqlExecutionLogRecord[],
+  order: ExecutionConsoleOrder,
+): SqlExecutionLogRecord[] {
+  if (order === 'oldest-first') {
+    return [...records];
+  }
+
+  const executionGroups = new Map<string, SqlExecutionLogRecord[]>();
+  records.forEach((record) => {
+    const group = executionGroups.get(record.executionId);
+    if (group) {
+      group.push(record);
+    } else {
+      executionGroups.set(record.executionId, [record]);
+    }
+  });
+
+  return Array.from(executionGroups.values())
+    .reverse()
+    .flat();
+}
+
+export function isAtLatestExecutionEdge(metrics: ScrollMetrics, order: ExecutionConsoleOrder, threshold = 24) {
+  if (order === 'newest-first') {
+    return metrics.scrollTop <= threshold;
+  }
+  return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight <= threshold;
+}
+
+export function getLatestExecutionEdgeScrollTop(scrollHeight: number, order: ExecutionConsoleOrder) {
+  return order === 'newest-first' ? 0 : scrollHeight;
+}

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.ts
@@ -7,12 +7,6 @@ interface ExecutionConsolePreferenceStorage {
   setItem(key: string, value: string): void;
 }
 
-interface ScrollMetrics {
-  scrollTop: number;
-  scrollHeight: number;
-  clientHeight: number;
-}
-
 export const DEFAULT_EXECUTION_CONSOLE_ORDER: ExecutionConsoleOrder = 'oldest-first';
 
 export function createExecutionConsoleOrderStorageKey(clientEdition: string, runtimeEnv: string) {
@@ -74,13 +68,6 @@ export function orderExecutionLogRecords(
   return Array.from(executionGroups.values())
     .reverse()
     .flat();
-}
-
-export function isAtLatestExecutionEdge(metrics: ScrollMetrics, order: ExecutionConsoleOrder, threshold = 24) {
-  if (order === 'newest-first') {
-    return metrics.scrollTop <= threshold;
-  }
-  return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight <= threshold;
 }
 
 export function getLatestExecutionEdgeScrollTop(scrollHeight: number, order: ExecutionConsoleOrder) {

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/index.tsx
@@ -1,6 +1,6 @@
-import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { Button, Dropdown, type MenuProps } from 'antd';
-import { ArrowDownToLine, Copy, Sparkles, Trash2 } from 'lucide-react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Button, Dropdown, Segmented, type MenuProps } from 'antd';
+import { ArrowDownToLine, ArrowUpToLine, Copy, Sparkles, Trash2 } from 'lucide-react';
 import { IconfontSvg, staticMessage } from '@chat2db/ui';
 import i18n from '@/i18n';
 import { copyToClipboard } from '@/utils/copy';
@@ -16,7 +16,19 @@ import type {
   SqlExecutionLogRecord,
   SqlExecutionLogResultOutput,
 } from '@/service/sqlExecutionLog';
+import {
+  createExecutionConsoleOrderStorageKey,
+  getExecutionConsolePreferenceStorage,
+  getLatestExecutionEdgeScrollTop,
+  isAtLatestExecutionEdge,
+  orderExecutionLogRecords,
+  persistExecutionConsoleOrder,
+  readExecutionConsoleOrder,
+  type ExecutionConsoleOrder,
+} from './executionConsolePreferences';
 import { useStyles } from './style';
+
+const ORDER_STORAGE_KEY = createExecutionConsoleOrderStorageKey('community', __RUNTIME_ENV__);
 
 interface IProps {
   records: SqlExecutionLogRecord[];
@@ -31,19 +43,48 @@ export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable
     theme: { appearance },
   } = useStyles();
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [followTail, setFollowTail] = useState(true);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [order, setOrder] = useState<ExecutionConsoleOrder>(() =>
+    readExecutionConsoleOrder(getExecutionConsolePreferenceStorage(), ORDER_STORAGE_KEY),
+  );
+  const [followLatest, setFollowLatest] = useState(true);
   const setCurrentWorkspaceExtend = useWorkspaceStore((state) => state.setCurrentWorkspaceExtend);
+  const orderedRecords = useMemo(() => orderExecutionLogRecords(records, order), [records, order]);
+
+  const alignToLatest = useCallback(() => {
+    const container = scrollRef.current;
+    if (container) {
+      container.scrollTop = getLatestExecutionEdgeScrollTop(container.scrollHeight, order);
+    }
+  }, [order]);
 
   useEffect(() => {
-    if (!followTail) return;
-    const frame = window.requestAnimationFrame(() => {
-      const container = scrollRef.current;
-      if (container) container.scrollTop = container.scrollHeight;
-    });
+    if (!followLatest) return;
+    const frame = window.requestAnimationFrame(alignToLatest);
     return () => window.cancelAnimationFrame(frame);
-  }, [records, followTail]);
+  }, [orderedRecords, followLatest, alignToLatest]);
 
-  const plainText = useMemo(() => buildPlainText(records), [records]);
+  useEffect(() => {
+    const container = scrollRef.current;
+    const content = contentRef.current;
+    if (!container || !content || typeof ResizeObserver === 'undefined') return;
+
+    let frame: number | undefined;
+    const observer = new ResizeObserver(() => {
+      if (!followLatest) return;
+      if (frame !== undefined) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(alignToLatest);
+    });
+    observer.observe(container);
+    observer.observe(content);
+
+    return () => {
+      observer.disconnect();
+      if (frame !== undefined) window.cancelAnimationFrame(frame);
+    };
+  }, [followLatest, alignToLatest]);
+
+  const plainText = useMemo(() => buildPlainText(orderedRecords), [orderedRecords]);
 
   const handleCopy = async () => {
     await copyToClipboard(plainText);
@@ -53,14 +94,28 @@ export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable
   const handleScroll = () => {
     const container = scrollRef.current;
     if (!container) return;
-    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-    setFollowTail(distanceFromBottom < 24);
+    setFollowLatest(
+      isAtLatestExecutionEdge(
+        {
+          scrollTop: container.scrollTop,
+          scrollHeight: container.scrollHeight,
+          clientHeight: container.clientHeight,
+        },
+        order,
+      ),
+    );
   };
 
-  const handleFollowTail = () => {
-    setFollowTail(true);
-    const container = scrollRef.current;
-    if (container) container.scrollTop = container.scrollHeight;
+  const handleFollowLatest = () => {
+    setFollowLatest(true);
+    alignToLatest();
+  };
+
+  const handleOrderChange = (value: string | number) => {
+    const nextOrder = value as ExecutionConsoleOrder;
+    setOrder(nextOrder);
+    setFollowLatest(true);
+    persistExecutionConsoleOrder(getExecutionConsolePreferenceStorage(), ORDER_STORAGE_KEY, nextOrder);
   };
 
   const handleContextMenuClick: MenuProps['onClick'] = ({ key }) => {
@@ -69,7 +124,7 @@ export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable
     } else if (key === 'clear') {
       onClear();
     } else if (key === 'follow') {
-      handleFollowTail();
+      handleFollowLatest();
     }
   };
 
@@ -92,97 +147,119 @@ export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable
 
   return (
     <div className={styles.console}>
+      <div className={styles.toolbar}>
+        <Segmented
+          className={styles.orderControl}
+          size="small"
+          value={order}
+          onChange={handleOrderChange}
+          options={[
+            { value: 'oldest-first', label: i18n('common.text.oldestFirst') },
+            { value: 'newest-first', label: i18n('common.text.newestFirst') },
+          ]}
+        />
+        {!followLatest && (
+          <Button
+            size="small"
+            icon={order === 'newest-first' ? <ArrowUpToLine size={14} /> : <ArrowDownToLine size={14} />}
+            onClick={handleFollowLatest}
+          >
+            {i18n('common.button.followConsole')}
+          </Button>
+        )}
+      </div>
       <Dropdown
         menu={{
           items: [
             { key: 'copy', icon: <Copy size={14} />, label: i18n('common.button.copyConsole') },
             { key: 'clear', icon: <Trash2 size={14} />, label: i18n('common.button.clearConsole'), danger: true },
-            { key: 'follow', icon: <ArrowDownToLine size={14} />, label: i18n('common.button.followConsole') },
+            {
+              key: 'follow',
+              icon: order === 'newest-first' ? <ArrowUpToLine size={14} /> : <ArrowDownToLine size={14} />,
+              label: i18n('common.button.followConsole'),
+            },
           ],
           onClick: handleContextMenuClick,
         }}
         trigger={['contextMenu']}
       >
         <div className={styles.scrollArea} ref={scrollRef} onScroll={handleScroll}>
-          {records.map((record, recordIndex) => {
-            const showContext =
-              recordIndex === 0 || contextKey(records[recordIndex - 1].context) !== contextKey(record.context);
-            const databaseInfo = getDatabaseInfo(record.context.databaseType);
-            return (
-              <div className={styles.record} key={record.id}>
-                {showContext && (
-                  <div className={styles.contextLine}>
-                    <span className={styles.contextRule} />
-                    <span className={styles.contextContent}>
-                      <IconfontSvg
-                        className={styles.databaseIcon}
-                        size={14}
-                        existDark={databaseInfo?.iconExistDark}
-                        appearance={appearance}
-                        code={databaseInfo?.icon || 'icon-chat-database'}
-                      />
-                      <span className={styles.contextText}>{formatContext(record.context)}</span>
-                    </span>
-                    <span className={styles.contextRule} />
-                  </div>
-                )}
-                <div className={styles.line}>
-                  <TimeCell value={record.startedAtEpochMs} prominent />
-                  <div className={styles.sqlContent}>
-                    <span className={styles.prompt}>
-                      {record.context.schemaName || record.context.databaseName || 'SQL'}&gt;
-                    </span>
-                    <SQLPreview className={styles.sql} sql={record.sql} source="execution-console" />
-                  </div>
-                </div>
-                {record.outputs.map((output) =>
-                  output.kind === 'message' ? (
-                    <MessageLine
-                      key={output.id}
-                      output={output}
-                      record={record}
-                      onAIDiagnose={handleAIDiagnose}
-                    />
-                  ) : (
-                    <ResultLine
-                      key={output.id}
-                      output={output}
-                      record={record}
-                      isResultAvailable={isResultAvailable}
-                      onOpenResult={onOpenResult}
-                      onAIDiagnose={handleAIDiagnose}
-                    />
-                  ),
-                )}
-                {record.status === 'running' && (
-                  <ConsoleLine
-                    className={styles.runningLine}
-                    timestamp={record.startedAtEpochMs}
-                    content={
-                      <span className={styles.runningContent}>
-                        <span className={styles.runningDot} />
-                        {i18n('common.text.currentExecution')}
+          <div className={styles.scrollContent} ref={contentRef}>
+            {orderedRecords.map((record, recordIndex) => {
+              const showContext =
+                recordIndex === 0 || contextKey(orderedRecords[recordIndex - 1].context) !== contextKey(record.context);
+              const databaseInfo = getDatabaseInfo(record.context.databaseType);
+              return (
+                <div className={styles.record} key={record.id}>
+                  {showContext && (
+                    <div className={styles.contextLine}>
+                      <span className={styles.contextRule} />
+                      <span className={styles.contextContent}>
+                        <IconfontSvg
+                          className={styles.databaseIcon}
+                          size={14}
+                          existDark={databaseInfo?.iconExistDark}
+                          appearance={appearance}
+                          code={databaseInfo?.icon || 'icon-chat-database'}
+                        />
+                        <span className={styles.contextText}>{formatContext(record.context)}</span>
                       </span>
-                    }
-                  />
-                )}
-                {record.status === 'cancelled' && (
-                  <ConsoleLine
-                    className={styles.cancelledLine}
-                    timestamp={record.finishedAtEpochMs || record.startedAtEpochMs}
-                    content={i18n('common.text.executionCancelled')}
-                  />
-                )}
-                {record.status === 'success' && record.outputs.length === 0 && (
-                  <ConsoleLine
-                    className={styles.successLine}
-                    timestamp={record.finishedAtEpochMs || record.startedAtEpochMs}
-                    content={`${i18n('common.text.executionCompleted')} · ${formatMilliseconds(record.durationMs)}`}
-                  />
-                )}
-              </div>
-            );
-          })}
+                      <span className={styles.contextRule} />
+                    </div>
+                  )}
+                  <div className={styles.line}>
+                    <TimeCell value={record.startedAtEpochMs} prominent />
+                    <div className={styles.sqlContent}>
+                      <span className={styles.prompt}>
+                        {record.context.schemaName || record.context.databaseName || 'SQL'}&gt;
+                      </span>
+                      <SQLPreview className={styles.sql} sql={record.sql} source="execution-console" />
+                    </div>
+                  </div>
+                  {record.outputs.map((output) =>
+                    output.kind === 'message' ? (
+                      <MessageLine key={output.id} output={output} record={record} onAIDiagnose={handleAIDiagnose} />
+                    ) : (
+                      <ResultLine
+                        key={output.id}
+                        output={output}
+                        record={record}
+                        isResultAvailable={isResultAvailable}
+                        onOpenResult={onOpenResult}
+                        onAIDiagnose={handleAIDiagnose}
+                      />
+                    ),
+                  )}
+                  {record.status === 'running' && (
+                    <ConsoleLine
+                      className={styles.runningLine}
+                      timestamp={record.startedAtEpochMs}
+                      content={
+                        <span className={styles.runningContent}>
+                          <span className={styles.runningDot} />
+                          {i18n('common.text.currentExecution')}
+                        </span>
+                      }
+                    />
+                  )}
+                  {record.status === 'cancelled' && (
+                    <ConsoleLine
+                      className={styles.cancelledLine}
+                      timestamp={record.finishedAtEpochMs || record.startedAtEpochMs}
+                      content={i18n('common.text.executionCancelled')}
+                    />
+                  )}
+                  {record.status === 'success' && record.outputs.length === 0 && (
+                    <ConsoleLine
+                      className={styles.successLine}
+                      timestamp={record.finishedAtEpochMs || record.startedAtEpochMs}
+                      content={`${i18n('common.text.executionCompleted')} · ${formatMilliseconds(record.durationMs)}`}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
       </Dropdown>
     </div>

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { Button, Dropdown, Segmented, type MenuProps } from 'antd';
-import { ArrowDownToLine, ArrowUpToLine, Copy, Sparkles, Trash2 } from 'lucide-react';
+import { Button, Dropdown, type MenuProps } from 'antd';
+import { ArrowDownToLine, ArrowDownUp, ArrowUpToLine, Check, Copy, Sparkles, Trash2 } from 'lucide-react';
 import { IconfontSvg, staticMessage } from '@chat2db/ui';
 import i18n from '@/i18n';
 import { copyToClipboard } from '@/utils/copy';
@@ -20,7 +20,6 @@ import {
   createExecutionConsoleOrderStorageKey,
   getExecutionConsolePreferenceStorage,
   getLatestExecutionEdgeScrollTop,
-  isAtLatestExecutionEdge,
   orderExecutionLogRecords,
   persistExecutionConsoleOrder,
   readExecutionConsoleOrder,
@@ -91,30 +90,17 @@ export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable
     staticMessage.success(i18n('common.button.copySuccessfully'));
   };
 
-  const handleScroll = () => {
-    const container = scrollRef.current;
-    if (!container) return;
-    setFollowLatest(
-      isAtLatestExecutionEdge(
-        {
-          scrollTop: container.scrollTop,
-          scrollHeight: container.scrollHeight,
-          clientHeight: container.clientHeight,
-        },
-        order,
-      ),
-    );
-  };
-
-  const handleFollowLatest = () => {
+  const handleToggleFollowLatest = () => {
+    if (followLatest) {
+      setFollowLatest(false);
+      return;
+    }
     setFollowLatest(true);
     alignToLatest();
   };
 
-  const handleOrderChange = (value: string | number) => {
-    const nextOrder = value as ExecutionConsoleOrder;
+  const handleOrderChange = (nextOrder: ExecutionConsoleOrder) => {
     setOrder(nextOrder);
-    setFollowLatest(true);
     persistExecutionConsoleOrder(getExecutionConsolePreferenceStorage(), ORDER_STORAGE_KEY, nextOrder);
   };
 
@@ -124,7 +110,9 @@ export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable
     } else if (key === 'clear') {
       onClear();
     } else if (key === 'follow') {
-      handleFollowLatest();
+      handleToggleFollowLatest();
+    } else if (key === 'toggle-order') {
+      handleOrderChange(order === 'oldest-first' ? 'newest-first' : 'oldest-first');
     }
   };
 
@@ -147,43 +135,37 @@ export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable
 
   return (
     <div className={styles.console}>
-      <div className={styles.toolbar}>
-        <Segmented
-          className={styles.orderControl}
-          size="small"
-          value={order}
-          onChange={handleOrderChange}
-          options={[
-            { value: 'oldest-first', label: i18n('common.text.oldestFirst') },
-            { value: 'newest-first', label: i18n('common.text.newestFirst') },
-          ]}
-        />
-        {!followLatest && (
-          <Button
-            size="small"
-            icon={order === 'newest-first' ? <ArrowUpToLine size={14} /> : <ArrowDownToLine size={14} />}
-            onClick={handleFollowLatest}
-          >
-            {i18n('common.button.followConsole')}
-          </Button>
-        )}
-      </div>
       <Dropdown
         menu={{
           items: [
             { key: 'copy', icon: <Copy size={14} />, label: i18n('common.button.copyConsole') },
-            { key: 'clear', icon: <Trash2 size={14} />, label: i18n('common.button.clearConsole'), danger: true },
+            { type: 'divider' },
+            {
+              key: 'toggle-order',
+              icon: <ArrowDownUp size={14} />,
+              label: `${i18n('common.text.order')}: ${i18n(
+                order === 'oldest-first' ? 'common.text.oldestFirst' : 'common.text.newestFirst',
+              )}`,
+            },
             {
               key: 'follow',
-              icon: order === 'newest-first' ? <ArrowUpToLine size={14} /> : <ArrowDownToLine size={14} />,
+              icon: followLatest ? (
+                <Check size={14} />
+              ) : order === 'newest-first' ? (
+                <ArrowUpToLine size={14} />
+              ) : (
+                <ArrowDownToLine size={14} />
+              ),
               label: i18n('common.button.followConsole'),
             },
+            { type: 'divider' },
+            { key: 'clear', icon: <Trash2 size={14} />, label: i18n('common.button.clearConsole'), danger: true },
           ],
           onClick: handleContextMenuClick,
         }}
         trigger={['contextMenu']}
       >
-        <div className={styles.scrollArea} ref={scrollRef} onScroll={handleScroll}>
+        <div className={styles.scrollArea} ref={scrollRef}>
           <div className={styles.scrollContent} ref={contentRef}>
             {orderedRecords.map((record, recordIndex) => {
               const showContext =

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/style.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/style.ts
@@ -8,6 +8,20 @@ export const useStyles = createStyles(({ css, token }) => ({
     background: ${token.colorBgContainer};
     color: ${token.colorText};
   `,
+  toolbar: css`
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 8px;
+    min-height: 36px;
+    padding: 4px 12px;
+    border-bottom: 1px solid ${token.colorBorderSecondary};
+  `,
+  orderControl: css`
+    max-width: 100%;
+  `,
   scrollArea: css`
     flex: 1;
     min-height: 0;
@@ -16,6 +30,9 @@ export const useStyles = createStyles(({ css, token }) => ({
     font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
     font-size: 12px;
     line-height: 1.65;
+  `,
+  scrollContent: css`
+    min-width: 0;
   `,
   record: css`
     min-width: 0;

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/style.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/style.ts
@@ -8,20 +8,6 @@ export const useStyles = createStyles(({ css, token }) => ({
     background: ${token.colorBgContainer};
     color: ${token.colorText};
   `,
-  toolbar: css`
-    flex: none;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-    gap: 8px;
-    min-height: 36px;
-    padding: 4px 12px;
-    border-bottom: 1px solid ${token.colorBorderSecondary};
-  `,
-  orderControl: css`
-    max-width: 100%;
-  `,
   scrollArea: css`
     flex: 1;
     min-height: 0;

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -441,7 +441,17 @@ export default memo<IProps>(
     }, []);
 
     useEffect(() => {
-      setTimeout(() => tableInstance?.resize?.(), 0);
+      if (!tableInstance) {
+        return;
+      }
+
+      const resizeTimer = window.setTimeout(() => {
+        if (resultSetTableRef.current?.tableInstance === tableInstance) {
+          tableInstance.resize?.();
+        }
+      }, 0);
+
+      return () => window.clearTimeout(resizeTimer);
     }, [inspectorOpen, tableInstance]);
 
     return (

--- a/chat2db-community-client/src/i18n/en-US/common.ts
+++ b/chat2db-community-client/src/i18n/en-US/common.ts
@@ -226,6 +226,7 @@ export default {
   'common.button.copyConsole': 'Copy output',
   'common.button.clearConsole': 'Clear output',
   'common.button.followConsole': 'Follow latest entry',
+  'common.text.order': 'Order',
   'common.text.oldestFirst': 'Oldest first',
   'common.text.newestFirst': 'Newest first',
   'common.text.rowsReturned': '{1} rows returned',

--- a/chat2db-community-client/src/i18n/en-US/common.ts
+++ b/chat2db-community-client/src/i18n/en-US/common.ts
@@ -226,6 +226,8 @@ export default {
   'common.button.copyConsole': 'Copy output',
   'common.button.clearConsole': 'Clear output',
   'common.button.followConsole': 'Follow latest entry',
+  'common.text.oldestFirst': 'Oldest first',
+  'common.text.newestFirst': 'Newest first',
   'common.text.rowsReturned': '{1} rows returned',
   'common.text.executeDuration': 'execute {1} ms',
   'common.text.fetchDuration': 'fetch {1} ms',

--- a/chat2db-community-client/src/i18n/es-ES/common.ts
+++ b/chat2db-community-client/src/i18n/es-ES/common.ts
@@ -263,6 +263,7 @@ export default {
   'common.button.copyConsole': 'Copiar salida',
   'common.button.clearConsole': 'Limpiar salida',
   'common.button.followConsole': 'Seguir la última entrada',
+  'common.text.order': 'Orden',
   'common.text.oldestFirst': 'Antiguos primero',
   'common.text.newestFirst': 'Nuevos primero',
   'common.text.rowsReturned': '{1} filas devueltas',

--- a/chat2db-community-client/src/i18n/es-ES/common.ts
+++ b/chat2db-community-client/src/i18n/es-ES/common.ts
@@ -263,6 +263,8 @@ export default {
   'common.button.copyConsole': 'Copiar salida',
   'common.button.clearConsole': 'Limpiar salida',
   'common.button.followConsole': 'Seguir la última entrada',
+  'common.text.oldestFirst': 'Antiguos primero',
+  'common.text.newestFirst': 'Nuevos primero',
   'common.text.rowsReturned': '{1} filas devueltas',
   'common.text.executeDuration': 'ejecución {1} ms',
   'common.text.fetchDuration': 'lectura {1} ms',

--- a/chat2db-community-client/src/i18n/ja-JP/common.ts
+++ b/chat2db-community-client/src/i18n/ja-JP/common.ts
@@ -226,6 +226,7 @@ export default {
   'common.button.copyConsole': '出力をコピー',
   'common.button.clearConsole': '出力をクリア',
   'common.button.followConsole': '最新のログを追従',
+  'common.text.order': '並び順',
   'common.text.oldestFirst': '古い順',
   'common.text.newestFirst': '新しい順',
   'common.text.rowsReturned': '{1} 行を取得',

--- a/chat2db-community-client/src/i18n/ja-JP/common.ts
+++ b/chat2db-community-client/src/i18n/ja-JP/common.ts
@@ -226,6 +226,8 @@ export default {
   'common.button.copyConsole': '出力をコピー',
   'common.button.clearConsole': '出力をクリア',
   'common.button.followConsole': '最新のログを追従',
+  'common.text.oldestFirst': '古い順',
+  'common.text.newestFirst': '新しい順',
   'common.text.rowsReturned': '{1} 行を取得',
   'common.text.executeDuration': '実行 {1} ms',
   'common.text.fetchDuration': '取得 {1} ms',

--- a/chat2db-community-client/src/i18n/ko-KR/common.ts
+++ b/chat2db-community-client/src/i18n/ko-KR/common.ts
@@ -263,6 +263,7 @@ export default {
   'common.button.copyConsole': '출력 복사',
   'common.button.clearConsole': '출력 지우기',
   'common.button.followConsole': '최신 로그 따라가기',
+  'common.text.order': '정렬',
   'common.text.oldestFirst': '오래된 순',
   'common.text.newestFirst': '최신 순',
   'common.text.rowsReturned': '{1}개 행 반환',

--- a/chat2db-community-client/src/i18n/ko-KR/common.ts
+++ b/chat2db-community-client/src/i18n/ko-KR/common.ts
@@ -263,6 +263,8 @@ export default {
   'common.button.copyConsole': '출력 복사',
   'common.button.clearConsole': '출력 지우기',
   'common.button.followConsole': '최신 로그 따라가기',
+  'common.text.oldestFirst': '오래된 순',
+  'common.text.newestFirst': '최신 순',
   'common.text.rowsReturned': '{1}개 행 반환',
   'common.text.executeDuration': '실행 {1} ms',
   'common.text.fetchDuration': '읽기 {1} ms',

--- a/chat2db-community-client/src/i18n/zh-CN/common.ts
+++ b/chat2db-community-client/src/i18n/zh-CN/common.ts
@@ -224,6 +224,7 @@ export default {
   'common.button.copyConsole': '复制输出',
   'common.button.clearConsole': '清空输出',
   'common.button.followConsole': '跟随最新日志',
+  'common.text.order': '排序规则',
   'common.text.oldestFirst': '最早优先',
   'common.text.newestFirst': '最新优先',
   'common.text.rowsReturned': '返回 {1} 行',

--- a/chat2db-community-client/src/i18n/zh-CN/common.ts
+++ b/chat2db-community-client/src/i18n/zh-CN/common.ts
@@ -224,6 +224,8 @@ export default {
   'common.button.copyConsole': '复制输出',
   'common.button.clearConsole': '清空输出',
   'common.button.followConsole': '跟随最新日志',
+  'common.text.oldestFirst': '最早优先',
+  'common.text.newestFirst': '最新优先',
   'common.text.rowsReturned': '返回 {1} 行',
   'common.text.executeDuration': '执行 {1} ms',
   'common.text.fetchDuration': '读取 {1} ms',


### PR DESCRIPTION
## Related issue

Closes #1916

## Summary

- Add persisted oldest-first/newest-first execution-group ordering while preserving statement order inside each execution.
- Keep Output free of a persistent toolbar and group its right-click menu as copy; ordering plus follow; destructive clear.
- Make follow-latest a real explicit toggle: a check means enabled, an order-aware edge arrow means disabled, and manual scrolling or ordering changes never mutate the setting.
- Track the bottom edge for oldest-first and the top edge for newest-first after new records or layout-size changes while follow mode is enabled.
- Cancel and identity-check deferred result-grid `resize()` work so page refresh cannot resize a released VTable instance.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:execution-console` - passed.
  - `yarn test:sql-execution-log` - passed.
  - `yarn test:search-result-tab-selection` - passed.
  - `yarn lint:eslint` - passed with zero warnings.
  - `yarn build:web:community` - passed.
  - `git diff --check` - passed.
  - Project knowledge lint - passed.
  - `yarn test:i18n` - all changed `common.ts` translations and source hashes pass; the command still reports only the existing `es-ES/setting.ts` and `ko-KR/setting.ts` stale source hashes reproduced from `main`.
- Runtime verification:
  - The Community frontend hot-compiled each correction at `http://localhost:8889`.
  - The frontend and proxied `/api/system` endpoint returned HTTP 200.
  - Manual local testing exercised ordering, follow-state feedback, manual history scrolling, and repeated page refreshes; issues found during that testing were corrected in this update.

## Risk and compatibility

- Public API or stored data: no public API changes; adds only the namespaced local preference key `chat2db.community.<runtime>.execution-console.order.v1`.
- Database or driver compatibility: N/A - execution and reducer data contracts are unchanged.
- Network, privacy, or security: no new network calls or credential handling.
- Community / Local / Pro boundary: changes only the Community client; Enterprise is unchanged.
- Backward compatibility: oldest-first remains the default, existing records are not mutated, and existing copy, clear, and follow actions remain available from the context menu.
- Lifecycle behavior: deferred VTable resize work is now cancelled on cleanup and skipped unless the forwarded ref still points to the same instance.

## Reviewer map

- Start with `ExecutionConsole/index.tsx` for grouped menu and explicit follow behavior.
- Review `executionConsolePreferences.ts` for persisted ordering, execution-group reversal, and order-specific latest-edge targeting.
- Review `ResultSet/index.tsx` for the refresh/unmount resize guard.
- Failure conditions: newest-first reverses statements inside one execution; scrolling or ordering changes the follow toggle; disabled follow still auto-scrolls; or refresh calls `resize()` after VTable release.
- Rollback path: revert this PR; the new local-storage preference becomes unused and does not affect older builds.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with implementation, tests, review, and verification; the resulting diff and test evidence were reviewed before submission.
