### PR TITLE
fix(workspace): keep Data Browser active for database queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Run AI Markdown code context test
         run: yarn run test:ai-markdown-code
 
+      - name: Run active workspace tab locator contract
+        run: yarn run test:active-tab-locator
+
       - name: Run BaseTable tree interaction contract
         run: yarn run test:base-table-interaction
 

--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -27,6 +27,7 @@
     "lint:eslint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
     "lint:style": "stylelint \"src/**/*.{css,less}\" --max-warnings=0",
     "test:i18n": "node ./scripts/validate-i18n.cjs",
+    "test:active-tab-locator": "tsx src/pages/main/workspace/utils/activeTabLocator.test.ts",
     "test:ai-markdown-code": "tsx src/blocks/AI/markdownCode.test.tsx",
     "test:base-table-interaction": "tsx src/components/BaseTable/treeInteraction.test.ts",
     "test:database-object-sorting": "tsx src/blocks/NewTree/utils/sortTreeNodes.test.ts",

--- a/chat2db-community-client/src/constants/workspace.ts
+++ b/chat2db-community-client/src/constants/workspace.ts
@@ -92,5 +92,6 @@ export const workspaceTabConfig: {
 export const initUserConfigTree = {
   showComment: true,
   followActiveWorkspaceTab: true,
+  workspaceLeftPanel: 'database' as const,
   sortDatabaseObjects: false,
 };

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExplorer/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExplorer/index.tsx
@@ -21,6 +21,7 @@ type SearchBarHandle = { focus: () => void; blur: () => void };
 
 interface WorkspaceExplorerProps {
   active?: boolean;
+  onSessionActivate?: (sessionId: IWorkspaceTab['id']) => void;
 }
 
 export interface WorkspaceExplorerRef {
@@ -29,7 +30,7 @@ export interface WorkspaceExplorerRef {
 
 const WorkspaceExplorer = memo(
   forwardRef<WorkspaceExplorerRef, WorkspaceExplorerProps>((
-    { active = true },
+    { active = true, onSessionActivate },
     ref,
   ) => {
   const { styles } = useStyles();
@@ -152,6 +153,7 @@ const WorkspaceExplorer = memo(
   }
 
   function handleSessionDragStart(event: React.DragEvent<HTMLButtonElement>, session: IWorkspaceTab) {
+    onSessionActivate?.(session.id);
     setActiveConsoleId(session.id);
     const payload = {
       id: session.id,
@@ -249,6 +251,7 @@ const WorkspaceExplorer = memo(
                 onDragStart={(event) => handleSessionDragStart(event, session)}
                 onClick={(event) => {
                   event.stopPropagation();
+                  onSessionActivate?.(session.id);
                   setActiveConsoleId(session.id);
                 }}
               >

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
@@ -154,7 +154,12 @@ const WorkspaceLeft = memo(() => {
   const activePanel = resolveWorkspaceLeftPanel(userConfigTree.workspaceLeftPanel);
   const currentPanel = showExplorerPanel ? activePanel : 'database';
   const setActivePanel = useCallback(
-    (panel: WorkspaceLeftPanel) => changeUserConfigTree('workspaceLeftPanel', panel),
+    (panel: WorkspaceLeftPanel) => {
+      const persistedPanel = resolveWorkspaceLeftPanel(useTreeStore.getState().userConfigTree.workspaceLeftPanel);
+      if (persistedPanel !== panel) {
+        changeUserConfigTree('workspaceLeftPanel', panel);
+      }
+    },
     [changeUserConfigTree],
   );
   const activeTab = useMemo(
@@ -344,10 +349,10 @@ const WorkspaceLeft = memo(() => {
     if (explorerSessionActivationRef.current !== null && !isExplorerSessionActivation) {
       explorerSessionActivationRef.current = null;
     }
-    if (showExplorerPanel && autoFollowPanel) {
+    if (showExplorerPanel && autoFollowPanel && activePanel !== autoFollowPanel) {
       setActivePanel(autoFollowPanel);
     }
-  }, [autoFollowPanel, isExplorerSessionActivation, setActivePanel, showExplorerPanel]);
+  }, [activePanel, autoFollowPanel, isExplorerSessionActivation, setActivePanel, showExplorerPanel]);
 
   useEffect(() => {
     if (!pendingManualDatabaseLocateRef.current) {

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
@@ -9,8 +9,9 @@ import type { TreeNodeData } from '@/typings';
 import { isCommunityEnv, isDesktop, isDesktopEnv, isWebEnv } from '@/utils/env';
 import feedback from '@/utils/feedback';
 import { Flex } from 'antd';
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type Key } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type Key } from 'react';
 import {
+  getAutoFollowWorkspaceLeftPanel,
   getActiveTabLocateTarget,
   resolveWorkspaceLeftPanel,
   type ActiveTabDatabaseCandidate,
@@ -159,6 +160,7 @@ const WorkspaceLeft = memo(() => {
   );
   const activeTabLocateTarget = useMemo(() => getActiveTabLocateTarget(activeTab), [activeTab]);
   const autoFollowActiveWorkspaceTab = userConfigTree.followActiveWorkspaceTab !== false;
+  const autoFollowPanel = getAutoFollowWorkspaceLeftPanel(autoFollowActiveWorkspaceTab, activeTabLocateTarget);
   const panelOptions: Array<{ label: string; value: WorkspaceLeftPanel }> = [
     { label: i18n('workspace.explorer.title'), value: 'explorer' },
     { label: i18n('workspace.explorer.databases'), value: 'database' },
@@ -313,6 +315,12 @@ const WorkspaceLeft = memo(() => {
       }
     });
   }, [locateActiveWorkspaceTab]);
+
+  useLayoutEffect(() => {
+    if (showExplorerPanel && autoFollowPanel) {
+      setActivePanel(autoFollowPanel);
+    }
+  }, [autoFollowPanel, setActivePanel, showExplorerPanel]);
 
   useEffect(() => {
     if (

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
@@ -12,6 +12,7 @@ import { Flex } from 'antd';
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type Key } from 'react';
 import {
   getActiveTabLocateTarget,
+  resolveWorkspaceLeftPanel,
   type ActiveTabDatabaseCandidate,
   type ActiveTabLocateTarget,
   type WorkspaceLeftPanel,
@@ -133,20 +134,25 @@ function findDatabaseLocateNode(treeData: TreeNodeData[] | null | undefined, can
 const WorkspaceLeft = memo(() => {
   const explorerRef = useRef<WorkspaceExplorerRef>(null);
   const locateRequestSeqRef = useRef(0);
-  const [activePanel, setActivePanel] = useState<WorkspaceLeftPanel>('explorer');
   const shouldProbeDesktopBridge = !isWebEnv && (isDesktopEnv || isCommunityEnv || isDesktop);
   const [desktopBridgeReady, setDesktopBridgeReady] = useState(() => isDesktop || hasDesktopBridge());
   const { styles } = useStyles();
   const showExplorerPanel = shouldProbeDesktopBridge && desktopBridgeReady;
-  const currentPanel = showExplorerPanel ? activePanel : 'database';
   const { activeConsoleId, workspaceTabList } = useWorkspaceStore((state) => ({
     activeConsoleId: state.activeConsoleId,
     workspaceTabList: state.workspaceTabList,
   }));
-  const { treeDataReady, userConfigTree } = useTreeStore((state) => ({
+  const { changeUserConfigTree, treeDataReady, userConfigTree } = useTreeStore((state) => ({
+    changeUserConfigTree: state.changeUserConfigTree,
     treeDataReady: !!state.treeData,
     userConfigTree: state.userConfigTree,
   }));
+  const activePanel = resolveWorkspaceLeftPanel(userConfigTree.workspaceLeftPanel);
+  const currentPanel = showExplorerPanel ? activePanel : 'database';
+  const setActivePanel = useCallback(
+    (panel: WorkspaceLeftPanel) => changeUserConfigTree('workspaceLeftPanel', panel),
+    [changeUserConfigTree],
+  );
   const activeTab = useMemo(
     () => workspaceTabList?.find((tab) => tab.id === activeConsoleId),
     [activeConsoleId, workspaceTabList],
@@ -271,7 +277,7 @@ const WorkspaceLeft = memo(() => {
       selectDatabaseTreeNode(result, { clearSearch: options?.clearSearch });
       return result.fallback ? 'fallback' : 'hit';
     },
-    [loadDatabasePath, selectDatabaseTreeNode, showExplorerPanel],
+    [loadDatabasePath, selectDatabaseTreeNode, setActivePanel, showExplorerPanel],
   );
 
   const locateActiveWorkspaceTab = useCallback(
@@ -294,7 +300,7 @@ const WorkspaceLeft = memo(() => {
 
       return locateDatabaseTree(target, { ...options, requestSeq });
     },
-    [activeTabLocateTarget, locateDatabaseTree, showExplorerPanel],
+    [activeTabLocateTarget, locateDatabaseTree, setActivePanel, showExplorerPanel],
   );
 
   const handleLocateActiveWorkspaceTab = useCallback(() => {

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
@@ -14,6 +14,7 @@ import {
   getAutoFollowWorkspaceLeftPanel,
   getActiveTabLocateTarget,
   resolveWorkspaceLeftPanel,
+  shouldLocateActiveTabOnPanelSelection,
   type ActiveTabDatabaseCandidate,
   type ActiveTabLocateTarget,
   type WorkspaceLeftPanel,
@@ -135,6 +136,8 @@ function findDatabaseLocateNode(treeData: TreeNodeData[] | null | undefined, can
 const WorkspaceLeft = memo(() => {
   const explorerRef = useRef<WorkspaceExplorerRef>(null);
   const locateRequestSeqRef = useRef(0);
+  const explorerSessionActivationRef = useRef<string | number | null>(null);
+  const pendingManualDatabaseLocateRef = useRef(false);
   const shouldProbeDesktopBridge = !isWebEnv && (isDesktopEnv || isCommunityEnv || isDesktop);
   const [desktopBridgeReady, setDesktopBridgeReady] = useState(() => isDesktop || hasDesktopBridge());
   const { styles } = useStyles();
@@ -160,7 +163,12 @@ const WorkspaceLeft = memo(() => {
   );
   const activeTabLocateTarget = useMemo(() => getActiveTabLocateTarget(activeTab), [activeTab]);
   const autoFollowActiveWorkspaceTab = userConfigTree.followActiveWorkspaceTab !== false;
-  const autoFollowPanel = getAutoFollowWorkspaceLeftPanel(autoFollowActiveWorkspaceTab, activeTabLocateTarget);
+  const isExplorerSessionActivation = explorerSessionActivationRef.current === activeConsoleId;
+  const autoFollowPanel = getAutoFollowWorkspaceLeftPanel(
+    autoFollowActiveWorkspaceTab,
+    activeTabLocateTarget,
+    isExplorerSessionActivation ? 'explorerSession' : 'workspaceTab',
+  );
   const panelOptions: Array<{ label: string; value: WorkspaceLeftPanel }> = [
     { label: i18n('workspace.explorer.title'), value: 'explorer' },
     { label: i18n('workspace.explorer.databases'), value: 'database' },
@@ -316,14 +324,49 @@ const WorkspaceLeft = memo(() => {
     });
   }, [locateActiveWorkspaceTab]);
 
+  const handleExplorerSessionActivate = useCallback((sessionId: string | number) => {
+    explorerSessionActivationRef.current = sessionId;
+  }, []);
+
+  const handlePanelSelection = useCallback(
+    (panel: WorkspaceLeftPanel) => {
+      setActivePanel(panel);
+      const shouldLocate = shouldLocateActiveTabOnPanelSelection(panel, activeTabLocateTarget);
+      pendingManualDatabaseLocateRef.current = shouldLocate && !treeDataReady;
+      if (shouldLocate && treeDataReady) {
+        void locateActiveWorkspaceTab({ clearSearch: true });
+      }
+    },
+    [activeTabLocateTarget, locateActiveWorkspaceTab, setActivePanel, treeDataReady],
+  );
+
   useLayoutEffect(() => {
+    if (explorerSessionActivationRef.current !== null && !isExplorerSessionActivation) {
+      explorerSessionActivationRef.current = null;
+    }
     if (showExplorerPanel && autoFollowPanel) {
       setActivePanel(autoFollowPanel);
     }
-  }, [autoFollowPanel, setActivePanel, showExplorerPanel]);
+  }, [autoFollowPanel, isExplorerSessionActivation, setActivePanel, showExplorerPanel]);
+
+  useEffect(() => {
+    if (!pendingManualDatabaseLocateRef.current) {
+      return;
+    }
+    if (currentPanel !== 'database' || activeTabLocateTarget?.surface === 'localFile') {
+      pendingManualDatabaseLocateRef.current = false;
+      return;
+    }
+    if (!treeDataReady || activeTabLocateTarget?.surface !== 'databaseTree') {
+      return;
+    }
+    pendingManualDatabaseLocateRef.current = false;
+    void locateActiveWorkspaceTab({ clearSearch: true });
+  }, [activeTabLocateTarget, currentPanel, locateActiveWorkspaceTab, treeDataReady]);
 
   useEffect(() => {
     if (
+      isExplorerSessionActivation ||
       !autoFollowActiveWorkspaceTab ||
       !activeTabLocateTarget ||
       activeTabLocateTarget.surface === 'databaseTree'
@@ -331,10 +374,11 @@ const WorkspaceLeft = memo(() => {
       return;
     }
     void locateActiveWorkspaceTab();
-  }, [activeTabLocateTarget, autoFollowActiveWorkspaceTab, locateActiveWorkspaceTab]);
+  }, [activeTabLocateTarget, autoFollowActiveWorkspaceTab, isExplorerSessionActivation, locateActiveWorkspaceTab]);
 
   useEffect(() => {
     if (
+      isExplorerSessionActivation ||
       !autoFollowActiveWorkspaceTab ||
       !activeTabLocateTarget ||
       activeTabLocateTarget.surface !== 'databaseTree' ||
@@ -343,7 +387,13 @@ const WorkspaceLeft = memo(() => {
       return;
     }
     void locateActiveWorkspaceTab();
-  }, [activeTabLocateTarget, autoFollowActiveWorkspaceTab, locateActiveWorkspaceTab, treeDataReady]);
+  }, [
+    activeTabLocateTarget,
+    autoFollowActiveWorkspaceTab,
+    isExplorerSessionActivation,
+    locateActiveWorkspaceTab,
+    treeDataReady,
+  ]);
 
   return (
     <>
@@ -358,7 +408,7 @@ const WorkspaceLeft = memo(() => {
                   className={[styles.resourceTitle, activePanel === item.value ? styles.resourceTitleActive : '']
                     .filter(Boolean)
                     .join(' ')}
-                  onClick={() => setActivePanel(item.value)}
+                  onClick={() => handlePanelSelection(item.value)}
                 >
                   {item.label}
                 </button>
@@ -369,7 +419,11 @@ const WorkspaceLeft = memo(() => {
         {showExplorerPanel ? (
           <>
             <div className={[styles.panelPane, currentPanel === 'explorer' ? styles.panelPaneActive : ''].join(' ')}>
-              <WorkspaceExplorer ref={explorerRef} active={currentPanel === 'explorer'} />
+              <WorkspaceExplorer
+                ref={explorerRef}
+                active={currentPanel === 'explorer'}
+                onSessionActivate={handleExplorerSessionActivate}
+              />
             </div>
             <div className={[styles.panelPane, currentPanel === 'database' ? styles.panelPaneActive : ''].join(' ')}>
               <WorkspaceLeftActionBar

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { WorkspaceTabType, initUserConfigTree } from '@/constants/workspace';
 import type { IWorkspaceTab } from '@/typings';
-import { getDirectActiveTabLocateTarget, resolveWorkspaceLeftPanel } from './activeTabTarget';
+import {
+  getAutoFollowWorkspaceLeftPanel,
+  getDirectActiveTabLocateTarget,
+  resolveWorkspaceLeftPanel,
+} from './activeTabTarget';
 
 function consoleTab(uniqueData: IWorkspaceTab['uniqueData']): IWorkspaceTab {
   return {
@@ -37,5 +41,8 @@ assert.equal(getDirectActiveTabLocateTarget(consoleTab(undefined)), null);
 assert.equal(initUserConfigTree.workspaceLeftPanel, 'database');
 assert.equal(resolveWorkspaceLeftPanel(undefined), 'database');
 assert.equal(resolveWorkspaceLeftPanel('explorer'), 'explorer');
+assert.equal(getAutoFollowWorkspaceLeftPanel(true, { surface: 'databaseTree' }), 'database');
+assert.equal(getAutoFollowWorkspaceLeftPanel(true, { surface: 'localFile' }), 'explorer');
+assert.equal(getAutoFollowWorkspaceLeftPanel(false, { surface: 'databaseTree' }), undefined);
 
 console.log('Active workspace tab locator tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { WorkspaceTabType, initUserConfigTree } from '@/constants/workspace';
+import type { IWorkspaceTab } from '@/typings';
+import { getDirectActiveTabLocateTarget, resolveWorkspaceLeftPanel } from './activeTabTarget';
+
+function consoleTab(uniqueData: IWorkspaceTab['uniqueData']): IWorkspaceTab {
+  return {
+    id: 101,
+    type: WorkspaceTabType.CONSOLE,
+    title: 'Query',
+    uniqueData,
+  };
+}
+
+for (const uniqueData of [
+  { dataSourceId: 7 },
+  { dataSourceId: 7, databaseName: 'app' },
+  { dataSourceId: 7, databaseName: 'app', schemaName: 'public' },
+]) {
+  assert.deepEqual(getDirectActiveTabLocateTarget(consoleTab(uniqueData)), { surface: 'databaseTree' });
+}
+
+assert.deepEqual(
+  getDirectActiveTabLocateTarget({
+    id: 'local-file',
+    type: WorkspaceTabType.LocalSQLFile,
+    title: 'local.sql',
+    uniqueData: { filePath: '/tmp/local.sql' },
+  }),
+  {
+    surface: 'localFile',
+    filePath: '/tmp/local.sql',
+  },
+);
+
+assert.equal(getDirectActiveTabLocateTarget(consoleTab(undefined)), null);
+assert.equal(initUserConfigTree.workspaceLeftPanel, 'database');
+assert.equal(resolveWorkspaceLeftPanel(undefined), 'database');
+assert.equal(resolveWorkspaceLeftPanel('explorer'), 'explorer');
+
+console.log('Active workspace tab locator tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
@@ -5,6 +5,7 @@ import {
   getAutoFollowWorkspaceLeftPanel,
   getDirectActiveTabLocateTarget,
   resolveWorkspaceLeftPanel,
+  shouldLocateActiveTabOnPanelSelection,
 } from './activeTabTarget';
 
 function consoleTab(uniqueData: IWorkspaceTab['uniqueData']): IWorkspaceTab {
@@ -42,7 +43,11 @@ assert.equal(initUserConfigTree.workspaceLeftPanel, 'database');
 assert.equal(resolveWorkspaceLeftPanel(undefined), 'database');
 assert.equal(resolveWorkspaceLeftPanel('explorer'), 'explorer');
 assert.equal(getAutoFollowWorkspaceLeftPanel(true, { surface: 'databaseTree' }), 'database');
+assert.equal(getAutoFollowWorkspaceLeftPanel(true, { surface: 'databaseTree' }, 'explorerSession'), undefined);
 assert.equal(getAutoFollowWorkspaceLeftPanel(true, { surface: 'localFile' }), 'explorer');
 assert.equal(getAutoFollowWorkspaceLeftPanel(false, { surface: 'databaseTree' }), undefined);
+assert.equal(shouldLocateActiveTabOnPanelSelection('database', { surface: 'databaseTree' }), true);
+assert.equal(shouldLocateActiveTabOnPanelSelection('explorer', { surface: 'databaseTree' }), false);
+assert.equal(shouldLocateActiveTabOnPanelSelection('database', { surface: 'localFile' }), false);
 
 console.log('Active workspace tab locator tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
@@ -6,6 +6,8 @@ import { getDirectActiveTabLocateTarget } from './activeTabTarget';
 export {
   getAutoFollowWorkspaceLeftPanel,
   resolveWorkspaceLeftPanel,
+  shouldLocateActiveTabOnPanelSelection,
+  type WorkspaceTabActivationSource,
   type WorkspaceLeftPanel,
 } from './activeTabTarget';
 

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
@@ -1,8 +1,9 @@
 import { TreeNodeType, WorkspaceTabType } from '@/constants';
 import { treeConfig } from '@/blocks/NewTree/treeConfig';
 import type { IWorkspaceTab } from '@/typings';
+import { getDirectActiveTabLocateTarget } from './activeTabTarget';
 
-export type WorkspaceLeftPanel = 'explorer' | 'database';
+export { resolveWorkspaceLeftPanel, type WorkspaceLeftPanel } from './activeTabTarget';
 
 export interface ActiveTabDatabaseCandidate {
   key?: string;
@@ -278,22 +279,16 @@ export function getActiveTabLocateTarget(
     return null;
   }
 
-  if (activeTab.type === WorkspaceTabType.CONSOLE) {
+  const directTarget = getDirectActiveTabLocateTarget(activeTab);
+  if (directTarget?.surface === 'databaseTree') {
     return databaseTreeTarget(
       getContextCandidates(activeTab.uniqueData),
       getContextLoadPath(activeTab.uniqueData),
     );
   }
 
-  if (activeTab.type === WorkspaceTabType.LocalSQLFile) {
-    const filePath = activeTab.uniqueData?.filePath;
-    if (!filePath) {
-      return null;
-    }
-    return {
-      surface: 'localFile',
-      filePath,
-    };
+  if (directTarget !== undefined) {
+    return directTarget;
   }
 
   return getDatabaseObjectLocateTarget(activeTab);

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
@@ -3,7 +3,11 @@ import { treeConfig } from '@/blocks/NewTree/treeConfig';
 import type { IWorkspaceTab } from '@/typings';
 import { getDirectActiveTabLocateTarget } from './activeTabTarget';
 
-export { resolveWorkspaceLeftPanel, type WorkspaceLeftPanel } from './activeTabTarget';
+export {
+  getAutoFollowWorkspaceLeftPanel,
+  resolveWorkspaceLeftPanel,
+  type WorkspaceLeftPanel,
+} from './activeTabTarget';
 
 export interface ActiveTabDatabaseCandidate {
   key?: string;

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
@@ -16,6 +16,16 @@ export function resolveWorkspaceLeftPanel(panel?: WorkspaceLeftPanel): Workspace
   return panel || 'database';
 }
 
+export function getAutoFollowWorkspaceLeftPanel(
+  enabled: boolean,
+  target?: Pick<DirectActiveTabLocateTarget, 'surface'> | null,
+): WorkspaceLeftPanel | undefined {
+  if (!enabled || !target) {
+    return undefined;
+  }
+  return target.surface === 'localFile' ? 'explorer' : 'database';
+}
+
 export function getDirectActiveTabLocateTarget(
   activeTab?: IWorkspaceTab | null,
 ): DirectActiveTabLocateTarget | null | undefined {

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
@@ -2,6 +2,7 @@ import { WorkspaceTabType } from '@/constants/workspace';
 import type { IWorkspaceTab } from '@/typings/workspace';
 
 export type WorkspaceLeftPanel = 'explorer' | 'database';
+export type WorkspaceTabActivationSource = 'workspaceTab' | 'explorerSession';
 
 export type DirectActiveTabLocateTarget =
   | {
@@ -19,11 +20,19 @@ export function resolveWorkspaceLeftPanel(panel?: WorkspaceLeftPanel): Workspace
 export function getAutoFollowWorkspaceLeftPanel(
   enabled: boolean,
   target?: Pick<DirectActiveTabLocateTarget, 'surface'> | null,
+  source: WorkspaceTabActivationSource = 'workspaceTab',
 ): WorkspaceLeftPanel | undefined {
-  if (!enabled || !target) {
+  if (!enabled || !target || source === 'explorerSession') {
     return undefined;
   }
   return target.surface === 'localFile' ? 'explorer' : 'database';
+}
+
+export function shouldLocateActiveTabOnPanelSelection(
+  panel: WorkspaceLeftPanel,
+  target?: Pick<DirectActiveTabLocateTarget, 'surface'> | null,
+): boolean {
+  return panel === 'database' && target?.surface === 'databaseTree';
 }
 
 export function getDirectActiveTabLocateTarget(

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
@@ -1,0 +1,36 @@
+import { WorkspaceTabType } from '@/constants/workspace';
+import type { IWorkspaceTab } from '@/typings/workspace';
+
+export type WorkspaceLeftPanel = 'explorer' | 'database';
+
+export type DirectActiveTabLocateTarget =
+  | {
+      surface: 'localFile';
+      filePath: string;
+    }
+  | {
+      surface: 'databaseTree';
+    };
+
+export function resolveWorkspaceLeftPanel(panel?: WorkspaceLeftPanel): WorkspaceLeftPanel {
+  return panel || 'database';
+}
+
+export function getDirectActiveTabLocateTarget(
+  activeTab?: IWorkspaceTab | null,
+): DirectActiveTabLocateTarget | null | undefined {
+  if (!activeTab) {
+    return null;
+  }
+
+  if (activeTab.type === WorkspaceTabType.CONSOLE) {
+    return activeTab.uniqueData?.dataSourceId ? { surface: 'databaseTree' } : null;
+  }
+
+  if (activeTab.type === WorkspaceTabType.LocalSQLFile) {
+    const filePath = activeTab.uniqueData?.filePath;
+    return filePath ? { surface: 'localFile', filePath } : null;
+  }
+
+  return undefined;
+}

--- a/chat2db-community-client/src/typings/database.ts
+++ b/chat2db-community-client/src/typings/database.ts
@@ -264,6 +264,8 @@ export interface IUserConfigTree {
   showComment: boolean;
   // Whether to follow the currently open workspace tab
   followActiveWorkspaceTab?: boolean;
+  // The selected workspace sidebar surface
+  workspaceLeftPanel?: 'explorer' | 'database';
   // Whether to sort database object nodes by name without changing datasource order
   sortDatabaseObjects?: boolean;
 }


### PR DESCRIPTION
## Related issue

Closes #1915

## Summary

- Persist the selected workspace sidebar surface in the existing local tree configuration instead of resetting it when `WorkspaceLeft` mounts again.
- Default missing or legacy sidebar configuration to Data Browser while preserving explicit Files selections.
- Make auto-follow activation-source aware: database-backed query tabs created or activated outside Files target Data Browser, while clicking or dragging an entry in Files > Open Sessions keeps Files active.
- When the user explicitly selects Data Browser, locate and expand the active console's datasource/database/schema node, deferring the request until the database tree is ready when necessary.
- Keep panel persistence idempotent by writing only when the requested panel differs from the stored value.
- Keep real local SQL file tabs mapped to Files and preserve the current panel when Auto-follow is disabled.
- Add a deterministic TypeScript regression test, package script, and Community CI step.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results on rebased head `13c0d8b9`:
  - `yarn test:active-tab-locator` - passed.
  - `yarn lint:eslint` - passed with zero warnings.
  - `yarn build:web:community --app_version=5.3.0` - passed.
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'` - passed.
  - `git diff --check origin/main...HEAD` - passed.
- Manual verification: N/A - this workflow requires a packaged Community desktop client; runtime verification is intentionally left for the client build.
- UI evidence: N/A - no packaged client was built in this change.

## Risk and compatibility

- Public API or stored data: No public API change. Adds optional `workspaceLeftPanel` state to the existing local tree-store configuration; legacy records without it resolve to Data Browser.
- Database or driver compatibility: N/A - database-independent frontend navigation only.
- Network, privacy, or security: N/A - no network or credential behavior changes.
- Community / Local / Pro boundary: Community frontend only; no Enterprise, Local, Gateway, or JCEF packaging code changed.
- Backward compatibility: Existing persisted settings remain readable. Auto-follow disabled still leaves the persisted manual panel selection unchanged.

## Reviewer map

- Start here: `WorkspaceLeft/index.tsx` for idempotent persisted panel ownership, activation-source suppression, and manual Data Browser locating; then `WorkspaceExplorer/index.tsx` for Open Sessions activation provenance; then `activeTabTarget.ts` and `activeTabLocator.test.ts` for the browser-independent contract.
- Failure condition: Creating or activating a database query outside Files fails to select Data Browser; clicking an Open Sessions entry jumps from Files to Data Browser; manually selecting Data Browser fails to locate the active console node; the Auto-follow effect repeatedly persists an already-selected panel; a real local SQL file fails to activate Files; or disabling Auto-follow changes the current sidebar panel.
- Rollback or disable path: Revert `13c0d8b9`, `d3198fd6`, `3d8fcab0`, and `34f25e8a` in reverse chronological order. The change has no server migration or external state.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex traced the workspace-tab and sidebar state flow, implemented the patch and deterministic regression test, addressed automated review feedback, rebased onto current `main`, and ran the reported verification commands. The maintainer retains responsibility for packaged-client runtime validation.
