### PR TITLE
fix(community): isolate project sync events

### DIFF
--- a/.github/workflows/community-project-sync.yml
+++ b/.github/workflows/community-project-sync.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: community-project-sync-${{ github.repository }}
+  group: community-project-sync-${{ github.repository }}-${{ github.event.issue && format('issue-{0}', github.event.issue.number) || github.event.pull_request && format('pull-request-{0}', github.event.pull_request.number) || 'reconcile' }}
   cancel-in-progress: false
 
 jobs:

--- a/script/github/sync-community-project.test.js
+++ b/script/github/sync-community-project.test.js
@@ -1,4 +1,6 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const {
@@ -8,6 +10,18 @@ const {
   issueEventStatus,
   pullRequestStatus,
 } = require('./sync-community-project');
+
+test('isolates workflow concurrency by content type and number', () => {
+  const workflow = fs.readFileSync(
+    path.resolve(__dirname, '../../.github/workflows/community-project-sync.yml'),
+    'utf8',
+  );
+  assert.match(
+    workflow,
+    /group: community-project-sync-\$\{\{ github\.repository \}\}-\$\{\{ github\.event\.issue && format\('issue-\{0\}', github\.event\.issue\.number\) \|\| github\.event\.pull_request && format\('pull-request-\{0\}', github\.event\.pull_request\.number\) \|\| 'reconcile' \}\}/,
+  );
+  assert.match(workflow, /cancel-in-progress: false/);
+});
 
 test('extracts unique same-repository closing references', () => {
   assert.deepEqual(closingIssueNumbers('Closes #12\nfixes #12\nResolves #34'), [12, 34]);


### PR DESCRIPTION
## Related issue

Closes #1946

## Summary

- Isolate Community Project workflow concurrency by Issue or pull-request number so unrelated events cannot cancel each other's pending synchronization.
- Keep scheduled and manual full-board reconciliation serialized under a shared `reconcile` key.
- Add a source-level regression test for the concurrency contract while preserving `cancel-in-progress: false`.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [x] Documentation only

## Verification

- Commands and results:
  - `node --test script/github/issue-claim.test.js script/github/sync-community-project.test.js` - passed, 33 tests.
  - `ruby script/github/validate-community-operations.rb` - passed.
  - `actionlint .github/workflows/community-project-sync.yml` - passed.
  - `ruby -e 'require "yaml"; YAML.safe_load(File.read(".github/workflows/community-project-sync.yml"), aliases: false)'` - passed.
  - `git diff --check` - passed.
- Manual verification: The production run history after #1939 showed unrelated Project sync runs entering one repository-wide concurrency group; this PR narrows the key to the event content number.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A; no application API or stored data changes.
- Database or driver compatibility: N/A; no database code changes.
- Network, privacy, or security: The existing Project token and permissions are unchanged.
- Community / Local / Pro boundary: Community repository automation only.
- Backward compatibility: Lifecycle mapping and scheduled reconciliation behavior are unchanged; only event serialization changes.

## Reviewer map

- Start here: `.github/workflows/community-project-sync.yml`, then the concurrency contract in `script/github/sync-community-project.test.js`.
- Failure condition: Two different Issue or pull-request events still share one concurrency key, or manual/scheduled reconciliation no longer serializes.
- Rollback or disable path: Revert this commit to restore the repository-wide concurrency group.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex identified the cancellation pattern from live workflow runs, implemented the scoped concurrency key and test, and ran the reported verification. The maintainer retains responsibility for the workflow policy.
