### PR TITLE
fix(workspace): preserve manual Files selection

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
@@ -345,14 +345,15 @@ const WorkspaceLeft = memo(() => {
     [activeTabLocateTarget, locateActiveWorkspaceTab, setActivePanel, treeDataReady],
   );
 
+  // Manual panel selection remains authoritative until workspace-tab activation changes.
   useLayoutEffect(() => {
     if (explorerSessionActivationRef.current !== null && !isExplorerSessionActivation) {
       explorerSessionActivationRef.current = null;
     }
-    if (showExplorerPanel && autoFollowPanel && activePanel !== autoFollowPanel) {
+    if (showExplorerPanel && autoFollowPanel) {
       setActivePanel(autoFollowPanel);
     }
-  }, [activePanel, autoFollowPanel, isExplorerSessionActivation, setActivePanel, showExplorerPanel]);
+  }, [activeConsoleId, autoFollowPanel, isExplorerSessionActivation, setActivePanel, showExplorerPanel]);
 
   useEffect(() => {
     if (!pendingManualDatabaseLocateRef.current) {


### PR DESCRIPTION
## Related issue

Closes #1915

## Summary

- Preserve explicit Files/Data Browser selections by preventing the selected panel itself from retriggering Auto-follow.
- Trigger sidebar Auto-follow from workspace-tab activation changes instead of manual panel state changes.
- Retain the idempotent persisted-panel setter, Open Sessions suppression, and manual Data Browser node locating from PR #1943.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:active-tab-locator` - passed.
  - Targeted ESLint for `WorkspaceLeft/index.tsx` - passed with zero warnings.
  - `yarn lint:eslint` - passed with zero warnings.
  - `yarn build:web:community --app_version=5.3.0` - passed.
  - `git diff --check` - passed.
- Manual verification: passed in the packaged Community desktop client using the generated 5.3.1 frontend dist.
- UI evidence: maintainer confirmed that Files remains selectable and manual Data Browser selection locates the current console node.

## Risk and compatibility

- Public API or stored data: No API or data-shape change.
- Database or driver compatibility: N/A - database-independent frontend navigation only.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Community frontend only.
- Backward compatibility: Existing persisted panel state remains unchanged; same-value persistence remains a no-op.

## Reviewer map

- Start here: `WorkspaceLeft/index.tsx`, specifically the Auto-follow `useLayoutEffect` dependency list.
- Failure condition: Clicking Files while a database console is active immediately returns to Data Browser, or activating a different workspace tab no longer Auto-follows its target surface.
- Rollback or disable path: Revert `4b28d9ae`; there is no migration or external state.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex traced the merged regression to the Auto-follow effect dependency list, implemented the minimal correction, and ran the reported verification commands. The maintainer completed packaged-client runtime validation.
