### PR TITLE
fix(ai): contain long SQL preview overflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Run AI Markdown code context test
         run: yarn run test:ai-markdown-code
 
+      - name: Run AI message list scroll contract
+        run: yarn run test:ai-message-scroll
+
+      - name: Run SQL preview layout contract
+        run: yarn run test:sql-preview-layout
+
       - name: Run active workspace tab locator contract
         run: yarn run test:active-tab-locator
 

--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -29,6 +29,7 @@
     "test:i18n": "node ./scripts/validate-i18n.cjs",
     "test:active-tab-locator": "tsx src/pages/main/workspace/utils/activeTabLocator.test.ts",
     "test:ai-markdown-code": "tsx src/blocks/AI/markdownCode.test.tsx",
+    "test:ai-message-scroll": "tsx src/blocks/AI/messageListScroll.test.ts",
     "test:base-table-interaction": "tsx src/components/BaseTable/treeInteraction.test.ts",
     "test:database-object-sorting": "tsx src/blocks/NewTree/utils/sortTreeNodes.test.ts",
     "test:execution-console": "tsx src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.test.ts",

--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -35,6 +35,7 @@
     "test:redis-explorer": "tsx src/blocks/RedisAllData/redisExplorer.test.ts",
     "test:search-result-query-composer": "tsx src/blocks/SearchResult/components/ScreeningResult/queryComposer.test.ts",
     "test:search-result-tab-selection": "tsx src/blocks/SearchResult/tabSelection.test.ts",
+    "test:sql-preview-layout": "tsx src/components/SQLPreview/sqlPreviewLayout.test.ts",
     "test:sql-execution-log": "tsx src/service/sqlExecutionLog.test.ts",
     "test:sql-in-clipboard": "tsx src/utils/sqlInClipboard.test.ts",
     "modify:package:name": "node ./scripts/modify-package-name.js",

--- a/chat2db-community-client/src/blocks/AI/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/index.tsx
@@ -259,6 +259,7 @@ function MarkdownCodeBlock({ className, children }: { className?: string; childr
         language={lang}
         source="ai-markdown-sql-code-block"
         type="block"
+        wrap={false}
         renderAddons={
           onPinSql
             ? () => (

--- a/chat2db-community-client/src/blocks/AI/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/index.tsx
@@ -38,6 +38,11 @@ import AIModelConfigModal from './components/AIModelConfigModal';
 import { listAvailableModelOptions, resolveModelRequestPayload } from '@/service/aiModelConfig';
 import { isDesktop } from '@/utils/env';
 import { MarkdownPre, resolveMarkdownCode, useIsMarkdownCodeBlock } from './markdownCode';
+import {
+  resetMessageContainerHorizontalScroll,
+  scrollMessageContainerTo,
+  scrollMessageContainerToBottom,
+} from './messageListScroll';
 
 /** detects unclosed text in flowing text ```chart block, return chart and whether there are any unfinished diagrams */
 function splitIncompleteChartBlock(text: string): { textBeforeChart: string; hasIncompleteChart: boolean } {
@@ -522,7 +527,6 @@ export default function AI({ variant = 'page', onTableClick, onPinSql, onSession
   const chatInputRef = useRef<ChatInputPropsRef>(null);
   const messageListRef = useRef<HTMLDivElement>(null);
   const messageContentRef = useRef<HTMLDivElement>(null);
-  const bottomSentinelRef = useRef<HTMLDivElement>(null);
   const messageElementMapRef = useRef<Map<string, HTMLDivElement>>(new Map());
   const pendingViewportAnchorRef = useRef<string | null>(null);
   const currentRoundBlockRef = useRef<HTMLDivElement | null>(null);
@@ -562,7 +566,7 @@ export default function AI({ variant = 'page', onTableClick, onPinSql, onSession
     }
 
     lockScrollTracking('auto');
-    container.scrollTop += delta;
+    scrollMessageContainerTo(container, container.scrollTop + delta);
   }, [lockScrollTracking]);
 
   const scrollMessageToTop = useCallback((messageId: string, behavior: ScrollBehavior = 'auto') => {
@@ -573,10 +577,7 @@ export default function AI({ variant = 'page', onTableClick, onPinSql, onSession
     }
     lockScrollTracking(behavior);
     const nextScrollTop = Math.max(messageElement.offsetTop - MESSAGE_TOP_ALIGNMENT_GAP, 0);
-    container.scrollTo({
-      top: nextScrollTop,
-      behavior,
-    });
+    scrollMessageContainerTo(container, nextScrollTop, behavior);
 
     if (topAlignmentTimerRef.current !== null) {
       window.clearTimeout(topAlignmentTimerRef.current);
@@ -603,17 +604,7 @@ export default function AI({ variant = 'page', onTableClick, onPinSql, onSession
       return;
     }
     lockScrollTracking(behavior);
-    if (bottomSentinelRef.current) {
-      bottomSentinelRef.current.scrollIntoView({
-        block: 'end',
-        behavior,
-      });
-      return;
-    }
-    container.scrollTo({
-      top: container.scrollHeight,
-      behavior,
-    });
+    scrollMessageContainerToBottom(container, behavior);
   }, [lockScrollTracking]);
 
   const getMessageListContentHeight = useCallback(() => {
@@ -678,13 +669,14 @@ export default function AI({ variant = 'page', onTableClick, onPinSql, onSession
   }, []);
 
   const handleMessageListScroll = useCallback(() => {
-    if (suppressScrollTrackingRef.current) {
-      return;
-    }
     const container = messageListRef.current;
     if (!container) {
       return;
     }
+    if (suppressScrollTrackingRef.current) {
+      return;
+    }
+    resetMessageContainerHorizontalScroll(container);
     const isAtBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight <= SCROLL_BOTTOM_THRESHOLD;
     setAutoFollow(isAtBottom);
@@ -1989,7 +1981,6 @@ export default function AI({ variant = 'page', onTableClick, onPinSql, onSession
             <div className={styles.messageList} ref={messageListRef} onScroll={handleMessageListScroll}>
               <div className={styles.contentWidth} ref={messageContentRef}>
                 {renderMessages()}
-                <div ref={bottomSentinelRef} aria-hidden="true" />
               </div>
             </div>
           )}

--- a/chat2db-community-client/src/blocks/AI/messageListScroll.test.ts
+++ b/chat2db-community-client/src/blocks/AI/messageListScroll.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  resetMessageContainerHorizontalScroll,
+  scrollMessageContainerTo,
+  scrollMessageContainerToBottom,
+} from './messageListScroll';
+
+const scrollCalls: ScrollToOptions[] = [];
+const scrollOperations: string[] = [];
+let scrollLeft = 48;
+const container = {
+  scrollHeight: 1800,
+  get scrollLeft() {
+    return scrollLeft;
+  },
+  set scrollLeft(value: number) {
+    scrollLeft = value;
+    scrollOperations.push(`left:${value}`);
+  },
+  scrollTo(options: ScrollToOptions) {
+    scrollCalls.push(options);
+    scrollOperations.push(`top:${options.top}:${options.behavior}`);
+  },
+} as unknown as HTMLElement;
+
+scrollMessageContainerTo(container, 320, 'smooth');
+assert.deepEqual(scrollCalls.shift(), { top: 320, left: 0, behavior: 'smooth' });
+assert.deepEqual(scrollOperations, ['left:0', 'top:320:smooth']);
+assert.equal(container.scrollLeft, 0);
+
+scrollMessageContainerToBottom(container);
+assert.deepEqual(scrollCalls.shift(), { top: 1800, left: 0, behavior: 'auto' });
+
+container.scrollLeft = 24;
+assert.equal(resetMessageContainerHorizontalScroll(container), true);
+assert.equal(container.scrollLeft, 0);
+assert.equal(resetMessageContainerHorizontalScroll(container), false);
+
+const aiSource = readFileSync('src/blocks/AI/index.tsx', 'utf8');
+const aiStyleSource = readFileSync('src/blocks/AI/style.ts', 'utf8');
+
+assert.doesNotMatch(
+  aiSource,
+  /\.scrollIntoView\s*\(/,
+  'AI message scrolling must not move scrollable ancestors or their horizontal axes',
+);
+assert.doesNotMatch(aiSource, /\bcontainer\.scrollTo\s*\(/, 'AI scrolling must stay behind the vertical helper');
+assert.doesNotMatch(
+  aiSource,
+  /\bcontainer\.scrollTop\s*(?:\+=|-=|=)/,
+  'AI scrolling must not preserve an unknown horizontal offset through direct scrollTop writes',
+);
+assert.equal(
+  aiSource.match(/\bscrollMessageContainerTo(?:Bottom)?\(/g)?.length,
+  3,
+  'bottom follow, message anchoring, and alignment correction must all use the vertical helper',
+);
+assert.match(
+  aiSource,
+  /handleMessageListScroll[\s\S]{0,500}resetMessageContainerHorizontalScroll\(container\)/,
+  'manual or external message-list horizontal scrolling must be normalized',
+);
+assert.match(
+  aiStyleSource,
+  /main: css`[\s\S]*?overflow: hidden;[\s\S]*?overflow: clip;/,
+  'the AI root must reject programmatic overflow scrolling when the runtime supports overflow: clip',
+);
+
+console.log('AI message list scroll contract tests passed');

--- a/chat2db-community-client/src/blocks/AI/messageListScroll.ts
+++ b/chat2db-community-client/src/blocks/AI/messageListScroll.ts
@@ -1,0 +1,30 @@
+type MessageScrollTarget = Pick<HTMLElement, 'scrollLeft' | 'scrollTo'>;
+type MessageScrollContainer = Pick<HTMLElement, 'scrollHeight' | 'scrollLeft' | 'scrollTo'>;
+
+export function resetMessageContainerHorizontalScroll(container: Pick<HTMLElement, 'scrollLeft'>) {
+  if (container.scrollLeft === 0) {
+    return false;
+  }
+  container.scrollLeft = 0;
+  return true;
+}
+
+export function scrollMessageContainerTo(
+  container: MessageScrollTarget,
+  top: number,
+  behavior: ScrollBehavior = 'auto',
+) {
+  resetMessageContainerHorizontalScroll(container);
+  container.scrollTo({
+    top,
+    left: 0,
+    behavior,
+  });
+}
+
+export function scrollMessageContainerToBottom(
+  container: MessageScrollContainer,
+  behavior: ScrollBehavior = 'auto',
+) {
+  scrollMessageContainerTo(container, container.scrollHeight, behavior);
+}

--- a/chat2db-community-client/src/blocks/AI/style.ts
+++ b/chat2db-community-client/src/blocks/AI/style.ts
@@ -9,6 +9,7 @@ export const useStyles = createStyles(({ css, token, prefixCls }) => {
       min-width: 0;
       display: flex;
       flex-direction: column;
+      overflow: hidden;
       background-color: ${token.colorBgLayout};
     `,
 
@@ -142,25 +143,35 @@ export const useStyles = createStyles(({ css, token, prefixCls }) => {
 
     chatPanel: css`
       flex: 1;
+      width: 100%;
+      min-width: 0;
       min-height: 0;
       display: flex;
       flex-direction: column;
+      overflow: hidden;
       padding: 0 0 10px;
     `,
 
     chatPanelCenter: css`
       flex: 1;
+      width: 100%;
+      min-width: 0;
       min-height: 0;
       display: flex;
       flex-direction: column;
       justify-content: center;
+      overflow: hidden;
       padding: 0 0 14px;
     `,
 
     messageList: css`
       flex: 1;
+      width: 100%;
+      min-width: 0;
       min-height: 0;
-      overflow: auto;
+      overflow-x: hidden;
+      overflow-y: auto;
+      box-sizing: border-box;
       padding: 14px 0 10px;
     `,
 

--- a/chat2db-community-client/src/blocks/AI/style.ts
+++ b/chat2db-community-client/src/blocks/AI/style.ts
@@ -10,6 +10,7 @@ export const useStyles = createStyles(({ css, token, prefixCls }) => {
       display: flex;
       flex-direction: column;
       overflow: hidden;
+      overflow: clip;
       background-color: ${token.colorBgLayout};
     `,
 

--- a/chat2db-community-client/src/components/SQLPreview/index.tsx
+++ b/chat2db-community-client/src/components/SQLPreview/index.tsx
@@ -36,7 +36,7 @@ const SQLPreview = memo<SQLPreviewProps>((props) => {
     wrap = true,
     renderAddons,
   } = props;
-  const { styles, cx } = useStyles();
+  const { styles, cx } = useStyles({ wrap });
 
   const wrapperStyle = useMemo<CSSProperties>(
     () => ({
@@ -52,6 +52,7 @@ const SQLPreview = memo<SQLPreviewProps>((props) => {
       style={wrapperStyle}
       data-sql-preview="canonical"
       data-sql-preview-source={source}
+      data-sql-preview-wrap={wrap ? 'wrap' : 'scroll'}
     >
       <CodeHighlighter
         className={cx(styles.highlighter, surface === 'transparent' && styles.transparentHighlighter)}

--- a/chat2db-community-client/src/components/SQLPreview/sqlPreviewLayout.test.ts
+++ b/chat2db-community-client/src/components/SQLPreview/sqlPreviewLayout.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 const previewSource = readFileSync('src/components/SQLPreview/index.tsx', 'utf8');
 const styleSource = readFileSync('src/components/SQLPreview/style.ts', 'utf8');
 const aiSource = readFileSync('src/blocks/AI/index.tsx', 'utf8');
+const aiStyleSource = readFileSync('src/blocks/AI/style.ts', 'utf8');
 
 assert.match(previewSource, /useStyles\(\{ wrap \}\)/, 'SQLPreview must apply its wrap mode to local styles');
 assert.match(
@@ -30,6 +31,16 @@ assert.match(
   aiSource,
   /source="ai-markdown-sql-code-block"[\s\S]*?type="block"[\s\S]*?wrap=\{false\}/,
   'AI SQL fences must use the contained horizontal-scroll layout',
+);
+assert.match(
+  aiStyleSource,
+  /messageList: css`[\s\S]*?overflow-x: hidden;[\s\S]*?overflow-y: auto;/,
+  'the message list must scroll vertically without shifting the whole conversation horizontally',
+);
+assert.match(
+  aiStyleSource,
+  /chatPanel: css`[\s\S]*?min-width: 0;[\s\S]*?overflow: hidden;/,
+  'the chat panel must contain descendant intrinsic widths',
 );
 
 console.log('SQLPreview layout contract tests passed');

--- a/chat2db-community-client/src/components/SQLPreview/sqlPreviewLayout.test.ts
+++ b/chat2db-community-client/src/components/SQLPreview/sqlPreviewLayout.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const previewSource = readFileSync('src/components/SQLPreview/index.tsx', 'utf8');
+const styleSource = readFileSync('src/components/SQLPreview/style.ts', 'utf8');
+const aiSource = readFileSync('src/blocks/AI/index.tsx', 'utf8');
+
+assert.match(previewSource, /useStyles\(\{ wrap \}\)/, 'SQLPreview must apply its wrap mode to local styles');
+assert.match(
+  previewSource,
+  /data-sql-preview-wrap=\{wrap \? 'wrap' : 'scroll'\}/,
+  'SQLPreview must expose its active layout mode for desktop diagnostics',
+);
+
+assert.match(styleSource, /max-width: 100%;[\s\S]*min-width: 0;/, 'SQLPreview must stay within its parent width');
+assert.match(styleSource, /overflow-x: hidden;/, 'the SQLPreview wrapper must contain horizontal overflow');
+assert.match(styleSource, /pre \{[\s\S]*overflow-x: auto;/, 'the pre element must own horizontal scrolling');
+assert.match(
+  styleSource,
+  /&& pre code \{[\s\S]*width: \$\{wrap \? '100%' : 'max-content'\};/,
+  'unwrapped SQL must preserve its intrinsic width inside the scrolling pre element',
+);
+assert.match(
+  styleSource,
+  /white-space: \$\{wrap \? 'pre-wrap' : 'pre'\};/,
+  'wrap must switch between wrapped and single-line SQL rendering',
+);
+
+assert.match(
+  aiSource,
+  /source="ai-markdown-sql-code-block"[\s\S]*?type="block"[\s\S]*?wrap=\{false\}/,
+  'AI SQL fences must use the contained horizontal-scroll layout',
+);
+
+console.log('SQLPreview layout contract tests passed');

--- a/chat2db-community-client/src/components/SQLPreview/style.ts
+++ b/chat2db-community-client/src/components/SQLPreview/style.ts
@@ -1,19 +1,42 @@
 import { createStyles } from 'antd-style';
 
-export const useStyles = createStyles(({ css }) => {
+export const useStyles = createStyles(({ css }, { wrap }: { wrap: boolean }) => {
   return {
     sqlPreview: css`
       width: 100%;
+      max-width: 100%;
       min-width: 0;
       position: relative;
-      overflow: auto;
+      overflow-x: hidden;
+      overflow-y: auto;
       box-sizing: border-box;
     `,
     highlighter: css`
       width: 100%;
+      max-width: 100%;
+      min-width: 0;
+      overflow: hidden;
+      box-sizing: border-box;
 
       pre {
         margin: 0;
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+        overflow-x: auto;
+        overflow-y: hidden;
+        box-sizing: border-box;
+      }
+
+      && pre code {
+        display: block;
+        width: ${wrap ? '100%' : 'max-content'};
+        max-width: ${wrap ? '100%' : 'none'};
+        min-width: ${wrap ? '0' : '100%'};
+        overflow: visible;
+        white-space: ${wrap ? 'pre-wrap' : 'pre'};
+        overflow-wrap: ${wrap ? 'anywhere' : 'normal'};
+        word-break: ${wrap ? 'break-word' : 'normal'};
       }
     `,
     transparentHighlighter: css`


### PR DESCRIPTION
## Related issue

Closes #1905

## Summary

The earlier Markdown and `SQLPreview` containment fixes were necessary but did not explain the packaged JCEF symptom where the entire conversation shifted horizontally. Exact `sql` fences still require the local `SQLPreview` override because `@chat2db/ui` 1.45.3 ignores `wrap` and preserves intrinsic-width highlighted code.

The remaining cross-boundary path was AI bottom-follow: a sentinel called `scrollIntoView()`. That API considers the inline axis and every scrollable ancestor, while `overflow: hidden` containers remain programmatically scrollable. A long SQL response could therefore leave the SQL preview correctly contained yet still move the message list or an outer hidden scroller horizontally.

This revision removes the sentinel and centralizes bottom-follow, message anchoring, and alignment correction on the message-list element through `scrollTo({ top, left: 0 })`. Existing horizontal offset is reset before smooth vertical movement, unexpected manual offsets are normalized, and the AI root uses `overflow: clip` with `overflow: hidden` as the compatibility fallback. The SQLPreview containment and local highlighter override remain in place because they solve the separate intrinsic-width leak.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:ai-message-scroll` - passed; forbids AI-page `scrollIntoView`, direct message-container `scrollTo` and direct `scrollTop` writes, and locks all three automatic paths to the vertical helper.
  - `yarn test:ai-markdown-code` - passed.
  - `yarn test:sql-preview-layout` - passed.
  - Targeted ESLint for the AI and SQLPreview changed/test files with `--max-warnings=0` - passed.
  - CI workflow YAML parse - passed.
  - `git diff --check` - passed.
  - `yarn build:web:community --app_version=5.3.1` - passed twice, with a final rebuild after the independent review adjustment; Webpack compiled successfully.
  - Knowledge lint - passed.
- Artifact verification:
  - The final bundle contains Community version `5.3.1`, `ai-markdown-sql-code-block`, and the `overflow: clip` guard.
  - Replacement `dist.zip` uses the release-script-compatible single `dist/` root and passes `unzip -t`.
  - Replacement `dist.zip` SHA-256: `e1620a41cbb26bab55231072bc07dec78c0cb3b311a631202f19912adb1d6383`.
- UI evidence: Packaged JCEF retests showed that the first SQLPreview-only revision and the second CSS message-list-boundary revision were incomplete. The replacement artifact containing the axis-scoped auto-scroll fix is pending packaged JCEF runtime retest.

## Risk and compatibility

- Public API or stored data: N/A; no API or persistence changes.
- Database or driver compatibility: N/A; rendering-only change.
- Network, privacy, or security: N/A; no network or data-flow changes.
- Community / Local / Pro boundary: Community frontend only.
- Backward compatibility: Existing `SQLPreview` callers keep the same props and defaults. AI smooth vertical positioning is preserved, but horizontal offset is now always zeroed before it begins.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/AI/messageListScroll.ts`, then the three call sites in `src/blocks/AI/index.tsx`. Review `src/components/SQLPreview/style.ts` separately for the intrinsic-width containment layer.
- Failure condition: AI automatic following moves any scrollable ancestor horizontally; any of the three message viewport paths bypasses the helper; or a long SQL line widens the assistant/page instead of scrolling inside `SQLPreview`.
- Rollback or disable path: Revert the three commits in this PR; no migration or cleanup is required.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex performed the multi-frame root-cause analysis, traced the SQL/highlighter and message-scroll paths, implemented the scoped SQL containment and axis-scoped scrolling changes, added the regression contracts, and ran the reported checks. The maintainer supplied and reviewed the packaged desktop failures.
