### PR TITLE
fix: respect manual workspace panel selection

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
@@ -138,8 +138,6 @@ const WorkspaceLeft = memo(() => {
   const explorerRef = useRef<WorkspaceExplorerRef>(null);
   const locateRequestSeqRef = useRef(0);
   const explorerSessionActivationRef = useRef<string | number | null>(null);
-  const lastAutoFollowTabIdRef = useRef<string | number | null>(null);
-  const manualPanelOverrideRef = useRef(false);
   const pendingManualDatabaseLocateRef = useRef(false);
   const shouldProbeDesktopBridge = !isWebEnv && (isDesktopEnv || isCommunityEnv || isDesktop);
   const [desktopBridgeReady, setDesktopBridgeReady] = useState(() => isDesktop || hasDesktopBridge());
@@ -149,10 +147,18 @@ const WorkspaceLeft = memo(() => {
     activeConsoleId: state.activeConsoleId,
     workspaceTabList: state.workspaceTabList,
   }));
-  const { changeUserConfigTree, treeDataReady, userConfigTree } = useTreeStore((state) => ({
+  const {
+    changeUserConfigTree,
+    setWorkspaceLeftPanelManualOverrideTabId,
+    treeDataReady,
+    userConfigTree,
+    workspaceLeftPanelManualOverrideTabId,
+  } = useTreeStore((state) => ({
     changeUserConfigTree: state.changeUserConfigTree,
+    setWorkspaceLeftPanelManualOverrideTabId: state.setWorkspaceLeftPanelManualOverrideTabId,
     treeDataReady: !!state.treeData,
     userConfigTree: state.userConfigTree,
+    workspaceLeftPanelManualOverrideTabId: state.workspaceLeftPanelManualOverrideTabId,
   }));
   const activePanel = resolveWorkspaceLeftPanel(userConfigTree.workspaceLeftPanel);
   const currentPanel = showExplorerPanel ? activePanel : 'database';
@@ -355,7 +361,7 @@ const WorkspaceLeft = memo(() => {
 
   const handlePanelSelection = useCallback(
     (panel: WorkspaceLeftPanel) => {
-      manualPanelOverrideRef.current = true;
+      setWorkspaceLeftPanelManualOverrideTabId(activeConsoleId ?? null);
       setActivePanel(panel);
       const shouldLocate = shouldLocateActiveTabOnPanelSelection(panel, activeTabLocateTarget);
       pendingManualDatabaseLocateRef.current = shouldLocate && !treeDataReady;
@@ -363,7 +369,14 @@ const WorkspaceLeft = memo(() => {
         void locateActiveWorkspaceTab({ clearSearch: true });
       }
     },
-    [activeTabLocateTarget, locateActiveWorkspaceTab, setActivePanel, treeDataReady],
+    [
+      activeConsoleId,
+      activeTabLocateTarget,
+      locateActiveWorkspaceTab,
+      setActivePanel,
+      setWorkspaceLeftPanelManualOverrideTabId,
+      treeDataReady,
+    ],
   );
 
   useLayoutEffect(() => {
@@ -373,16 +386,24 @@ const WorkspaceLeft = memo(() => {
     const autoFollowState = resolveWorkspaceLeftAutoFollowState({
       activeWorkspaceTabId: activeConsoleId,
       autoFollowPanel,
-      lastAutoFollowTabId: lastAutoFollowTabIdRef.current,
-      manualOverride: manualPanelOverrideRef.current,
+      manualOverrideTabId: workspaceLeftPanelManualOverrideTabId,
       showExplorerPanel,
     });
-    lastAutoFollowTabIdRef.current = autoFollowState.activeWorkspaceTabId;
-    manualPanelOverrideRef.current = autoFollowState.manualOverride;
+    if (autoFollowState.manualOverrideTabId !== workspaceLeftPanelManualOverrideTabId) {
+      setWorkspaceLeftPanelManualOverrideTabId(autoFollowState.manualOverrideTabId);
+    }
     if (autoFollowState.shouldApplyAutoFollow && autoFollowPanel) {
       setActivePanel(autoFollowPanel);
     }
-  }, [activeConsoleId, autoFollowPanel, isExplorerSessionActivation, setActivePanel, showExplorerPanel]);
+  }, [
+    activeConsoleId,
+    autoFollowPanel,
+    isExplorerSessionActivation,
+    setActivePanel,
+    setWorkspaceLeftPanelManualOverrideTabId,
+    showExplorerPanel,
+    workspaceLeftPanelManualOverrideTabId,
+  ]);
 
   useEffect(() => {
     if (!pendingManualDatabaseLocateRef.current) {

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
@@ -14,6 +14,7 @@ import {
   getAutoFollowWorkspaceLeftPanel,
   getActiveTabLocateTarget,
   resolveWorkspaceLeftPanel,
+  resolveWorkspaceLeftAutoFollowState,
   shouldLocateActiveTabOnPanelSelection,
   type ActiveTabDatabaseCandidate,
   type ActiveTabLocateTarget,
@@ -137,6 +138,8 @@ const WorkspaceLeft = memo(() => {
   const explorerRef = useRef<WorkspaceExplorerRef>(null);
   const locateRequestSeqRef = useRef(0);
   const explorerSessionActivationRef = useRef<string | number | null>(null);
+  const lastAutoFollowTabIdRef = useRef<string | number | null>(null);
+  const manualPanelOverrideRef = useRef(false);
   const pendingManualDatabaseLocateRef = useRef(false);
   const shouldProbeDesktopBridge = !isWebEnv && (isDesktopEnv || isCommunityEnv || isDesktop);
   const [desktopBridgeReady, setDesktopBridgeReady] = useState(() => isDesktop || hasDesktopBridge());
@@ -335,6 +338,7 @@ const WorkspaceLeft = memo(() => {
 
   const handlePanelSelection = useCallback(
     (panel: WorkspaceLeftPanel) => {
+      manualPanelOverrideRef.current = true;
       setActivePanel(panel);
       const shouldLocate = shouldLocateActiveTabOnPanelSelection(panel, activeTabLocateTarget);
       pendingManualDatabaseLocateRef.current = shouldLocate && !treeDataReady;
@@ -350,7 +354,16 @@ const WorkspaceLeft = memo(() => {
     if (explorerSessionActivationRef.current !== null && !isExplorerSessionActivation) {
       explorerSessionActivationRef.current = null;
     }
-    if (showExplorerPanel && autoFollowPanel) {
+    const autoFollowState = resolveWorkspaceLeftAutoFollowState({
+      activeWorkspaceTabId: activeConsoleId,
+      autoFollowPanel,
+      lastAutoFollowTabId: lastAutoFollowTabIdRef.current,
+      manualOverride: manualPanelOverrideRef.current,
+      showExplorerPanel,
+    });
+    lastAutoFollowTabIdRef.current = autoFollowState.activeWorkspaceTabId;
+    manualPanelOverrideRef.current = autoFollowState.manualOverride;
+    if (autoFollowState.shouldApplyAutoFollow && autoFollowPanel) {
       setActivePanel(autoFollowPanel);
     }
   }, [activeConsoleId, autoFollowPanel, isExplorerSessionActivation, setActivePanel, showExplorerPanel]);

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
@@ -55,13 +55,12 @@ assert.deepEqual(
   resolveWorkspaceLeftAutoFollowState({
     activeWorkspaceTabId: 101,
     autoFollowPanel: 'database',
-    lastAutoFollowTabId: null,
-    manualOverride: false,
+    manualOverrideTabId: null,
     showExplorerPanel: true,
   }),
   {
     activeWorkspaceTabId: 101,
-    manualOverride: false,
+    manualOverrideTabId: null,
     shouldApplyAutoFollow: true,
   },
 );
@@ -69,13 +68,12 @@ assert.deepEqual(
   resolveWorkspaceLeftAutoFollowState({
     activeWorkspaceTabId: 101,
     autoFollowPanel: 'database',
-    lastAutoFollowTabId: 101,
-    manualOverride: true,
+    manualOverrideTabId: 101,
     showExplorerPanel: true,
   }),
   {
     activeWorkspaceTabId: 101,
-    manualOverride: true,
+    manualOverrideTabId: 101,
     shouldApplyAutoFollow: false,
   },
 );
@@ -83,13 +81,12 @@ assert.deepEqual(
   resolveWorkspaceLeftAutoFollowState({
     activeWorkspaceTabId: 102,
     autoFollowPanel: 'database',
-    lastAutoFollowTabId: 101,
-    manualOverride: true,
+    manualOverrideTabId: 101,
     showExplorerPanel: true,
   }),
   {
     activeWorkspaceTabId: 102,
-    manualOverride: false,
+    manualOverrideTabId: null,
     shouldApplyAutoFollow: true,
   },
 );
@@ -97,13 +94,12 @@ assert.deepEqual(
   resolveWorkspaceLeftAutoFollowState({
     activeWorkspaceTabId: 102,
     autoFollowPanel: 'database',
-    lastAutoFollowTabId: 102,
-    manualOverride: false,
+    manualOverrideTabId: null,
     showExplorerPanel: false,
   }),
   {
     activeWorkspaceTabId: 102,
-    manualOverride: false,
+    manualOverrideTabId: null,
     shouldApplyAutoFollow: false,
   },
 );

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
@@ -4,6 +4,7 @@ import type { IWorkspaceTab } from '@/typings';
 import {
   getAutoFollowWorkspaceLeftPanel,
   getDirectActiveTabLocateTarget,
+  resolveWorkspaceLeftAutoFollowState,
   resolveWorkspaceLeftPanel,
   shouldLocateActiveTabOnPanelSelection,
 } from './activeTabTarget';
@@ -49,5 +50,62 @@ assert.equal(getAutoFollowWorkspaceLeftPanel(false, { surface: 'databaseTree' })
 assert.equal(shouldLocateActiveTabOnPanelSelection('database', { surface: 'databaseTree' }), true);
 assert.equal(shouldLocateActiveTabOnPanelSelection('explorer', { surface: 'databaseTree' }), false);
 assert.equal(shouldLocateActiveTabOnPanelSelection('database', { surface: 'localFile' }), false);
+
+assert.deepEqual(
+  resolveWorkspaceLeftAutoFollowState({
+    activeWorkspaceTabId: 101,
+    autoFollowPanel: 'database',
+    lastAutoFollowTabId: null,
+    manualOverride: false,
+    showExplorerPanel: true,
+  }),
+  {
+    activeWorkspaceTabId: 101,
+    manualOverride: false,
+    shouldApplyAutoFollow: true,
+  },
+);
+assert.deepEqual(
+  resolveWorkspaceLeftAutoFollowState({
+    activeWorkspaceTabId: 101,
+    autoFollowPanel: 'database',
+    lastAutoFollowTabId: 101,
+    manualOverride: true,
+    showExplorerPanel: true,
+  }),
+  {
+    activeWorkspaceTabId: 101,
+    manualOverride: true,
+    shouldApplyAutoFollow: false,
+  },
+);
+assert.deepEqual(
+  resolveWorkspaceLeftAutoFollowState({
+    activeWorkspaceTabId: 102,
+    autoFollowPanel: 'database',
+    lastAutoFollowTabId: 101,
+    manualOverride: true,
+    showExplorerPanel: true,
+  }),
+  {
+    activeWorkspaceTabId: 102,
+    manualOverride: false,
+    shouldApplyAutoFollow: true,
+  },
+);
+assert.deepEqual(
+  resolveWorkspaceLeftAutoFollowState({
+    activeWorkspaceTabId: 102,
+    autoFollowPanel: 'database',
+    lastAutoFollowTabId: 102,
+    manualOverride: false,
+    showExplorerPanel: false,
+  }),
+  {
+    activeWorkspaceTabId: 102,
+    manualOverride: false,
+    shouldApplyAutoFollow: false,
+  },
+);
 
 console.log('Active workspace tab locator tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
@@ -5,6 +5,7 @@ import { getDirectActiveTabLocateTarget } from './activeTabTarget';
 
 export {
   getAutoFollowWorkspaceLeftPanel,
+  resolveWorkspaceLeftAutoFollowState,
   resolveWorkspaceLeftPanel,
   shouldLocateActiveTabOnPanelSelection,
   type WorkspaceTabActivationSource,

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
@@ -3,6 +3,7 @@ import type { IWorkspaceTab } from '@/typings/workspace';
 
 export type WorkspaceLeftPanel = 'explorer' | 'database';
 export type WorkspaceTabActivationSource = 'workspaceTab' | 'explorerSession';
+export type WorkspaceTabActivationId = string | number | null | undefined;
 
 export type DirectActiveTabLocateTarget =
   | {
@@ -33,6 +34,30 @@ export function shouldLocateActiveTabOnPanelSelection(
   target?: Pick<DirectActiveTabLocateTarget, 'surface'> | null,
 ): boolean {
   return panel === 'database' && target?.surface === 'databaseTree';
+}
+
+export function resolveWorkspaceLeftAutoFollowState({
+  activeWorkspaceTabId,
+  autoFollowPanel,
+  lastAutoFollowTabId,
+  manualOverride,
+  showExplorerPanel,
+}: {
+  activeWorkspaceTabId: WorkspaceTabActivationId;
+  autoFollowPanel?: WorkspaceLeftPanel;
+  lastAutoFollowTabId: WorkspaceTabActivationId;
+  manualOverride: boolean;
+  showExplorerPanel: boolean;
+}) {
+  const normalizedActiveTabId = activeWorkspaceTabId ?? null;
+  const normalizedLastTabId = lastAutoFollowTabId ?? null;
+  const nextManualOverride = normalizedActiveTabId === normalizedLastTabId ? manualOverride : false;
+
+  return {
+    activeWorkspaceTabId: normalizedActiveTabId,
+    manualOverride: nextManualOverride,
+    shouldApplyAutoFollow: showExplorerPanel && !!autoFollowPanel && !nextManualOverride,
+  };
 }
 
 export function getDirectActiveTabLocateTarget(

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
@@ -39,24 +39,23 @@ export function shouldLocateActiveTabOnPanelSelection(
 export function resolveWorkspaceLeftAutoFollowState({
   activeWorkspaceTabId,
   autoFollowPanel,
-  lastAutoFollowTabId,
-  manualOverride,
+  manualOverrideTabId,
   showExplorerPanel,
 }: {
   activeWorkspaceTabId: WorkspaceTabActivationId;
   autoFollowPanel?: WorkspaceLeftPanel;
-  lastAutoFollowTabId: WorkspaceTabActivationId;
-  manualOverride: boolean;
+  manualOverrideTabId: WorkspaceTabActivationId;
   showExplorerPanel: boolean;
 }) {
   const normalizedActiveTabId = activeWorkspaceTabId ?? null;
-  const normalizedLastTabId = lastAutoFollowTabId ?? null;
-  const nextManualOverride = normalizedActiveTabId === normalizedLastTabId ? manualOverride : false;
+  const normalizedManualOverrideTabId = manualOverrideTabId ?? null;
+  const nextManualOverrideTabId =
+    normalizedActiveTabId === normalizedManualOverrideTabId ? normalizedManualOverrideTabId : null;
 
   return {
     activeWorkspaceTabId: normalizedActiveTabId,
-    manualOverride: nextManualOverride,
-    shouldApplyAutoFollow: showExplorerPanel && !!autoFollowPanel && !nextManualOverride,
+    manualOverrideTabId: nextManualOverrideTabId,
+    shouldApplyAutoFollow: showExplorerPanel && !!autoFollowPanel && nextManualOverrideTabId === null,
   };
 }
 

--- a/chat2db-community-client/src/store/tree/index.tsx
+++ b/chat2db-community-client/src/store/tree/index.tsx
@@ -54,6 +54,7 @@ export interface TreeState {
   searchResultKeys: string[] | null;
   searchResult: TreeNodeData[] | null;
   userConfigTree: IUserConfigTree;
+  workspaceLeftPanelManualOverrideTabId: string | number | null;
   // Hidden node id
   hiddenTreeNodeIds: {
     [key: string]: string[];
@@ -81,6 +82,7 @@ export const initTreeState = {
   searchResult: null,
   currentLoadingTreeNode: null,
   userConfigTree: initUserConfigTree,
+  workspaceLeftPanelManualOverrideTabId: null,
   // Hidden node id
   hiddenTreeNodeIds: null,
 };
@@ -119,6 +121,7 @@ export interface TreeAction {
   deleteAiDataCollectionElement: (treeNodeData: TreeNodeData, handleLoadData: any) => Promise<void>;
   refreshAiDataCollection: (dataSourceId: number) => void;
   changeUserConfigTree: (type: string, value: any) => void;
+  setWorkspaceLeftPanelManualOverrideTabId: (tabId: TreeState['workspaceLeftPanelManualOverrideTabId']) => void;
   // Update node data through key
   updateTreeNodeDataByKey: (key: React.Key, getTreeNodeKeyParams?: GetTreeNodeKeyParams) => void;
   // Refresh data with details
@@ -562,6 +565,9 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
         },
       };
     });
+  },
+  setWorkspaceLeftPanelManualOverrideTabId: (workspaceLeftPanelManualOverrideTabId) => {
+    set({ workspaceLeftPanelManualOverrideTabId });
   },
   updateTreeNodeDataByKey: (key, getTreeNodeKeyParams) => {
     const newTreeData = get().treeData;


### PR DESCRIPTION
## Summary
- Preserve manual Workspace left panel selection within the current active workspace tab.
- Clear the manual override only when active workspace tab activation changes, so auto-follow can apply on the next tab.
- Add regression coverage for auto-follow state transitions.

## Test Plan
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn install --frozen-lockfile`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn run test:active-tab-locator`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn run lint`
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn run build:web:community --app_version=0.0.0`
- `git diff --check`
