### PR TITLE
fix(workspace): keep left panel selection manual

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExplorer/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExplorer/index.tsx
@@ -21,7 +21,6 @@ type SearchBarHandle = { focus: () => void; blur: () => void };
 
 interface WorkspaceExplorerProps {
   active?: boolean;
-  onSessionActivate?: (sessionId: IWorkspaceTab['id']) => void;
 }
 
 export interface WorkspaceExplorerRef {
@@ -30,7 +29,7 @@ export interface WorkspaceExplorerRef {
 
 const WorkspaceExplorer = memo(
   forwardRef<WorkspaceExplorerRef, WorkspaceExplorerProps>((
-    { active = true, onSessionActivate },
+    { active = true },
     ref,
   ) => {
   const { styles } = useStyles();
@@ -85,8 +84,16 @@ const WorkspaceExplorer = memo(
   }, [openSessions, trimmedSearchKeyword]);
 
   useEffect(() => {
+    if (!active) {
+      return;
+    }
     const activeRow = activeSessionRowRef.current;
     if (!activeRow) {
+      const activeSessionIsFiltered =
+        !!trimmedSearchKeyword && openSessions.some((session) => session.id === activeConsoleId);
+      if (activeSessionIsFiltered) {
+        setSearchKeyword('');
+      }
       return;
     }
 
@@ -97,7 +104,7 @@ const WorkspaceExplorer = memo(
         activeRow.scrollIntoView(false);
       }
     });
-  }, [activeConsoleId, filteredOpenSessions.length, sessionPanelHeight]);
+  }, [active, activeConsoleId, filteredOpenSessions.length, openSessions, sessionPanelHeight, trimmedSearchKeyword]);
 
   useImperativeHandle(
     ref,
@@ -153,7 +160,6 @@ const WorkspaceExplorer = memo(
   }
 
   function handleSessionDragStart(event: React.DragEvent<HTMLButtonElement>, session: IWorkspaceTab) {
-    onSessionActivate?.(session.id);
     setActiveConsoleId(session.id);
     const payload = {
       id: session.id,
@@ -251,7 +257,6 @@ const WorkspaceExplorer = memo(
                 onDragStart={(event) => handleSessionDragStart(event, session)}
                 onClick={(event) => {
                   event.stopPropagation();
-                  onSessionActivate?.(session.id);
                   setActiveConsoleId(session.id);
                 }}
               >

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx
@@ -9,13 +9,11 @@ import type { TreeNodeData } from '@/typings';
 import { isCommunityEnv, isDesktop, isDesktopEnv, isWebEnv } from '@/utils/env';
 import feedback from '@/utils/feedback';
 import { Flex } from 'antd';
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type Key } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type Key } from 'react';
 import {
-  getAutoFollowWorkspaceLeftPanel,
-  getActiveTabLocateTarget,
+  getActiveTabLocateTargetForPanel,
+  getActiveTabLocateTargets,
   resolveWorkspaceLeftPanel,
-  resolveWorkspaceLeftAutoFollowState,
-  shouldLocateActiveTabOnPanelSelection,
   type ActiveTabDatabaseCandidate,
   type ActiveTabLocateTarget,
   type WorkspaceLeftPanel,
@@ -32,11 +30,6 @@ interface LocatedTreeNode {
   ancestors: Key[];
   fallback?: boolean;
 }
-
-const waitNextFrame = () =>
-  new Promise<void>((resolve) => {
-    window.requestAnimationFrame(() => resolve());
-  });
 
 function hasDesktopBridge() {
   return typeof window.javaQuery === 'function';
@@ -137,8 +130,7 @@ function findDatabaseLocateNode(treeData: TreeNodeData[] | null | undefined, can
 const WorkspaceLeft = memo(() => {
   const explorerRef = useRef<WorkspaceExplorerRef>(null);
   const locateRequestSeqRef = useRef(0);
-  const explorerSessionActivationRef = useRef<string | number | null>(null);
-  const pendingManualDatabaseLocateRef = useRef(false);
+  const pendingManualPanelLocateRef = useRef<WorkspaceLeftPanel | null>(null);
   const shouldProbeDesktopBridge = !isWebEnv && (isDesktopEnv || isCommunityEnv || isDesktop);
   const [desktopBridgeReady, setDesktopBridgeReady] = useState(() => isDesktop || hasDesktopBridge());
   const { styles } = useStyles();
@@ -147,18 +139,10 @@ const WorkspaceLeft = memo(() => {
     activeConsoleId: state.activeConsoleId,
     workspaceTabList: state.workspaceTabList,
   }));
-  const {
-    changeUserConfigTree,
-    setWorkspaceLeftPanelManualOverrideTabId,
-    treeDataReady,
-    userConfigTree,
-    workspaceLeftPanelManualOverrideTabId,
-  } = useTreeStore((state) => ({
+  const { changeUserConfigTree, treeDataReady, userConfigTree } = useTreeStore((state) => ({
     changeUserConfigTree: state.changeUserConfigTree,
-    setWorkspaceLeftPanelManualOverrideTabId: state.setWorkspaceLeftPanelManualOverrideTabId,
     treeDataReady: !!state.treeData,
     userConfigTree: state.userConfigTree,
-    workspaceLeftPanelManualOverrideTabId: state.workspaceLeftPanelManualOverrideTabId,
   }));
   const activePanel = resolveWorkspaceLeftPanel(userConfigTree.workspaceLeftPanel);
   const currentPanel = showExplorerPanel ? activePanel : 'database';
@@ -175,20 +159,14 @@ const WorkspaceLeft = memo(() => {
     () => workspaceTabList?.find((tab) => tab.id === activeConsoleId),
     [activeConsoleId, workspaceTabList],
   );
-  const activeTabLocateTarget = useMemo(() => getActiveTabLocateTarget(activeTab), [activeTab]);
+  const activeTabLocateTargets = useMemo(() => getActiveTabLocateTargets(activeTab), [activeTab]);
+  const activeTabLocateTarget = getActiveTabLocateTargetForPanel(activeTabLocateTargets, currentPanel);
   const autoFollowActiveWorkspaceTab = userConfigTree.followActiveWorkspaceTab !== false;
-  const isExplorerSessionActivation = explorerSessionActivationRef.current === activeConsoleId;
-  const autoFollowPanel = getAutoFollowWorkspaceLeftPanel(
-    autoFollowActiveWorkspaceTab,
-    activeTabLocateTarget,
-    isExplorerSessionActivation ? 'explorerSession' : 'workspaceTab',
-  );
   const panelOptions: Array<{ label: string; value: WorkspaceLeftPanel }> = [
     { label: i18n('workspace.explorer.title'), value: 'explorer' },
     { label: i18n('workspace.explorer.databases'), value: 'database' },
   ];
-  const locateDisabled =
-    !activeTabLocateTarget || (!showExplorerPanel && activeTabLocateTarget.surface === 'localFile');
+  const locateDisabled = !activeTabLocateTarget;
 
   useEffect(() => {
     if (!shouldProbeDesktopBridge || desktopBridgeReady) {
@@ -279,15 +257,6 @@ const WorkspaceLeft = memo(() => {
         return 'miss';
       }
 
-      if (showExplorerPanel) {
-        setActivePanel('database');
-        await waitNextFrame();
-      }
-
-      if (options?.requestSeq !== undefined && options.requestSeq !== locateRequestSeqRef.current) {
-        return 'miss';
-      }
-
       const treeStore = useTreeStore.getState();
       const previousSelection = {
         currentTreeNode: treeStore.currentTreeNode,
@@ -318,34 +287,33 @@ const WorkspaceLeft = memo(() => {
       selectDatabaseTreeNode(result, { clearSearch: options?.clearSearch });
       return result.fallback ? 'fallback' : 'hit';
     },
-    [loadDatabasePath, selectDatabaseTreeNode, setActivePanel, showExplorerPanel],
+    [loadDatabasePath, selectDatabaseTreeNode],
   );
 
   const locateActiveWorkspaceTab = useCallback(
-    async (options?: { clearSearch?: boolean }): Promise<LocateStatus> => {
+    async (panel: WorkspaceLeftPanel = currentPanel, options?: { clearSearch?: boolean }): Promise<LocateStatus> => {
       const requestSeq = locateRequestSeqRef.current + 1;
       locateRequestSeqRef.current = requestSeq;
-      const target = activeTabLocateTarget;
+      const target = getActiveTabLocateTargetForPanel(activeTabLocateTargets, panel);
       if (!target) {
         return 'miss';
       }
 
+      if (target.surface === 'explorerSession') {
+        return target.sessionId === activeConsoleId ? 'hit' : 'miss';
+      }
+
       if (target.surface === 'localFile') {
-        if (!showExplorerPanel) {
-          return 'miss';
-        }
-        setActivePanel('explorer');
-        await waitNextFrame();
         return explorerRef.current?.locateLocalFile(target.filePath) ? 'hit' : 'miss';
       }
 
       return locateDatabaseTree(target, { ...options, requestSeq });
     },
-    [activeTabLocateTarget, locateDatabaseTree, setActivePanel, showExplorerPanel],
+    [activeConsoleId, activeTabLocateTargets, currentPanel, locateDatabaseTree],
   );
 
   const handleLocateActiveWorkspaceTab = useCallback(() => {
-    void locateActiveWorkspaceTab({ clearSearch: true }).then((status) => {
+    void locateActiveWorkspaceTab(currentPanel, { clearSearch: true }).then((status) => {
       if (status === 'miss') {
         feedback.warning(i18n('workspace.tips.locateActiveTabFailed'));
       }
@@ -353,103 +321,54 @@ const WorkspaceLeft = memo(() => {
         feedback.info(i18n('workspace.tips.locateActiveTabFallback'));
       }
     });
-  }, [locateActiveWorkspaceTab]);
-
-  const handleExplorerSessionActivate = useCallback((sessionId: string | number) => {
-    explorerSessionActivationRef.current = sessionId;
-  }, []);
+  }, [currentPanel, locateActiveWorkspaceTab]);
 
   const handlePanelSelection = useCallback(
     (panel: WorkspaceLeftPanel) => {
-      setWorkspaceLeftPanelManualOverrideTabId(activeConsoleId ?? null);
-      setActivePanel(panel);
-      const shouldLocate = shouldLocateActiveTabOnPanelSelection(panel, activeTabLocateTarget);
-      pendingManualDatabaseLocateRef.current = shouldLocate && !treeDataReady;
-      if (shouldLocate && treeDataReady) {
-        void locateActiveWorkspaceTab({ clearSearch: true });
+      pendingManualPanelLocateRef.current = panel;
+      if (panel !== currentPanel) {
+        setActivePanel(panel);
+        return;
       }
+
+      const target = getActiveTabLocateTargetForPanel(activeTabLocateTargets, panel);
+      if (!target) {
+        pendingManualPanelLocateRef.current = null;
+        return;
+      }
+      if (target.surface === 'databaseTree' && !treeDataReady) {
+        return;
+      }
+
+      pendingManualPanelLocateRef.current = null;
+      void locateActiveWorkspaceTab(panel, { clearSearch: true });
     },
-    [
-      activeConsoleId,
-      activeTabLocateTarget,
-      locateActiveWorkspaceTab,
-      setActivePanel,
-      setWorkspaceLeftPanelManualOverrideTabId,
-      treeDataReady,
-    ],
+    [activeTabLocateTargets, currentPanel, locateActiveWorkspaceTab, setActivePanel, treeDataReady],
   );
 
-  useLayoutEffect(() => {
-    if (explorerSessionActivationRef.current !== null && !isExplorerSessionActivation) {
-      explorerSessionActivationRef.current = null;
-    }
-    const autoFollowState = resolveWorkspaceLeftAutoFollowState({
-      activeWorkspaceTabId: activeConsoleId,
-      autoFollowPanel,
-      manualOverrideTabId: workspaceLeftPanelManualOverrideTabId,
-      showExplorerPanel,
-    });
-    if (autoFollowState.manualOverrideTabId !== workspaceLeftPanelManualOverrideTabId) {
-      setWorkspaceLeftPanelManualOverrideTabId(autoFollowState.manualOverrideTabId);
-    }
-    if (autoFollowState.shouldApplyAutoFollow && autoFollowPanel) {
-      setActivePanel(autoFollowPanel);
-    }
-  }, [
-    activeConsoleId,
-    autoFollowPanel,
-    isExplorerSessionActivation,
-    setActivePanel,
-    setWorkspaceLeftPanelManualOverrideTabId,
-    showExplorerPanel,
-    workspaceLeftPanelManualOverrideTabId,
-  ]);
-
   useEffect(() => {
-    if (!pendingManualDatabaseLocateRef.current) {
+    // Cancel an in-flight database locate even when the new target cannot be located in this panel.
+    locateRequestSeqRef.current += 1;
+    const isManualPanelLocate = pendingManualPanelLocateRef.current === currentPanel;
+    if (!isManualPanelLocate && !autoFollowActiveWorkspaceTab) {
       return;
     }
-    if (currentPanel !== 'database' || activeTabLocateTarget?.surface === 'localFile') {
-      pendingManualDatabaseLocateRef.current = false;
-      return;
-    }
-    if (!treeDataReady || activeTabLocateTarget?.surface !== 'databaseTree') {
-      return;
-    }
-    pendingManualDatabaseLocateRef.current = false;
-    void locateActiveWorkspaceTab({ clearSearch: true });
-  }, [activeTabLocateTarget, currentPanel, locateActiveWorkspaceTab, treeDataReady]);
 
-  useEffect(() => {
-    if (
-      isExplorerSessionActivation ||
-      !autoFollowActiveWorkspaceTab ||
-      !activeTabLocateTarget ||
-      activeTabLocateTarget.surface === 'databaseTree'
-    ) {
+    if (!activeTabLocateTarget) {
+      if (isManualPanelLocate) {
+        pendingManualPanelLocateRef.current = null;
+      }
       return;
     }
-    void locateActiveWorkspaceTab();
-  }, [activeTabLocateTarget, autoFollowActiveWorkspaceTab, isExplorerSessionActivation, locateActiveWorkspaceTab]);
+    if (activeTabLocateTarget.surface === 'databaseTree' && !treeDataReady) {
+      return;
+    }
 
-  useEffect(() => {
-    if (
-      isExplorerSessionActivation ||
-      !autoFollowActiveWorkspaceTab ||
-      !activeTabLocateTarget ||
-      activeTabLocateTarget.surface !== 'databaseTree' ||
-      !treeDataReady
-    ) {
-      return;
+    if (isManualPanelLocate) {
+      pendingManualPanelLocateRef.current = null;
     }
-    void locateActiveWorkspaceTab();
-  }, [
-    activeTabLocateTarget,
-    autoFollowActiveWorkspaceTab,
-    isExplorerSessionActivation,
-    locateActiveWorkspaceTab,
-    treeDataReady,
-  ]);
+    void locateActiveWorkspaceTab(currentPanel, isManualPanelLocate ? { clearSearch: true } : undefined);
+  }, [activeTabLocateTarget, autoFollowActiveWorkspaceTab, currentPanel, locateActiveWorkspaceTab, treeDataReady]);
 
   return (
     <>
@@ -475,11 +394,7 @@ const WorkspaceLeft = memo(() => {
         {showExplorerPanel ? (
           <>
             <div className={[styles.panelPane, currentPanel === 'explorer' ? styles.panelPaneActive : ''].join(' ')}>
-              <WorkspaceExplorer
-                ref={explorerRef}
-                active={currentPanel === 'explorer'}
-                onSessionActivate={handleExplorerSessionActivate}
-              />
+              <WorkspaceExplorer ref={explorerRef} active={currentPanel === 'explorer'} />
             </div>
             <div className={[styles.panelPane, currentPanel === 'database' ? styles.panelPaneActive : ''].join(' ')}>
               <WorkspaceLeftActionBar

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.test.ts
@@ -2,11 +2,9 @@ import assert from 'node:assert/strict';
 import { WorkspaceTabType, initUserConfigTree } from '@/constants/workspace';
 import type { IWorkspaceTab } from '@/typings';
 import {
-  getAutoFollowWorkspaceLeftPanel,
-  getDirectActiveTabLocateTarget,
-  resolveWorkspaceLeftAutoFollowState,
+  getActiveTabLocateTargetForPanel,
+  getDirectActiveTabLocateTargets,
   resolveWorkspaceLeftPanel,
-  shouldLocateActiveTabOnPanelSelection,
 } from './activeTabTarget';
 
 function consoleTab(uniqueData: IWorkspaceTab['uniqueData']): IWorkspaceTab {
@@ -18,90 +16,60 @@ function consoleTab(uniqueData: IWorkspaceTab['uniqueData']): IWorkspaceTab {
   };
 }
 
-for (const uniqueData of [
-  { dataSourceId: 7 },
-  { dataSourceId: 7, databaseName: 'app' },
-  { dataSourceId: 7, databaseName: 'app', schemaName: 'public' },
-]) {
-  assert.deepEqual(getDirectActiveTabLocateTarget(consoleTab(uniqueData)), { surface: 'databaseTree' });
-}
-
-assert.deepEqual(
-  getDirectActiveTabLocateTarget({
-    id: 'local-file',
-    type: WorkspaceTabType.LocalSQLFile,
-    title: 'local.sql',
-    uniqueData: { filePath: '/tmp/local.sql' },
-  }),
-  {
-    surface: 'localFile',
-    filePath: '/tmp/local.sql',
+const connectedConsole = consoleTab({
+  dataSourceId: 7,
+  databaseName: 'app',
+  schemaName: 'public',
+});
+const disconnectedConsole = consoleTab(undefined);
+const localFile: IWorkspaceTab = {
+  id: 'local-file',
+  type: WorkspaceTabType.LocalSQLFile,
+  title: 'local.sql',
+  uniqueData: { filePath: '/tmp/local.sql' },
+};
+const databaseObject: IWorkspaceTab = {
+  id: 'table-editor',
+  type: WorkspaceTabType.EditTable,
+  title: 'users',
+  uniqueData: {
+    dataSourceId: 7,
+    databaseName: 'app',
+    schemaName: 'public',
+    tableName: 'users',
   },
-);
+};
 
-assert.equal(getDirectActiveTabLocateTarget(consoleTab(undefined)), null);
+assert.deepEqual(getDirectActiveTabLocateTargets(connectedConsole), {
+  explorer: { surface: 'explorerSession', sessionId: 101 },
+  database: { surface: 'databaseTree' },
+});
+assert.deepEqual(getDirectActiveTabLocateTargets(disconnectedConsole), {
+  explorer: { surface: 'explorerSession', sessionId: 101 },
+  database: undefined,
+});
+assert.deepEqual(getDirectActiveTabLocateTargets(localFile), {
+  explorer: { surface: 'localFile', filePath: '/tmp/local.sql' },
+});
+
+const consoleTargets = getDirectActiveTabLocateTargets(connectedConsole)!;
+assert.equal(getActiveTabLocateTargetForPanel(consoleTargets, 'explorer')?.surface, 'explorerSession');
+assert.equal(getActiveTabLocateTargetForPanel(consoleTargets, 'database')?.surface, 'databaseTree');
+
+const localFileTargets = getDirectActiveTabLocateTargets(localFile)!;
+assert.equal(getActiveTabLocateTargetForPanel(localFileTargets, 'explorer')?.surface, 'localFile');
+assert.equal(getActiveTabLocateTargetForPanel(localFileTargets, 'database'), undefined);
+
+assert.equal(getDirectActiveTabLocateTargets(databaseObject), undefined);
+const databaseObjectTargets = {
+  database: { surface: 'databaseTree' as const },
+};
+assert.equal(getActiveTabLocateTargetForPanel(databaseObjectTargets, 'explorer'), undefined);
+assert.equal(getActiveTabLocateTargetForPanel(databaseObjectTargets, 'database')?.surface, 'databaseTree');
+
+assert.deepEqual(getDirectActiveTabLocateTargets(null), {});
 assert.equal(initUserConfigTree.workspaceLeftPanel, 'database');
 assert.equal(resolveWorkspaceLeftPanel(undefined), 'database');
 assert.equal(resolveWorkspaceLeftPanel('explorer'), 'explorer');
-assert.equal(getAutoFollowWorkspaceLeftPanel(true, { surface: 'databaseTree' }), 'database');
-assert.equal(getAutoFollowWorkspaceLeftPanel(true, { surface: 'databaseTree' }, 'explorerSession'), undefined);
-assert.equal(getAutoFollowWorkspaceLeftPanel(true, { surface: 'localFile' }), 'explorer');
-assert.equal(getAutoFollowWorkspaceLeftPanel(false, { surface: 'databaseTree' }), undefined);
-assert.equal(shouldLocateActiveTabOnPanelSelection('database', { surface: 'databaseTree' }), true);
-assert.equal(shouldLocateActiveTabOnPanelSelection('explorer', { surface: 'databaseTree' }), false);
-assert.equal(shouldLocateActiveTabOnPanelSelection('database', { surface: 'localFile' }), false);
-
-assert.deepEqual(
-  resolveWorkspaceLeftAutoFollowState({
-    activeWorkspaceTabId: 101,
-    autoFollowPanel: 'database',
-    manualOverrideTabId: null,
-    showExplorerPanel: true,
-  }),
-  {
-    activeWorkspaceTabId: 101,
-    manualOverrideTabId: null,
-    shouldApplyAutoFollow: true,
-  },
-);
-assert.deepEqual(
-  resolveWorkspaceLeftAutoFollowState({
-    activeWorkspaceTabId: 101,
-    autoFollowPanel: 'database',
-    manualOverrideTabId: 101,
-    showExplorerPanel: true,
-  }),
-  {
-    activeWorkspaceTabId: 101,
-    manualOverrideTabId: 101,
-    shouldApplyAutoFollow: false,
-  },
-);
-assert.deepEqual(
-  resolveWorkspaceLeftAutoFollowState({
-    activeWorkspaceTabId: 102,
-    autoFollowPanel: 'database',
-    manualOverrideTabId: 101,
-    showExplorerPanel: true,
-  }),
-  {
-    activeWorkspaceTabId: 102,
-    manualOverrideTabId: null,
-    shouldApplyAutoFollow: true,
-  },
-);
-assert.deepEqual(
-  resolveWorkspaceLeftAutoFollowState({
-    activeWorkspaceTabId: 102,
-    autoFollowPanel: 'database',
-    manualOverrideTabId: null,
-    showExplorerPanel: false,
-  }),
-  {
-    activeWorkspaceTabId: 102,
-    manualOverrideTabId: null,
-    shouldApplyAutoFollow: false,
-  },
-);
 
 console.log('Active workspace tab locator tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabLocator.ts
@@ -1,14 +1,11 @@
 import { TreeNodeType, WorkspaceTabType } from '@/constants';
 import { treeConfig } from '@/blocks/NewTree/treeConfig';
 import type { IWorkspaceTab } from '@/typings';
-import { getDirectActiveTabLocateTarget } from './activeTabTarget';
+import { getDirectActiveTabLocateTargets, type ExplorerActiveTabLocateTarget } from './activeTabTarget';
 
 export {
-  getAutoFollowWorkspaceLeftPanel,
-  resolveWorkspaceLeftAutoFollowState,
+  getActiveTabLocateTargetForPanel,
   resolveWorkspaceLeftPanel,
-  shouldLocateActiveTabOnPanelSelection,
-  type WorkspaceTabActivationSource,
   type WorkspaceLeftPanel,
 } from './activeTabTarget';
 
@@ -22,16 +19,18 @@ export interface ActiveTabDatabaseCandidate {
   fallback?: boolean;
 }
 
-export type ActiveTabLocateTarget =
-  | {
-      surface: 'localFile';
-      filePath: string;
-    }
-  | {
-      surface: 'databaseTree';
-      candidates: ActiveTabDatabaseCandidate[];
-      loadPath: string[];
-    };
+export interface DatabaseActiveTabLocateTarget {
+  surface: 'databaseTree';
+  candidates: ActiveTabDatabaseCandidate[];
+  loadPath: string[];
+}
+
+export interface ActiveTabLocateTargets {
+  explorer?: ExplorerActiveTabLocateTarget;
+  database?: DatabaseActiveTabLocateTarget;
+}
+
+export type ActiveTabLocateTarget = ExplorerActiveTabLocateTarget | DatabaseActiveTabLocateTarget;
 
 function createTreeKey(treeNodeType: TreeNodeType, data: Record<string, unknown>) {
   return treeConfig[treeNodeType].createTreeNodeKey?.(data);
@@ -112,9 +111,7 @@ function getContextLoadPath(uniqueData: IWorkspaceTab['uniqueData']) {
 
   const { dataSourceId, databaseName, schemaName } = uniqueData;
   const dataSourceKey = createTreeKey(TreeNodeType.DATA_SOURCE, { dataSourceId });
-  const databaseKey = databaseName
-    ? createTreeKey(TreeNodeType.DATABASE, { dataSourceId, databaseName })
-    : undefined;
+  const databaseKey = databaseName ? createTreeKey(TreeNodeType.DATABASE, { dataSourceId, databaseName }) : undefined;
   const schemaKey = schemaName
     ? createTreeKey(TreeNodeType.SCHEMA, { dataSourceId, databaseName, schemaName })
     : undefined;
@@ -140,9 +137,9 @@ function getObjectParentLoadPath(uniqueData: IWorkspaceTab['uniqueData'], parent
 function databaseTreeTarget(
   candidates: ActiveTabDatabaseCandidate[],
   loadPath: string[],
-): ActiveTabLocateTarget | null {
+): DatabaseActiveTabLocateTarget | undefined {
   if (!candidates.length) {
-    return null;
+    return undefined;
   }
 
   return {
@@ -152,10 +149,10 @@ function databaseTreeTarget(
   };
 }
 
-function getDatabaseObjectLocateTarget(activeTab: IWorkspaceTab): ActiveTabLocateTarget | null {
+function getDatabaseObjectLocateTarget(activeTab: IWorkspaceTab): DatabaseActiveTabLocateTarget | undefined {
   const uniqueData = activeTab.uniqueData;
   if (!uniqueData?.dataSourceId) {
-    return null;
+    return undefined;
   }
 
   const { dataSourceId, databaseName, schemaName } = uniqueData;
@@ -275,28 +272,26 @@ function getDatabaseObjectLocateTarget(activeTab: IWorkspaceTab): ActiveTabLocat
       return databaseTreeTarget(getContextCandidates(uniqueData), getContextLoadPath(uniqueData));
 
     default:
-      return null;
+      return undefined;
   }
 }
 
-export function getActiveTabLocateTarget(
-  activeTab?: IWorkspaceTab | null,
-): ActiveTabLocateTarget | null {
+export function getActiveTabLocateTargets(activeTab?: IWorkspaceTab | null): ActiveTabLocateTargets {
   if (!activeTab) {
-    return null;
+    return {};
   }
 
-  const directTarget = getDirectActiveTabLocateTarget(activeTab);
-  if (directTarget?.surface === 'databaseTree') {
-    return databaseTreeTarget(
-      getContextCandidates(activeTab.uniqueData),
-      getContextLoadPath(activeTab.uniqueData),
-    );
+  const directTargets = getDirectActiveTabLocateTargets(activeTab);
+  if (directTargets !== undefined) {
+    return {
+      explorer: directTargets.explorer,
+      database: directTargets.database
+        ? databaseTreeTarget(getContextCandidates(activeTab.uniqueData), getContextLoadPath(activeTab.uniqueData))
+        : undefined,
+    };
   }
 
-  if (directTarget !== undefined) {
-    return directTarget;
-  }
-
-  return getDatabaseObjectLocateTarget(activeTab);
+  return {
+    database: getDatabaseObjectLocateTarget(activeTab),
+  };
 }

--- a/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/activeTabTarget.ts
@@ -2,77 +2,54 @@ import { WorkspaceTabType } from '@/constants/workspace';
 import type { IWorkspaceTab } from '@/typings/workspace';
 
 export type WorkspaceLeftPanel = 'explorer' | 'database';
-export type WorkspaceTabActivationSource = 'workspaceTab' | 'explorerSession';
-export type WorkspaceTabActivationId = string | number | null | undefined;
 
-export type DirectActiveTabLocateTarget =
+export type ExplorerActiveTabLocateTarget =
+  | {
+      surface: 'explorerSession';
+      sessionId: IWorkspaceTab['id'];
+    }
   | {
       surface: 'localFile';
       filePath: string;
-    }
-  | {
-      surface: 'databaseTree';
     };
+
+export interface DirectActiveTabLocateTargets {
+  explorer?: ExplorerActiveTabLocateTarget;
+  database?: {
+    surface: 'databaseTree';
+  };
+}
 
 export function resolveWorkspaceLeftPanel(panel?: WorkspaceLeftPanel): WorkspaceLeftPanel {
   return panel || 'database';
 }
 
-export function getAutoFollowWorkspaceLeftPanel(
-  enabled: boolean,
-  target?: Pick<DirectActiveTabLocateTarget, 'surface'> | null,
-  source: WorkspaceTabActivationSource = 'workspaceTab',
-): WorkspaceLeftPanel | undefined {
-  if (!enabled || !target || source === 'explorerSession') {
-    return undefined;
-  }
-  return target.surface === 'localFile' ? 'explorer' : 'database';
-}
-
-export function shouldLocateActiveTabOnPanelSelection(
+export function getActiveTabLocateTargetForPanel<TExplorer, TDatabase>(
+  targets: { explorer?: TExplorer; database?: TDatabase },
   panel: WorkspaceLeftPanel,
-  target?: Pick<DirectActiveTabLocateTarget, 'surface'> | null,
-): boolean {
-  return panel === 'database' && target?.surface === 'databaseTree';
+): TExplorer | TDatabase | undefined {
+  return targets[panel];
 }
 
-export function resolveWorkspaceLeftAutoFollowState({
-  activeWorkspaceTabId,
-  autoFollowPanel,
-  manualOverrideTabId,
-  showExplorerPanel,
-}: {
-  activeWorkspaceTabId: WorkspaceTabActivationId;
-  autoFollowPanel?: WorkspaceLeftPanel;
-  manualOverrideTabId: WorkspaceTabActivationId;
-  showExplorerPanel: boolean;
-}) {
-  const normalizedActiveTabId = activeWorkspaceTabId ?? null;
-  const normalizedManualOverrideTabId = manualOverrideTabId ?? null;
-  const nextManualOverrideTabId =
-    normalizedActiveTabId === normalizedManualOverrideTabId ? normalizedManualOverrideTabId : null;
-
-  return {
-    activeWorkspaceTabId: normalizedActiveTabId,
-    manualOverrideTabId: nextManualOverrideTabId,
-    shouldApplyAutoFollow: showExplorerPanel && !!autoFollowPanel && nextManualOverrideTabId === null,
-  };
-}
-
-export function getDirectActiveTabLocateTarget(
+export function getDirectActiveTabLocateTargets(
   activeTab?: IWorkspaceTab | null,
-): DirectActiveTabLocateTarget | null | undefined {
+): DirectActiveTabLocateTargets | undefined {
   if (!activeTab) {
-    return null;
+    return {};
   }
 
   if (activeTab.type === WorkspaceTabType.CONSOLE) {
-    return activeTab.uniqueData?.dataSourceId ? { surface: 'databaseTree' } : null;
+    return {
+      explorer: { surface: 'explorerSession', sessionId: activeTab.id },
+      database: activeTab.uniqueData?.dataSourceId ? { surface: 'databaseTree' } : undefined,
+    };
   }
 
   if (activeTab.type === WorkspaceTabType.LocalSQLFile) {
     const filePath = activeTab.uniqueData?.filePath;
-    return filePath ? { surface: 'localFile', filePath } : null;
+    return {
+      explorer: filePath ? { surface: 'localFile', filePath } : undefined,
+    };
   }
 
   return undefined;

--- a/chat2db-community-client/src/store/tree/index.tsx
+++ b/chat2db-community-client/src/store/tree/index.tsx
@@ -54,7 +54,6 @@ export interface TreeState {
   searchResultKeys: string[] | null;
   searchResult: TreeNodeData[] | null;
   userConfigTree: IUserConfigTree;
-  workspaceLeftPanelManualOverrideTabId: string | number | null;
   // Hidden node id
   hiddenTreeNodeIds: {
     [key: string]: string[];
@@ -82,7 +81,6 @@ export const initTreeState = {
   searchResult: null,
   currentLoadingTreeNode: null,
   userConfigTree: initUserConfigTree,
-  workspaceLeftPanelManualOverrideTabId: null,
   // Hidden node id
   hiddenTreeNodeIds: null,
 };
@@ -121,7 +119,6 @@ export interface TreeAction {
   deleteAiDataCollectionElement: (treeNodeData: TreeNodeData, handleLoadData: any) => Promise<void>;
   refreshAiDataCollection: (dataSourceId: number) => void;
   changeUserConfigTree: (type: string, value: any) => void;
-  setWorkspaceLeftPanelManualOverrideTabId: (tabId: TreeState['workspaceLeftPanelManualOverrideTabId']) => void;
   // Update node data through key
   updateTreeNodeDataByKey: (key: React.Key, getTreeNodeKeyParams?: GetTreeNodeKeyParams) => void;
   // Refresh data with details
@@ -565,9 +562,6 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
         },
       };
     });
-  },
-  setWorkspaceLeftPanelManualOverrideTabId: (workspaceLeftPanelManualOverrideTabId) => {
-    set({ workspaceLeftPanelManualOverrideTabId });
   },
   updateTreeNodeDataByKey: (key, getTreeNodeKeyParams) => {
     const newTreeData = get().treeData;


### PR DESCRIPTION
## Related issue

Closes #1974

## Summary

Keep the Files and Data Browser left-panel selection under explicit user control.

- Active Console tabs expose both Files/Active Sessions and Data Browser location targets without switching the selected panel.
- Local file tabs locate only in Files, while database-object tabs locate only in Data Browser.
- Manually selecting Files or Data Browser locates the active tab in that panel.
- Clear a Files search when it hides the active Console so the session can be scrolled into view.
- Remove the previous automatic-follow and per-tab manual-override state.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn lint` - passed.
  - `yarn test:i18n` - passed.
  - `yarn test:active-tab-locator` - passed.
  - `yarn build:web:community --app_version=0.0.0` - passed; Webpack compiled successfully in 18.07s.
  - `mvn -B clean package -Dmaven.test.skip=true -Dchat2db.finalName=chat2db-community -f chat2db-community-server/pom.xml -pl chat2db-community-start -am` - passed; 48 modules succeeded in 37.304s.
- Manual verification: Started an isolated Community Web runtime on frontend `8890` and backend `10826`. The frontend compiled successfully in 15.28s; `/`, direct `/api/system`, and proxied `/api/system` returned HTTP 200. The runtime-only Files visibility override used for this local Community Web check is not included in this PR.
- UI evidence: N/A - validated interactively in the isolated local runtime; no screenshot or recording attached.

## Risk and compatibility

- Public API or stored data: N/A - frontend workspace state only.
- Database or driver compatibility: N/A - no database or driver changes.
- Network, privacy, or security: N/A - no network or security behavior changes.
- Community / Local / Pro boundary: The workspace navigation logic is shared; the runtime-only Community Web Files visibility override is excluded.
- Backward compatibility: Intentionally removes automatic Files/Data Browser panel switching. Explicit panel clicks continue to locate the active tab in the selected browser.

## Reviewer map

- Start here: `chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/index.tsx`, then `utils/activeTabTarget.ts` and `utils/activeTabLocator.ts`.
- Failure condition: Activating a Console changes the selected Files/Data Browser panel, or manually selecting a panel fails to locate the active tab there.
- Rollback or disable path: Revert commit `b35f1e55`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with implementation, tests, runtime verification, and PR preparation. The contributor reviewed the resulting scope and behavior.
