### PR TITLE
feat(result-set): use full-height inspector rail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Run Redis explorer contract
         run: yarn run test:redis-explorer
 
+      - name: Run result inspector contract
+        run: yarn run test:result-inspector
+
       - name: Run SQL execution log contract
         run: yarn run test:sql-execution-log
 

--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -32,6 +32,7 @@
     "test:database-object-sorting": "tsx src/blocks/NewTree/utils/sortTreeNodes.test.ts",
     "test:execution-console": "tsx src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.test.ts",
     "test:redis-explorer": "tsx src/blocks/RedisAllData/redisExplorer.test.ts",
+    "test:result-inspector": "tsx src/store/workspace/utils/resultInspector.test.ts && yarn test:search-result-tab-selection",
     "test:search-result-query-composer": "tsx src/blocks/SearchResult/components/ScreeningResult/queryComposer.test.ts",
     "test:search-result-tab-selection": "tsx src/blocks/SearchResult/tabSelection.test.ts",
     "test:saved-console-tree-refresh": "tsx src/store/tree/savedConsoleTreeRefresh.test.ts",

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -31,6 +31,7 @@ import { useAIStore } from '@/store/ai';
 import { useWorkspaceStore } from '@/store/workspace';
 import {
   getWorkspaceResultInspectorCode,
+  shouldClearInactiveResultInspector,
   WORKSPACE_RESULT_INSPECTOR_PORTAL_ID,
 } from '@/store/workspace/utils/resultInspector';
 import { staticMessage } from '@chat2db/ui';
@@ -38,6 +39,7 @@ import { X } from 'lucide-react';
 
 interface IProps {
   resultData: IManageResultData;
+  active: boolean;
   viewTable?: boolean;
 }
 
@@ -100,6 +102,19 @@ export default memo<IProps>(
         workspaceStore.setCurrentWorkspaceExtend(null);
       }
     }, [inspectorExtendCode]);
+
+    useEffect(() => {
+      const workspaceStore = useWorkspaceStore.getState();
+      if (
+        shouldClearInactiveResultInspector(
+          workspaceStore.currentWorkspaceExtend,
+          inspectorExtendCode,
+          props.active,
+        )
+      ) {
+        workspaceStore.setCurrentWorkspaceExtend(null);
+      }
+    }, [inspectorExtendCode, props.active]);
 
     const activateInspector = useCallback(
       (tab: InspectorTab) => {

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useStyles } from './style';
 import ResultSetToolbar, { ResultSetToolbarRef, ToolbarOperationType } from '../ResultSetToolbar';
 import ScreeningResult, { IScreeningResultRef } from '../ScreeningResult';
@@ -26,6 +27,12 @@ import {
   isShortcutEventMatch,
 } from '@/constants/shortcut';
 import { useGlobalStore } from '@/store/global';
+import { useAIStore } from '@/store/ai';
+import { useWorkspaceStore } from '@/store/workspace';
+import {
+  getWorkspaceResultInspectorCode,
+  WORKSPACE_RESULT_INSPECTOR_PORTAL_ID,
+} from '@/store/workspace/utils/resultInspector';
 import { staticMessage } from '@chat2db/ui';
 import { X } from 'lucide-react';
 
@@ -59,11 +66,14 @@ export default memo<IProps>(
     const feSearchRef = useRef<FESearchRef>(null);
     const [orderByText, setOrderByText] = useState<string>('');
     const [submitLoading, setSubmitLoading] = useState(false);
-    const [inspectorOpen, setInspectorOpen] = useState(false);
     const [inspectorTab, setInspectorTab] = useState<InspectorTab>('row');
+    const [inspectorPortalTarget, setInspectorPortalTarget] = useState<HTMLElement | null>(null);
     const [selectedValues, setSelectedValues] = useState<unknown[]>([]);
     const [selectedRowCount, setSelectedRowCount] = useState(0);
     const [lastActiveCell, setLastActiveCell] = useState<IResultSetSelection['activeCell']>();
+    const currentWorkspaceExtend = useWorkspaceStore((state) => state.currentWorkspaceExtend);
+    const inspectorExtendCode = useMemo(() => getWorkspaceResultInspectorCode(searchAreaId), [searchAreaId]);
+    const inspectorOpen = currentWorkspaceExtend === inspectorExtendCode;
     const shortcutOverrides = useGlobalStore((s) => s.shortcutOverrides);
     const shortcutConfig = useMemo(
       () => getEffectiveShortcutConfigMap(shortcutOverrides as ShortcutOverrides),
@@ -78,8 +88,45 @@ export default memo<IProps>(
       setSelectedValues([]);
       setSelectedRowCount(0);
       setLastActiveCell(undefined);
-      setInspectorOpen(false);
-    }, [resultData]);
+      const workspaceStore = useWorkspaceStore.getState();
+      if (workspaceStore.currentWorkspaceExtend === inspectorExtendCode) {
+        workspaceStore.setCurrentWorkspaceExtend(null);
+      }
+    }, [inspectorExtendCode, resultData]);
+
+    const closeInspector = useCallback(() => {
+      const workspaceStore = useWorkspaceStore.getState();
+      if (workspaceStore.currentWorkspaceExtend === inspectorExtendCode) {
+        workspaceStore.setCurrentWorkspaceExtend(null);
+      }
+    }, [inspectorExtendCode]);
+
+    const activateInspector = useCallback(
+      (tab: InspectorTab) => {
+        setInspectorTab(tab);
+        useAIStore.getState().setShowPanel(false);
+        const workspaceStore = useWorkspaceStore.getState();
+        workspaceStore.setCurrentWorkspaceExtend(inspectorExtendCode);
+        workspaceStore.togglePanelRight(true);
+      },
+      [inspectorExtendCode],
+    );
+
+    useEffect(() => closeInspector, [closeInspector]);
+
+    useLayoutEffect(() => {
+      if (!inspectorOpen) {
+        setInspectorPortalTarget(null);
+        return undefined;
+      }
+
+      const resolvePortalTarget = () => {
+        setInspectorPortalTarget(document.getElementById(WORKSPACE_RESULT_INSPECTOR_PORTAL_ID));
+      };
+      resolvePortalTarget();
+      const animationFrame = window.requestAnimationFrame(resolvePortalTarget);
+      return () => window.cancelAnimationFrame(animationFrame);
+    }, [inspectorOpen]);
 
     // Only resultData changes here. Database metadata is stable, and the toolbar controls pagination.
     const handleExecuteSQL = useCallback(
@@ -280,8 +327,7 @@ export default memo<IProps>(
           row: params.row,
           rowId: nextParams.rowId,
         });
-        setInspectorOpen(true);
-        setInspectorTab('value');
+        activateInspector('value');
         setTimeout(() => {
           viewDataRef.current?.openPanel({
             ...nextParams,
@@ -290,7 +336,7 @@ export default memo<IProps>(
           });
         }, 0);
       },
-      [resultData?.canEdit],
+      [activateInspector, resultData?.canEdit],
     );
 
     const openRowInspector = useCallback((params) => {
@@ -304,10 +350,9 @@ export default memo<IProps>(
         row: params.row,
         rowId: params.rowId ?? record?.CHAT2DB_ROW_NUMBER,
       });
-      setInspectorOpen(true);
-      setInspectorTab('row');
+      activateInspector('row');
       setTimeout(() => rowDetailRef.current?.openPanel(params), 0);
-    }, []);
+    }, [activateInspector]);
 
     const onTableOperationUtils = useMemo(() => {
       return {
@@ -388,7 +433,7 @@ export default memo<IProps>(
         setSelectedRowCount(selection.rowCount);
         if (!selection.activeCell) {
           setLastActiveCell(undefined);
-          setInspectorOpen(false);
+          closeInspector();
           return;
         }
         setLastActiveCell(selection.activeCell);
@@ -400,7 +445,7 @@ export default memo<IProps>(
           }
         }
       },
-      [inspectorOpen, inspectorTab, openValueInspector],
+      [closeInspector, inspectorOpen, inspectorTab, openValueInspector],
     );
 
     const handleInspectorTabChange = useCallback(
@@ -417,7 +462,7 @@ export default memo<IProps>(
             String(record?.CHAT2DB_ROW_NUMBER) !== String(lastActiveCell.rowId)
           ) {
             setLastActiveCell(undefined);
-            setInspectorOpen(false);
+            closeInspector();
             return;
           }
           if (nextTab === 'row') {
@@ -432,13 +477,12 @@ export default memo<IProps>(
           });
         }, 0);
       },
-      [lastActiveCell, resultData?.canEdit],
+      [closeInspector, lastActiveCell, resultData?.canEdit],
     );
 
     const showAllAggregates = useCallback(() => {
-      setInspectorOpen(true);
-      setInspectorTab('aggregates');
-    }, []);
+      activateInspector('aggregates');
+    }, [activateInspector]);
 
     useEffect(() => {
       if (!tableInstance) {
@@ -508,57 +552,59 @@ export default memo<IProps>(
                   onSelectionChange={handleSelectionChange}
                 />
               </div>
-              {inspectorOpen && (
-                <aside className={styles.inspector}>
-                  <Tabs
-                    className={styles.inspectorTabs}
-                    size="small"
-                    activeKey={inspectorTab}
-                    onChange={handleInspectorTabChange}
-                    tabBarExtraContent={
-                      <Tooltip title={i18n('common.button.close')}>
-                        <Button
-                          type="text"
-                          size="small"
-                          className={styles.inspectorClose}
-                          aria-label={i18n('common.button.close')}
-                          icon={<X size={15} strokeWidth={1.75} />}
-                          onClick={() => setInspectorOpen(false)}
-                        />
-                      </Tooltip>
-                    }
-                    items={[
-                      {
-                        key: 'row',
-                        label: i18n('common.resultInspector.record'),
-                        children: (
-                          <RowDetail
-                            ref={rowDetailRef}
-                            resultData={resultData}
-                            onChangeData={handleRowDetailChangeData}
-                            onViewData={openValueInspector}
+              {inspectorOpen && inspectorPortalTarget &&
+                createPortal(
+                  <aside className={styles.inspector}>
+                    <Tabs
+                      className={styles.inspectorTabs}
+                      size="small"
+                      activeKey={inspectorTab}
+                      onChange={handleInspectorTabChange}
+                      tabBarExtraContent={
+                        <Tooltip title={i18n('common.button.close')}>
+                          <Button
+                            type="text"
+                            size="small"
+                            className={styles.inspectorClose}
+                            aria-label={i18n('common.button.close')}
+                            icon={<X size={15} strokeWidth={1.75} />}
+                            onClick={closeInspector}
                           />
-                        ),
-                      },
-                      {
-                        key: 'value',
-                        label: i18n('common.resultInspector.value'),
-                        children: <ViewData ref={viewDataRef} />,
-                      },
-                      {
-                        key: 'aggregates',
-                        label: i18n('common.resultInspector.aggregates'),
-                        children: (
-                          <SelectionAggregates
-                            selectedValues={selectedValues}
-                            selectedRowCount={selectedRowCount}
-                          />
-                        ),
-                      },
-                    ]}
-                  />
-                </aside>
-              )}
+                        </Tooltip>
+                      }
+                      items={[
+                        {
+                          key: 'row',
+                          label: i18n('common.resultInspector.record'),
+                          children: (
+                            <RowDetail
+                              ref={rowDetailRef}
+                              resultData={resultData}
+                              onChangeData={handleRowDetailChangeData}
+                              onViewData={openValueInspector}
+                            />
+                          ),
+                        },
+                        {
+                          key: 'value',
+                          label: i18n('common.resultInspector.value'),
+                          children: <ViewData ref={viewDataRef} />,
+                        },
+                        {
+                          key: 'aggregates',
+                          label: i18n('common.resultInspector.aggregates'),
+                          children: (
+                            <SelectionAggregates
+                              selectedValues={selectedValues}
+                              selectedRowCount={selectedRowCount}
+                            />
+                          ),
+                        },
+                      ]}
+                    />
+                  </aside>,
+                  inspectorPortalTarget,
+                )}
             </div>
             <StatusBar
               ref={statusBarRef}

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -640,5 +640,7 @@ export default memo<IProps>(
     );
   },
   (prevProps, nextProps) =>
-    prevProps.resultData === nextProps.resultData && prevProps.viewTable === nextProps.viewTable,
+    prevProps.active === nextProps.active &&
+    prevProps.resultData === nextProps.resultData &&
+    prevProps.viewTable === nextProps.viewTable,
 );

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/style.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/style.ts
@@ -30,10 +30,10 @@ export const useStyles = createStyles(({ css, token }) => {
       position: relative;
     `,
     inspector: css`
-      width: clamp(340px, 36%, 460px);
-      max-width: 50%;
+      width: 100%;
+      height: 100%;
       min-width: 0;
-      flex-shrink: 0;
+      min-height: 0;
       overflow: hidden;
       background: ${token.colorBgContainer};
       border-left: 1px solid ${token.colorBorderSecondary};

--- a/chat2db-community-client/src/blocks/SearchResult/components/SearchResultItem/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/SearchResultItem/index.tsx
@@ -13,12 +13,13 @@ import { QuestionType } from '@/constants/chat';
 
 interface IProps {
   resultData: IManageResultData;
+  active: boolean;
   viewTable?: boolean;
 }
 
 export default memo<IProps>(
   (props) => {
-    const { resultData, viewTable } = props;
+    const { active, resultData, viewTable } = props;
     const { styles } = useStyles();
     const setCurrentWorkspaceExtend = useWorkspaceStore((s) => s.setCurrentWorkspaceExtend);
 
@@ -51,7 +52,7 @@ export default memo<IProps>(
       return (
         <div className={styles.successResult}>
           {needTable ? (
-            <ResultSet viewTable={viewTable} resultData={resultData} />
+            <ResultSet active={active} viewTable={viewTable} resultData={resultData} />
           ) : (
             <div className={styles.updateCountBox}>
               <div className={styles.updateCount}>{i18n('common.text.affectedRows', resultData.updateCount)}</div>
@@ -79,5 +80,7 @@ export default memo<IProps>(
     );
   },
   (prevProps, nextProps) =>
-    prevProps.resultData === nextProps.resultData && prevProps.viewTable === nextProps.viewTable,
+    prevProps.active === nextProps.active &&
+    prevProps.resultData === nextProps.resultData &&
+    prevProps.viewTable === nextProps.viewTable,
 );

--- a/chat2db-community-client/src/blocks/SearchResult/components/ViewData/JsonAwareMonacoEditor.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ViewData/JsonAwareMonacoEditor.tsx
@@ -123,12 +123,7 @@ const JsonAwareMonacoEditor = ({ id, value, readOnly, onChange, onJsonChange }: 
       id={id}
       language="plaintext"
       didMount={handleEditorDidMount}
-      options={{
-        lineNumbers: 'off',
-        readOnly,
-        wordWrap: 'off',
-        scrollbar: { horizontal: 'auto' },
-      }}
+      options={{ lineNumbers: 'off', readOnly }}
     />
   );
 };

--- a/chat2db-community-client/src/blocks/SearchResult/components/ViewData/JsonAwareMonacoEditor.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ViewData/JsonAwareMonacoEditor.tsx
@@ -123,7 +123,12 @@ const JsonAwareMonacoEditor = ({ id, value, readOnly, onChange, onJsonChange }: 
       id={id}
       language="plaintext"
       didMount={handleEditorDidMount}
-      options={{ lineNumbers: 'off', readOnly }}
+      options={{
+        lineNumbers: 'off',
+        readOnly,
+        wordWrap: 'off',
+        scrollbar: { horizontal: 'auto' },
+      }}
     />
   );
 };

--- a/chat2db-community-client/src/blocks/SearchResult/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/index.tsx
@@ -23,8 +23,6 @@ import SQLPreview from '@/components/SQLPreview';
 import ExecutionConsole from './components/ExecutionConsole';
 import ExecutionMessages, { IExecutionMessageItem } from './components/ExecutionMessages';
 import type { SqlExecutionLogRecord } from '@/service/sqlExecutionLog';
-import { useWorkspaceStore } from '@/store/workspace';
-import { isWorkspaceResultInspectorCode } from '@/store/workspace/utils/resultInspector';
 import {
   ABSTRACT_TAB_ID,
   CONSOLE_TAB_ID,
@@ -163,10 +161,6 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
   }, [consoleMode, props.forceOutputTab, props.resultBatchKey]);
 
   const onChange = useCallback((uuid) => {
-    const workspaceStore = useWorkspaceStore.getState();
-    if (isWorkspaceResultInspectorCode(workspaceStore.currentWorkspaceExtend)) {
-      workspaceStore.setCurrentWorkspaceExtend(null);
-    }
     dispatchTabSelection({ type: 'activate', tabId: uuid });
   }, []);
 
@@ -198,12 +192,18 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
           label:
             queryResultData.displayName || queryResultData.comment || i18n('common.text.executionResult', index + 1),
           key: queryResultData.uuid!,
-          children: <SearchResultItem viewTable={viewTable || queryResultData.canEdit} resultData={queryResultData} />,
+          children: (
+            <SearchResultItem
+              active={activeTabId === queryResultData.uuid}
+              viewTable={viewTable || queryResultData.canEdit}
+              resultData={queryResultData}
+            />
+          ),
         };
       }) || [];
 
     return tabsListRes;
-  }, [resultDataList, visibleHistoryResultDataList, showHistory, consoleMode]);
+  }, [activeTabId, resultDataList, visibleHistoryResultDataList, showHistory, consoleMode]);
 
   const executionMessages = useMemo<IExecutionMessageItem[]>(() => {
     if (consoleMode || !resultDataList?.length) {

--- a/chat2db-community-client/src/blocks/SearchResult/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/index.tsx
@@ -23,6 +23,8 @@ import SQLPreview from '@/components/SQLPreview';
 import ExecutionConsole from './components/ExecutionConsole';
 import ExecutionMessages, { IExecutionMessageItem } from './components/ExecutionMessages';
 import type { SqlExecutionLogRecord } from '@/service/sqlExecutionLog';
+import { useWorkspaceStore } from '@/store/workspace';
+import { isWorkspaceResultInspectorCode } from '@/store/workspace/utils/resultInspector';
 import {
   ABSTRACT_TAB_ID,
   CONSOLE_TAB_ID,
@@ -161,6 +163,10 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
   }, [consoleMode, props.forceOutputTab, props.resultBatchKey]);
 
   const onChange = useCallback((uuid) => {
+    const workspaceStore = useWorkspaceStore.getState();
+    if (isWorkspaceResultInspectorCode(workspaceStore.currentWorkspaceExtend)) {
+      workspaceStore.setCurrentWorkspaceExtend(null);
+    }
     dispatchTabSelection({ type: 'activate', tabId: uuid });
   }, []);
 

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendBody/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendBody/index.tsx
@@ -4,6 +4,10 @@ import { useWorkspaceStore } from '@/store/workspace';
 import { useStyles } from './style';
 import { useAIStore } from '@/store/ai';
 import AI from '@/blocks/AI';
+import {
+  isWorkspaceResultInspectorCode,
+  WORKSPACE_RESULT_INSPECTOR_PORTAL_ID,
+} from '@/store/workspace/utils/resultInspector';
 
 export default () => {
   const { styles } = useStyles();
@@ -14,6 +18,14 @@ export default () => {
   const Component = useMemo(() => {
     return extendConfig.find((item) => item.code === currentWorkspaceExtend)?.components;
   }, [currentWorkspaceExtend]);
+
+  if (isWorkspaceResultInspectorCode(currentWorkspaceExtend)) {
+    return (
+      <div className={styles.currentWorkspaceExtendBox}>
+        <div id={WORKSPACE_RESULT_INSPECTOR_PORTAL_ID} className={styles.resultInspectorHost} />
+      </div>
+    );
+  }
 
   if (showPanel) {
     return (

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendBody/style.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendBody/style.ts
@@ -7,5 +7,12 @@ export const useStyles = createStyles(({ css, token }) => {
       border-right: 1px solid ${token.colorBorderLayout};
       overflow: hidden;
     `,
+    resultInspectorHost: css`
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
+      overflow: hidden;
+    `,
   };
 });

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceRight/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceRight/index.tsx
@@ -1,7 +1,12 @@
-import { Fragment, memo, useEffect, useState, useRef } from 'react';
+import { Fragment, memo, useLayoutEffect, useState, useRef } from 'react';
 import WorkspaceExtendBody from '../WorkspaceExtend/WorkspaceExtendBody';
 import WorkspaceExtendNav from '../WorkspaceExtend/WorkspaceExtendNav';
 import { useWorkspaceStore } from '@/store/workspace';
+import {
+  getResultInspectorPanelSize,
+  isWorkspaceResultInspectorCode,
+  RESULT_INSPECTOR_MAX_PANEL_RATIO,
+} from '@/store/workspace/utils/resultInspector';
 import SplitPane from 'react-split-pane';
 import ExportProgressBar from '@/blocks/ImportAndExport/components/ExportProgressBar';
 import { canImportExport } from '@/utils/env';
@@ -12,26 +17,27 @@ import WorkspaceTabs from '../WorkspaceTabs';
 import { useStyles } from './style';
 
 const WorkspaceRight = memo(() => {
-  const [size, setSize] = useState(0);
-  const [maxPanelSize, setMaxPanelSize] = useState(0);
+  const [workspaceWidth, setWorkspaceWidth] = useState(0);
   const draggablePanelRef = useRef<HTMLDivElement>(null);
 
   const { styles } = useStyles();
 
-  const { panelRight, panelRightWidth, setPanelRightWidth } = useWorkspaceStore((state) => {
+  const { currentWorkspaceExtend, panelRight, panelRightWidth, setPanelRightWidth } = useWorkspaceStore((state) => {
     return {
+      currentWorkspaceExtend: state.currentWorkspaceExtend,
       panelRight: state.layout.panelRight,
       panelRightWidth: state.layout.panelRightWidth,
       setPanelRightWidth: state.setPanelRightWidth,
     };
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!draggablePanelRef.current) return;
 
+    setWorkspaceWidth(draggablePanelRef.current.getBoundingClientRect().width);
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        setMaxPanelSize(entry.contentRect.width * 0.8);
+        setWorkspaceWidth(entry.contentRect.width);
       }
     });
 
@@ -39,13 +45,14 @@ const WorkspaceRight = memo(() => {
     return () => resizeObserver.disconnect();
   }, []);
 
-  useEffect(() => {
-    if (!panelRight) {
-      setSize(0);
-    } else {
-      setSize(panelRightWidth || 320);
-    }
-  }, [panelRight, panelRightWidth]);
+  const resultInspectorOpen = isWorkspaceResultInspectorCode(currentWorkspaceExtend);
+  const preferredPanelSize = panelRightWidth || 320;
+  const size = panelRight
+    ? resultInspectorOpen
+      ? getResultInspectorPanelSize(preferredPanelSize, workspaceWidth)
+      : preferredPanelSize
+    : 0;
+  const maxPanelSize = workspaceWidth * (resultInspectorOpen ? RESULT_INSPECTOR_MAX_PANEL_RATIO : 0.8);
 
   return (
     <div className={styles.workspaceRight}>
@@ -53,7 +60,7 @@ const WorkspaceRight = memo(() => {
         <SplitPane
           split="vertical"
           size={size}
-          pane1Style={{ width: '0px' }}
+          pane1Style={{ minWidth: '0px' }}
           minSize={150}
           maxSize={maxPanelSize}
           primary="second"

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
@@ -41,6 +41,7 @@ import ContentDiffTab from './ContentDiffTab';
 
 // ---- store -----
 import { useWorkspaceStore } from '@/store/workspace';
+import { isWorkspaceResultInspectorCode } from '@/store/workspace/utils/resultInspector';
 import { useTreeStore } from '@/store/tree';
 
 // ----- services -----
@@ -716,6 +717,13 @@ const WorkspaceTabs = memo(() => {
       });
     }
   }, [workspaceTabList, workspaceTabSplitLayout, activeConsoleId]);
+
+  useEffect(() => {
+    const workspaceStore = useWorkspaceStore.getState();
+    if (isWorkspaceResultInspectorCode(workspaceStore.currentWorkspaceExtend)) {
+      workspaceStore.setCurrentWorkspaceExtend(null);
+    }
+  }, [activeConsoleId]);
 
   // Convert consoleList to the shared workspaceTabList format first.
   useEffect(() => {

--- a/chat2db-community-client/src/store/workspace/utils/resultInspector.test.ts
+++ b/chat2db-community-client/src/store/workspace/utils/resultInspector.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import {
+  getWorkspaceResultInspectorCode,
+  isWorkspaceResultInspectorCode,
+  WORKSPACE_RESULT_INSPECTOR_PORTAL_ID,
+} from './resultInspector';
+
+const ownerCode = getWorkspaceResultInspectorCode('result-set-1');
+
+assert.equal(ownerCode, 'resultInspector:result-set-1');
+assert.equal(isWorkspaceResultInspectorCode(ownerCode), true);
+assert.equal(isWorkspaceResultInspectorCode('info'), false);
+assert.equal(isWorkspaceResultInspectorCode(null), false);
+assert.equal(WORKSPACE_RESULT_INSPECTOR_PORTAL_ID, 'workspace-result-inspector-portal');
+
+console.log('Workspace result inspector tests passed');

--- a/chat2db-community-client/src/store/workspace/utils/resultInspector.test.ts
+++ b/chat2db-community-client/src/store/workspace/utils/resultInspector.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import {
   getWorkspaceResultInspectorCode,
   isWorkspaceResultInspectorCode,
+  shouldClearInactiveResultInspector,
   WORKSPACE_RESULT_INSPECTOR_PORTAL_ID,
 } from './resultInspector';
 
@@ -11,6 +12,9 @@ assert.equal(ownerCode, 'resultInspector:result-set-1');
 assert.equal(isWorkspaceResultInspectorCode(ownerCode), true);
 assert.equal(isWorkspaceResultInspectorCode('info'), false);
 assert.equal(isWorkspaceResultInspectorCode(null), false);
+assert.equal(shouldClearInactiveResultInspector(ownerCode, ownerCode, false), true);
+assert.equal(shouldClearInactiveResultInspector(ownerCode, ownerCode, true), false);
+assert.equal(shouldClearInactiveResultInspector('resultInspector:other', ownerCode, false), false);
 assert.equal(WORKSPACE_RESULT_INSPECTOR_PORTAL_ID, 'workspace-result-inspector-portal');
 
 console.log('Workspace result inspector tests passed');

--- a/chat2db-community-client/src/store/workspace/utils/resultInspector.test.ts
+++ b/chat2db-community-client/src/store/workspace/utils/resultInspector.test.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import {
+  getResultInspectorPanelSize,
   getWorkspaceResultInspectorCode,
   isWorkspaceResultInspectorCode,
+  RESULT_INSPECTOR_MAX_PANEL_RATIO,
   shouldClearInactiveResultInspector,
   WORKSPACE_RESULT_INSPECTOR_PORTAL_ID,
 } from './resultInspector';
@@ -15,6 +17,10 @@ assert.equal(isWorkspaceResultInspectorCode(null), false);
 assert.equal(shouldClearInactiveResultInspector(ownerCode, ownerCode, false), true);
 assert.equal(shouldClearInactiveResultInspector(ownerCode, ownerCode, true), false);
 assert.equal(shouldClearInactiveResultInspector('resultInspector:other', ownerCode, false), false);
+assert.equal(getResultInspectorPanelSize(320, 1200), 320);
+assert.equal(getResultInspectorPanelSize(900, 1200), 600);
+assert.equal(getResultInspectorPanelSize(900, 0), 900);
+assert.equal(RESULT_INSPECTOR_MAX_PANEL_RATIO, 0.5);
 assert.equal(WORKSPACE_RESULT_INSPECTOR_PORTAL_ID, 'workspace-result-inspector-portal');
 
 console.log('Workspace result inspector tests passed');

--- a/chat2db-community-client/src/store/workspace/utils/resultInspector.ts
+++ b/chat2db-community-client/src/store/workspace/utils/resultInspector.ts
@@ -1,5 +1,7 @@
 export const WORKSPACE_RESULT_INSPECTOR_PORTAL_ID = 'workspace-result-inspector-portal';
 
+export const RESULT_INSPECTOR_MAX_PANEL_RATIO = 0.5;
+
 const WORKSPACE_RESULT_INSPECTOR_PREFIX = 'resultInspector:';
 
 export function getWorkspaceResultInspectorCode(ownerId: string) {
@@ -16,4 +18,9 @@ export function shouldClearInactiveResultInspector(
   active: boolean,
 ) {
   return !active && currentWorkspaceExtend === inspectorExtendCode;
+}
+
+export function getResultInspectorPanelSize(preferredSize: number, workspaceWidth: number) {
+  const maxSize = workspaceWidth * RESULT_INSPECTOR_MAX_PANEL_RATIO;
+  return maxSize > 0 ? Math.min(preferredSize, maxSize) : preferredSize;
 }

--- a/chat2db-community-client/src/store/workspace/utils/resultInspector.ts
+++ b/chat2db-community-client/src/store/workspace/utils/resultInspector.ts
@@ -1,0 +1,11 @@
+export const WORKSPACE_RESULT_INSPECTOR_PORTAL_ID = 'workspace-result-inspector-portal';
+
+const WORKSPACE_RESULT_INSPECTOR_PREFIX = 'resultInspector:';
+
+export function getWorkspaceResultInspectorCode(ownerId: string) {
+  return `${WORKSPACE_RESULT_INSPECTOR_PREFIX}${ownerId}`;
+}
+
+export function isWorkspaceResultInspectorCode(code?: string | null) {
+  return !!code?.startsWith(WORKSPACE_RESULT_INSPECTOR_PREFIX);
+}

--- a/chat2db-community-client/src/store/workspace/utils/resultInspector.ts
+++ b/chat2db-community-client/src/store/workspace/utils/resultInspector.ts
@@ -9,3 +9,11 @@ export function getWorkspaceResultInspectorCode(ownerId: string) {
 export function isWorkspaceResultInspectorCode(code?: string | null) {
   return !!code?.startsWith(WORKSPACE_RESULT_INSPECTOR_PREFIX);
 }
+
+export function shouldClearInactiveResultInspector(
+  currentWorkspaceExtend: string | null | undefined,
+  inspectorExtendCode: string,
+  active: boolean,
+) {
+  return !active && currentWorkspaceExtend === inspectorExtendCode;
+}


### PR DESCRIPTION
## Related issue

Closes #1976

## Summary

- Render the result-set Record, Value, and Aggregates inspector in the existing full-height workspace right rail through an owner-qualified React portal.
- Keep the result grid visible by capping the result inspector at 50% of the available workspace width while retaining persisted resizing.
- Clear stale inspector ownership across result-tab, workspace-tab, result refresh, selection clear, and unmount transitions without conflicting with the AI panel.
- Preserve the existing Monaco value-wrapping behavior and add the inspector ownership, tab-transition, and width contracts to Community CI.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn lint` - passed (ESLint and Stylelint, zero warnings).
  - `yarn test:result-inspector` - passed (owner lifecycle, width constraint, and result-tab transitions).
  - `yarn test:i18n` - passed.
  - `yarn build:web:community --app_version=5.3.0` - passed; Webpack compiled successfully.
  - Package JSON parsing, workflow YAML parsing, and `git diff --check` - passed.
- Manual verification: the corrected local Community UI keeps the result grid visible beside the full-height inspector and retains Value line wrapping. The backend (`10825`) and frontend (`8889`) return HTTP 200.
- UI evidence: N/A - the corrected interaction was checked locally, but no screenshot or recording is attached.

## Risk and compatibility

- Public API or stored data: N/A - no API or persistence-format changes.
- Database or driver compatibility: N/A - database-neutral frontend layout behavior.
- Network, privacy, or security: N/A - no new requests, data exposure, or permission changes.
- Community / Local / Pro boundary: Community frontend only; no commercial-code dependency.
- Backward compatibility: Record, Value, Aggregates, editing, and automatic value wrapping remain unchanged. Only inspector placement, ownership cleanup, and its result-specific maximum width change.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx`, then `src/pages/main/workspace/components/WorkspaceRight/index.tsx` and `src/store/workspace/utils/resultInspector.ts`.
- Failure condition: the inspector hides the complete result grid, exceeds half of the workspace, survives an owner/result/workspace transition, closes another extension's panel, or conflicts with the AI panel.
- Rollback or disable path: revert this PR; there is no persisted-data migration or server-side dependency.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for design exploration, implementation, focused tests, review, and PR preparation. Automated and manual verification results are disclosed above.
