### PR TITLE
feat(ci): notify QQ of Release, Deployment, and Discussion changes

### DIFF
--- a/.github/QQ_GROUP_NOTIFICATIONS.md
+++ b/.github/QQ_GROUP_NOTIFICATIONS.md
@@ -1,9 +1,9 @@
 # QQ Group Notifications
 
-The `QQ group notifications` workflow sends Issue and pull-request state changes
-to QQ group `1080856850` through a dedicated NapCat/OneBot account. GitHub
-Actions can reach the private Mac Studio deployment only through an
-authenticated Cloudflare Tunnel endpoint.
+The `QQ group notifications` workflow sends Issue, pull-request, Release,
+Deployment, and Discussion state changes to QQ group `1080856850` through a
+dedicated NapCat/OneBot account. GitHub Actions can reach the private Mac Studio
+deployment only through an authenticated Cloudflare Tunnel endpoint.
 
 ```text
 GitHub Actions -> HTTPS relay -> OneBot HTTP -> NapCat -> QQ group 1080856850
@@ -23,8 +23,9 @@ protocol changes, or account risk controls.
   rate-limited to 30 per minute.
 - NapCat WebUI binds only to host loopback. OneBot HTTP and WebSocket ports are
   not published on the host or Internet.
-- Only the item title and event metadata are sent. Bodies, comments, source
-  code, credentials, and other event payload fields are excluded.
+- Only Issue, pull-request, and Discussion titles plus selected Release and
+  Deployment metadata are sent. Bodies, comments, source code, Deployment
+  payloads, credentials, and other event payload fields are excluded.
 - `pull_request_target` checks out the notifier from the trusted default branch
   and never executes pull-request code. A manually dispatched test may use the
   explicitly selected maintainer branch.
@@ -99,6 +100,27 @@ The old `QQ_BOT_APP_ID`, `QQ_BOT_CLIENT_SECRET`, and `QQ_GROUP_OPENID` secrets
 are not used by this implementation and may be removed after the relay path is
 verified.
 
+## Notification coverage
+
+The workflow sends these repository events:
+
+- Issue and pull-request lifecycle and state changes listed in the workflow.
+- Release `published`, `unpublished`, `created`, `edited`, `deleted`,
+  `prereleased`, and `released` events. Messages include the tag, release name,
+  release state, actor, and release URL.
+- Deployment creation and every Deployment status update. Messages include the
+  environment, ref, mapped status, actor, and an environment or log URL when
+  GitHub provides one. URL query strings and fragments are removed.
+- Discussion `created`, `edited`, `deleted`, `transferred`, `pinned`,
+  `unpinned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `category_changed`,
+  `answered`, and `unanswered` events. Messages include the number, title,
+  category, current state, actor, and Discussion URL.
+
+Discussion comments are intentionally not subscribed to and do not generate QQ
+messages. GitHub does not run the `created`, `edited`, or `deleted` Release
+activity types for draft releases; `published` is the reliable event for both
+stable releases and prereleases when they become public.
+
 ## Verification
 
 Run automated checks:
@@ -118,6 +140,9 @@ Verify the live path in this order:
 4. Dispatch it again with `dry_run` disabled and confirm one QQ message.
 5. Open and close a test Issue, then open and close a test pull request. Confirm
    action, number, title, actor, URL, and merged/closed distinction.
+6. Publish or edit a test Release, create a test Deployment status, and change a
+   test Discussion state. Confirm their selected metadata and links, and confirm
+   that bodies, comments, Deployment payloads, and URL query strings are absent.
 
 The relay intentionally returns a generic `QQ delivery failed` response when
 OneBot is offline or rejects a message, so internal details are not exposed on

--- a/.github/workflows/qq-group-notifications.yml
+++ b/.github/workflows/qq-group-notifications.yml
@@ -42,6 +42,32 @@ on:
       - review_request_removed
       - auto_merge_enabled
       - auto_merge_disabled
+  release:
+    types:
+      - published
+      - unpublished
+      - created
+      - edited
+      - deleted
+      - prereleased
+      - released
+  deployment:
+  deployment_status:
+  discussion:
+    types:
+      - created
+      - edited
+      - deleted
+      - transferred
+      - pinned
+      - unpinned
+      - labeled
+      - unlabeled
+      - locked
+      - unlocked
+      - category_changed
+      - answered
+      - unanswered
   workflow_dispatch:
     inputs:
       message:
@@ -59,7 +85,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: qq-group-notification-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}-${{ github.event.action || 'manual' }}
+  group: qq-group-notification-${{ github.event.issue.number || github.event.pull_request.number || github.event.discussion.number || github.event.release.id || github.event.deployment.id || github.run_id }}-${{ github.event.action || 'manual' }}
   cancel-in-progress: false
 
 jobs:

--- a/script/github/notify_qq.py
+++ b/script/github/notify_qq.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Send GitHub Issue and pull request changes through the Chat2DB QQ relay."""
+"""Send selected GitHub repository changes through the Chat2DB QQ relay."""
 
 from __future__ import annotations
 
@@ -62,6 +62,47 @@ PULL_REQUEST_ACTIONS = {
     "auto_merge_disabled": "已禁用自动合并",
 }
 
+RELEASE_ACTIONS = {
+    "published": "已发布",
+    "unpublished": "已取消发布",
+    "created": "已创建",
+    "edited": "已编辑",
+    "deleted": "已删除",
+    "prereleased": "已设为预发布",
+    "released": "已设为正式发布",
+}
+
+DISCUSSION_ACTIONS = {
+    "created": "已创建",
+    "edited": "已编辑",
+    "deleted": "已删除",
+    "transferred": "已转移",
+    "pinned": "已置顶",
+    "unpinned": "已取消置顶",
+    "labeled": "已添加标签",
+    "unlabeled": "已移除标签",
+    "locked": "已锁定",
+    "unlocked": "已解锁",
+    "category_changed": "已更改分类",
+    "answered": "已标记回答",
+    "unanswered": "已取消回答",
+}
+
+DEPLOYMENT_STATES = {
+    "error": "错误",
+    "failure": "失败",
+    "inactive": "已停用",
+    "in_progress": "进行中",
+    "queued": "排队中",
+    "pending": "等待中",
+    "success": "成功",
+}
+
+DISCUSSION_STATES = {
+    "open": "开放",
+    "closed": "已关闭",
+}
+
 
 class ConfigurationError(RuntimeError):
     """Raised when required GitHub Actions configuration is invalid."""
@@ -100,6 +141,39 @@ def _join_message_lines(lines: list[str], max_length: int = 900) -> str:
 
 def _remove_urls(value: str) -> str:
     return URL_PATTERN.sub("[链接已省略]", value)
+
+
+def _safe_deployment_url(value: Any) -> str:
+    url = _clean_text(value, 500)
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return ""
+    if parsed.username or parsed.password:
+        return ""
+    return parsed._replace(query="", fragment="").geturl()
+
+
+def _release_status(release: Mapping[str, Any]) -> str:
+    if release.get("draft"):
+        return "草稿"
+    if release.get("prerelease"):
+        return "预发布"
+    return "正式发布"
+
+
+def _discussion_status(discussion: Mapping[str, Any], action: str) -> str:
+    if action == "deleted":
+        return "已删除"
+    if discussion.get("locked") or action == "locked":
+        return "已锁定"
+    if action == "unlocked":
+        return "已解锁"
+    if action == "answered" or discussion.get("answer_html_url"):
+        return "已回答"
+    if action == "unanswered":
+        return "未回答"
+    state = _clean_text(discussion.get("state"), 40).lower()
+    return DISCUSSION_STATES.get(state, state or "开放")
 
 
 def _event_detail(event_name: str, action: str, payload: Mapping[str, Any]) -> str:
@@ -150,6 +224,81 @@ def build_notification(
         message = _join_message_lines(lines)
         return message if include_url else _remove_urls(message)
 
+    sender = _login(payload.get("sender")) or _clean_text(actor, 80)
+
+    if event_name == "release":
+        release = payload.get("release") or {}
+        tag = _clean_text(release.get("tag_name"), 120) or "未命名"
+        name = _clean_text(release.get("name"), 220) or tag
+        action_label = RELEASE_ACTIONS.get(action, f"状态已变更（{action}）")
+        lines = [
+            f"{prefix} Release {tag} {action_label}",
+            f"名称：{name}",
+            f"状态：{_release_status(release)}",
+            f"操作者：{sender}",
+        ]
+        html_url = _clean_text(release.get("html_url"), 500)
+        if include_url and html_url:
+            lines.append(f"链接：{html_url}")
+        message = _join_message_lines(lines)
+        return message if include_url else _remove_urls(message)
+
+    if event_name in {"deployment", "deployment_status"}:
+        deployment = payload.get("deployment") or {}
+        environment = _clean_text(deployment.get("environment"), 120) or "未指定"
+        ref = _clean_text(deployment.get("ref"), 120)
+        if not ref:
+            ref = _clean_text(deployment.get("sha"), 12)[:7] or "未指定"
+
+        if event_name == "deployment":
+            action_label = "已创建"
+            status_label = "已创建"
+            status = {}
+        else:
+            action_label = "状态已更新"
+            status = payload.get("deployment_status") or {}
+            state = _clean_text(status.get("state"), 40).lower()
+            status_label = DEPLOYMENT_STATES.get(state, state or "未知")
+
+        lines = [
+            f"{prefix} Deployment {action_label}",
+            f"环境：{environment}",
+            f"Ref：{ref}",
+            f"状态：{status_label}",
+            f"操作者：{sender}",
+        ]
+        environment_url = _safe_deployment_url(status.get("environment_url"))
+        log_url = _safe_deployment_url(status.get("log_url"))
+        if include_url and environment_url:
+            lines.append(f"环境链接：{environment_url}")
+        elif include_url and log_url:
+            lines.append(f"日志：{log_url}")
+        message = _join_message_lines(lines)
+        return message if include_url else _remove_urls(message)
+
+    if event_name == "discussion":
+        discussion = payload.get("discussion") or {}
+        number = discussion.get("number") or "?"
+        title = _clean_text(discussion.get("title"), 220)
+        category = discussion.get("category") or {}
+        category_name = _clean_text(category.get("name"), 100) or "未分类"
+        action_label = DISCUSSION_ACTIONS.get(action, f"状态已变更（{action}）")
+        lines = [
+            f"{prefix} Discussion #{number} {action_label}",
+            f"标题：{title}",
+            f"分类：{category_name}",
+            f"状态：{_discussion_status(discussion, action)}",
+            f"操作者：{sender}",
+        ]
+        detail = _event_detail(event_name, action, payload)
+        if detail and not detail.endswith("："):
+            lines.append(detail)
+        html_url = _clean_text(discussion.get("html_url"), 500)
+        if include_url and html_url:
+            lines.append(f"链接：{html_url}")
+        message = _join_message_lines(lines)
+        return message if include_url else _remove_urls(message)
+
     if event_name == "issues":
         item = payload.get("issue") or {}
         item_name = "Issue"
@@ -166,7 +315,6 @@ def build_notification(
 
     number = item.get("number") or payload.get("number") or "?"
     title = _clean_text(item.get("title"), 220)
-    sender = _login(payload.get("sender")) or _clean_text(actor, 80)
     detail = _event_detail(event_name, action, payload)
     html_url = _clean_text(item.get("html_url"), 500)
 

--- a/script/github/test_notify_qq.py
+++ b/script/github/test_notify_qq.py
@@ -82,6 +82,123 @@ class NotificationFormattingTest(unittest.TestCase):
         self.assertIn("提交已更新", message)
         self.assertIn("提交：1111111 -> 2222222", message)
 
+    def test_release_published_includes_metadata_but_not_body(self):
+        payload = {
+            "action": "published",
+            "release": {
+                "tag_name": "v5.4.0",
+                "name": "Chat2DB 5.4.0",
+                "draft": False,
+                "prerelease": False,
+                "body": "release body must stay private",
+                "html_url": "https://github.com/OtterMind/Chat2DB/releases/tag/v5.4.0",
+            },
+            "sender": {"login": "release-manager"},
+        }
+
+        message = notify_qq.build_notification(
+            "release",
+            payload,
+            "OtterMind/Chat2DB",
+            "release-manager",
+            "",
+            include_url=True,
+        )
+
+        self.assertIn("Release v5.4.0 已发布", message)
+        self.assertIn("名称：Chat2DB 5.4.0", message)
+        self.assertIn("状态：正式发布", message)
+        self.assertIn("操作者：release-manager", message)
+        self.assertIn("/releases/tag/v5.4.0", message)
+        self.assertNotIn("release body must stay private", message)
+
+    def test_deployment_created_includes_environment_and_ref(self):
+        payload = {
+            "action": "created",
+            "deployment": {
+                "environment": "staging",
+                "ref": "main",
+                "payload": {"secret": "must-not-leak"},
+            },
+            "sender": {"login": "deploy-bot"},
+        }
+
+        message = notify_qq.build_notification(
+            "deployment",
+            payload,
+            "OtterMind/Chat2DB",
+            "deploy-bot",
+            "",
+            include_url=True,
+        )
+
+        self.assertIn("Deployment 已创建", message)
+        self.assertIn("环境：staging", message)
+        self.assertIn("Ref：main", message)
+        self.assertIn("状态：已创建", message)
+        self.assertNotIn("must-not-leak", message)
+
+    def test_deployment_status_uses_environment_url_without_query_credentials(self):
+        payload = {
+            "action": "created",
+            "deployment": {"environment": "production", "ref": "v5.4.0"},
+            "deployment_status": {
+                "state": "success",
+                "environment_url": "https://chat2db.example.com/app?token=must-not-leak",
+                "log_url": "https://logs.example.com/deploy/42?key=must-not-leak",
+            },
+            "sender": {"login": "github-actions"},
+        }
+
+        message = notify_qq.build_notification(
+            "deployment_status",
+            payload,
+            "OtterMind/Chat2DB",
+            "github-actions",
+            "",
+            include_url=True,
+        )
+
+        self.assertIn("Deployment 状态已更新", message)
+        self.assertIn("环境：production", message)
+        self.assertIn("Ref：v5.4.0", message)
+        self.assertIn("状态：成功", message)
+        self.assertIn("环境链接：https://chat2db.example.com/app", message)
+        self.assertNotIn("must-not-leak", message)
+        self.assertNotIn("logs.example.com", message)
+
+    def test_discussion_includes_category_and_status_but_not_body(self):
+        payload = {
+            "action": "created",
+            "discussion": {
+                "number": 12,
+                "title": "How should migrations work?",
+                "body": "discussion body must stay private",
+                "state": "open",
+                "locked": False,
+                "category": {"name": "Q&A"},
+                "html_url": "https://github.com/OtterMind/Chat2DB/discussions/12",
+            },
+            "sender": {"login": "community-member"},
+        }
+
+        message = notify_qq.build_notification(
+            "discussion",
+            payload,
+            "OtterMind/Chat2DB",
+            "community-member",
+            "",
+            include_url=True,
+        )
+
+        self.assertIn("Discussion #12 已创建", message)
+        self.assertIn("标题：How should migrations work?", message)
+        self.assertIn("分类：Q&A", message)
+        self.assertIn("状态：开放", message)
+        self.assertIn("操作者：community-member", message)
+        self.assertIn("/discussions/12", message)
+        self.assertNotIn("discussion body must stay private", message)
+
     def test_untrusted_title_is_bounded_and_control_characters_are_removed(self):
         payload = {
             "action": "edited",


### PR DESCRIPTION
## Related issue

Closes #2003

## Summary

Extend the existing QQ group notification workflow to cover Release lifecycle,
Deployment creation and status updates, and Discussion lifecycle events. The
formatter sends only bounded event metadata and intentionally excludes Release
and Discussion bodies, Discussion comments, Deployment payloads, and URL query
strings that may contain credentials.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `python3 script/github/test_notify_qq.py` - 17 tests passed.
  - `python3 script/github/qq_relay/test_relay_server.py` - 13 tests passed.
  - `actionlint .github/workflows/ci.yml .github/workflows/qq-group-notifications.yml` - passed with no findings.
  - `python3 -m py_compile script/github/notify_qq.py script/github/test_notify_qq.py` - passed.
  - `git diff --check` - passed.
- Manual verification: N/A before merge. A representative live repository event
  must be triggered after the trusted notifier lands on the default branch.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A; no product API or stored data changes.
- Database or driver compatibility: N/A; no database or driver changes.
- Network, privacy, or security: Uses the existing authenticated fixed-group
  relay. New formatters allowlist metadata, omit bodies and Deployment payloads,
  and strip query strings and fragments from Deployment links.
- Community / Local / Pro boundary: Repository automation only; no edition
  runtime behavior changes.
- Backward compatibility: Existing Issue, pull-request, and manual-test message
  paths are unchanged and remain covered by regression tests.

## Reviewer map

- Start here: `.github/workflows/qq-group-notifications.yml`, then
  `script/github/notify_qq.py::build_notification`.
- Failure condition: A subscribed event does not start the workflow, includes a
  disallowed payload field, or cannot be formatted and accepted by the relay.
- Rollback or disable path: Revert this PR to remove only the new event coverage,
  or disable `QQ group notifications` to stop all sends immediately.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with implementation, tests, documentation, and
verification; the resulting changes were reviewed against the Issue scope.
