### PR TITLE
docs(ci): clarify inactive deployment notification limit

### DIFF
--- a/.github/QQ_GROUP_NOTIFICATIONS.md
+++ b/.github/QQ_GROUP_NOTIFICATIONS.md
@@ -108,9 +108,10 @@ The workflow sends these repository events:
 - Release `published`, `unpublished`, `created`, `edited`, `deleted`,
   `prereleased`, and `released` events. Messages include the tag, release name,
   release state, actor, and release URL.
-- Deployment creation and every Deployment status update. Messages include the
-  environment, ref, mapped status, actor, and an environment or log URL when
-  GitHub provides one. URL query strings and fragments are removed.
+- Deployment creation and Deployment status updates emitted to Actions.
+  Messages include the environment, ref, mapped status, actor, and an
+  environment or log URL when GitHub provides one. URL query strings and
+  fragments are removed.
 - Discussion `created`, `edited`, `deleted`, `transferred`, `pinned`,
   `unpinned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `category_changed`,
   `answered`, and `unanswered` events. Messages include the number, title,
@@ -120,6 +121,9 @@ Discussion comments are intentionally not subscribed to and do not generate QQ
 messages. GitHub does not run the `created`, `edited`, or `deleted` Release
 activity types for draft releases; `published` is the reliable event for both
 stable releases and prereleases when they become public.
+GitHub also does not start `deployment_status` workflows when a Deployment is
+set to `inactive`, so transient-environment cleanup does not generate a QQ
+message.
 
 ## Verification
 


### PR DESCRIPTION
## Related issue

Closes #2003

## Summary

Correct the QQ notification operations guide after live Deployment validation.
GitHub Actions does not start a `deployment_status` workflow for the `inactive`
state, so the guide now documents that platform exception instead of claiming
that every status update creates a QQ message.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [x] Documentation only

## Verification

- Commands and results:
  - `git diff --check` - passed.
- Manual verification: Deployment `5584461344` emitted successful `deployment`
  and `deployment_status` workflow runs for creation and `success`; setting it to
  `inactive` created status `15880351577` but did not start a workflow.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A; documentation only.
- Database or driver compatibility: N/A; documentation only.
- Network, privacy, or security: N/A; no runtime configuration changed.
- Community / Local / Pro boundary: Community repository operations guide only.
- Backward compatibility: N/A; no behavior changed.

## Reviewer map

- Start here: `.github/QQ_GROUP_NOTIFICATIONS.md` notification coverage section.
- Failure condition: The guide implies `inactive` can trigger an Actions workflow.
- Rollback or disable path: Revert this documentation commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with live verification and documentation wording.
