### PR TITLE
feat(ci): notify QQ about comments and pull request reviews

### DIFF
--- a/.github/QQ_GROUP_NOTIFICATIONS.md
+++ b/.github/QQ_GROUP_NOTIFICATIONS.md
@@ -1,12 +1,20 @@
 # QQ Group Notifications
 
-The `QQ group notifications` workflow sends Issue, pull-request, Release,
-Deployment, and Discussion state changes to QQ group `1080856850` through a
-dedicated NapCat/OneBot account. GitHub Actions can reach the private Mac Studio
-deployment only through an authenticated Cloudflare Tunnel endpoint.
+The `QQ group notifications` workflow sends Issue, pull-request, comment,
+pull-request review, Release, Deployment, and Discussion state changes to QQ
+group `1080856850` through a dedicated NapCat/OneBot account. GitHub Actions can
+reach the private Mac Studio deployment only through an authenticated
+Cloudflare Tunnel endpoint.
 
 ```text
 GitHub Actions -> HTTPS relay -> OneBot HTTP -> NapCat -> QQ group 1080856850
+```
+
+Issue/PR comment and review events use a two-stage path so fork pull requests do
+not need access to repository secrets:
+
+```text
+Unprivileged event collector -> 1-day sanitized artifact -> trusted sender -> HTTPS relay
 ```
 
 The QQ account used by NapCat must be a dedicated secondary account. NapCat is
@@ -21,14 +29,22 @@ protocol changes, or account risk controls.
   token, the exact repository name, a bounded message, and a delivery ID.
 - Successful delivery IDs are deduplicated for 24 hours and accepted sends are
   rate-limited to 30 per minute.
+- The comment/review collector has no secrets, checks out only the default-branch
+  notifier, and uploads one 1-day artifact. The trusted `workflow_run` sender
+  validates its schema, repository, event allowlist, and message length before
+  using relay secrets.
 - NapCat WebUI binds only to host loopback. OneBot HTTP and WebSocket ports are
   not published on the host or Internet.
-- Only Issue, pull-request, and Discussion titles plus selected Release and
-  Deployment metadata are sent. Bodies, comments, source code, Deployment
-  payloads, credentials, and other event payload fields are excluded.
-- `pull_request_target` checks out the notifier from the trusted default branch
-  and never executes pull-request code. A manually dispatched test may use the
-  explicitly selected maintainer branch.
+- Comment and review notifications include at most 180 sanitized characters
+  from the public comment body. Deleted content, diff hunks, and source code are
+  never sent. OneBot CQ-code sequences are neutralized and rejected again by the
+  trusted sender. Because excerpts preserve other public user content,
+  credentials must never be posted in repository comments or reviews.
+- Issue, pull-request, Discussion, and Release bodies, Deployment payloads,
+  credentials, and other event payload fields are excluded.
+- Every repository event checks out the notifier from the trusted default branch
+  and never executes pull-request code or artifact content. A manually dispatched
+  test may use the explicitly selected maintainer branch.
 
 ## Mac Studio deployment
 
@@ -105,6 +121,15 @@ verified.
 The workflow sends these repository events:
 
 - Issue and pull-request lifecycle and state changes listed in the workflow.
+- Issue and pull-request conversation comment `created`, `edited`, and `deleted`
+  events. Messages distinguish Issue comments from pull-request comments and
+  include a bounded excerpt except when content is deleted.
+- Pull-request review `submitted`, `edited`, and `dismissed` events. Submitted
+  reviews distinguish approved, changes-requested, and commented states.
+- Line-level pull-request review comment `created`, `edited`, and `deleted`
+  events. Messages include the file location but exclude the diff hunk. A review
+  containing line comments can generate both a review summary notification and
+  individual line-comment notifications.
 - Release `published`, `unpublished`, `created`, `edited`, `deleted`,
   `prereleased`, and `released` events. Messages include the tag, release name,
   release state, actor, and release URL.
@@ -132,7 +157,10 @@ Run automated checks:
 ```bash
 python3 script/github/test_notify_qq.py
 python3 script/github/qq_relay/test_relay_server.py
-actionlint .github/workflows/ci.yml .github/workflows/qq-group-notifications.yml
+actionlint .github/workflows/ci.yml \
+  .github/workflows/qq-group-notifications.yml \
+  .github/workflows/qq-comment-review-events.yml \
+  .github/workflows/qq-comment-review-sender.yml
 ```
 
 Verify the live path in this order:
@@ -146,12 +174,17 @@ Verify the live path in this order:
    action, number, title, actor, URL, and merged/closed distinction.
 6. Publish or edit a test Release, create a test Deployment status, and change a
    test Discussion state. Confirm their selected metadata and links, and confirm
-   that bodies, comments, Deployment payloads, and URL query strings are absent.
+   that bodies, Deployment payloads, and URL query strings are absent.
+7. Create, edit, and delete a test Issue or pull-request comment, then submit an
+   approved, changes-requested, or commented pull-request review. Confirm the
+   item type, review result, bounded excerpt, actor, and URL; confirm deleted
+   text and diff hunks are absent.
 
 The relay intentionally returns a generic `QQ delivery failed` response when
 OneBot is offline or rejects a message, so internal details are not exposed on
 the public endpoint. Inspect local relay and NapCat container logs for diagnosis.
 
-To stop notifications immediately, disable the GitHub workflow or stop the
-Cloudflare connector. Rotate `RELAY_TOKEN`, `ONEBOT_TOKEN`, and the WebUI token
-by replacing the local values and updating the corresponding consumer.
+To stop notifications immediately, disable the QQ notification workflows or
+stop the Cloudflare connector. Rotate `RELAY_TOKEN`, `ONEBOT_TOKEN`, and the
+WebUI token by replacing the local values and updating the corresponding
+consumer.

--- a/.github/workflows/qq-comment-review-events.yml
+++ b/.github/workflows/qq-comment-review-events.yml
@@ -1,0 +1,55 @@
+name: QQ comment and review event collector
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+      - deleted
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+      - deleted
+
+permissions:
+  contents: read
+
+concurrency:
+  group: qq-comment-review-collect-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}-${{ github.event.comment.id || github.event.review.id || github.event.action }}
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    name: Collect sanitized QQ notification
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Pull-request events from forks do not receive repository secrets. This
+      # job uses no secrets and executes only the notifier from the default branch.
+      - name: Check out the trusted notifier
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: script/github/notify_qq.py
+          sparse-checkout-cone-mode: false
+
+      - name: Build sanitized notification artifact
+        env:
+          QQ_INCLUDE_URL: ${{ vars.QQ_NOTIFICATION_INCLUDE_URL || 'true' }}
+          QQ_MESSAGE_OUTPUT_PATH: qq-notification/message.json
+        run: python3 script/github/notify_qq.py
+
+      - name: Upload notification artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: qq-notification
+          path: qq-notification/message.json
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/qq-comment-review-sender.yml
+++ b/.github/workflows/qq-comment-review-sender.yml
@@ -1,0 +1,50 @@
+name: QQ comment and review notification sender
+
+on:
+  workflow_run:
+    workflows:
+      - QQ comment and review event collector
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: qq-comment-review-send-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  send:
+    name: Send collected QQ notification
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # workflow_run executes from the trusted default branch with secrets. Do
+      # not check out or execute code from the originating pull request.
+      - name: Check out the trusted notifier
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: script/github/notify_qq.py
+          sparse-checkout-cone-mode: false
+
+      - name: Download sanitized notification artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: qq-notification
+          path: qq-notification
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Send notification
+        env:
+          QQ_RELAY_URL: ${{ secrets.QQ_RELAY_URL }}
+          QQ_RELAY_TOKEN: ${{ secrets.QQ_RELAY_TOKEN }}
+          QQ_PREPARED_MESSAGE_PATH: qq-notification/message.json
+          QQ_DELIVERY_ID: ${{ github.event.workflow_run.id }}
+        run: python3 script/github/notify_qq.py

--- a/script/github/notify_qq.py
+++ b/script/github/notify_qq.py
@@ -18,6 +18,11 @@ from urllib.request import Request, urlopen
 
 TRANSIENT_HTTP_STATUSES = {429, 500, 502, 503, 504}
 URL_PATTERN = re.compile(r"(?i)\b(?:https?://|www\.)\S+")
+COLLECTED_EVENT_NAMES = {
+    "issue_comment",
+    "pull_request_review",
+    "pull_request_review_comment",
+}
 
 ISSUE_ACTIONS = {
     "opened": "已打开",
@@ -103,6 +108,26 @@ DISCUSSION_STATES = {
     "closed": "已关闭",
 }
 
+COMMENT_ACTIONS = {
+    "created": "已评论",
+    "edited": "已编辑评论",
+    "deleted": "已删除评论",
+}
+
+REVIEW_COMMENT_ACTIONS = {
+    "created": "新增代码评审评论",
+    "edited": "已编辑代码评审评论",
+    "deleted": "已删除代码评审评论",
+}
+
+REVIEW_STATES = {
+    "approved": "已批准",
+    "changes_requested": "要求修改",
+    "commented": "已评论",
+    "dismissed": "已撤销",
+    "pending": "待提交",
+}
+
 
 class ConfigurationError(RuntimeError):
     """Raised when required GitHub Actions configuration is invalid."""
@@ -120,6 +145,7 @@ class RelayAPIError(RuntimeError):
 def _clean_text(value: Any, max_length: int) -> str:
     text = str(value or "")
     text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", text)
+    text = re.sub(r"(?i)\[CQ:", "[CQ :", text)
     text = re.sub(r"\s+", " ", text).strip()
     if len(text) <= max_length:
         return text
@@ -176,6 +202,70 @@ def _discussion_status(discussion: Mapping[str, Any], action: str) -> str:
     return DISCUSSION_STATES.get(state, state or "开放")
 
 
+def _comment_excerpt(comment: Mapping[str, Any], action: str) -> str:
+    if action in {"deleted", "dismissed"}:
+        return ""
+    return _clean_text(comment.get("body"), 180)
+
+
+def _review_action_label(action: str, state: str) -> str:
+    if action == "dismissed":
+        return "评审已撤销"
+    if action == "edited":
+        return "评审已编辑"
+    if state == "approved":
+        return "评审已批准"
+    if state == "changes_requested":
+        return "评审要求修改"
+    if state == "commented":
+        return "收到评审评论"
+    return "已提交评审"
+
+
+def _write_prepared_message(
+    path: Path, event_name: str, repository: str, message: str
+) -> None:
+    if event_name not in COLLECTED_EVENT_NAMES:
+        raise ConfigurationError(f"Cannot collect unsupported event: {event_name}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "event_name": event_name,
+                "repository": repository,
+                "message": message,
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _read_prepared_message(path: Path, repository: str) -> tuple[str, str]:
+    if not path.is_file() or path.stat().st_size > 4096:
+        raise ConfigurationError("Prepared QQ notification is missing or too large")
+    try:
+        envelope = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ConfigurationError("Prepared QQ notification is not valid JSON") from error
+    if not isinstance(envelope, Mapping) or envelope.get("version") != 1:
+        raise ConfigurationError("Prepared QQ notification has an invalid format")
+    if envelope.get("repository") != repository:
+        raise ConfigurationError("Prepared QQ notification repository does not match")
+    event_name = str(envelope.get("event_name") or "")
+    if event_name not in COLLECTED_EVENT_NAMES:
+        raise ConfigurationError("Prepared QQ notification event is not allowed")
+    message = envelope.get("message")
+    if not isinstance(message, str) or not message or len(message) > 900:
+        raise ConfigurationError("Prepared QQ notification message is invalid")
+    if re.search(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", message):
+        raise ConfigurationError("Prepared QQ notification contains control characters")
+    if re.search(r"(?i)\[CQ:", message):
+        raise ConfigurationError("Prepared QQ notification contains a OneBot CQ code")
+    return event_name, message
+
+
 def _event_detail(event_name: str, action: str, payload: Mapping[str, Any]) -> str:
     if action in {"labeled", "unlabeled"}:
         label = payload.get("label") or {}
@@ -225,6 +315,81 @@ def build_notification(
         return message if include_url else _remove_urls(message)
 
     sender = _login(payload.get("sender")) or _clean_text(actor, 80)
+
+    if event_name == "issue_comment":
+        item = payload.get("issue") or {}
+        comment = payload.get("comment") or {}
+        item_name = "PR" if "pull_request" in item else "Issue"
+        number = item.get("number") or "?"
+        action_label = COMMENT_ACTIONS.get(action, f"评论状态已变更（{action}）")
+        commenter = _login(comment.get("user")) or sender
+        lines = [
+            f"{prefix} {item_name} #{number} {action_label}",
+            f"标题：{_clean_text(item.get('title'), 220)}",
+            f"评论者：{commenter}",
+        ]
+        excerpt = _comment_excerpt(comment, action)
+        if excerpt:
+            lines.append(f"摘要：{excerpt}")
+        html_url = _clean_text(
+            comment.get("html_url") if action != "deleted" else item.get("html_url"),
+            500,
+        )
+        if include_url and html_url:
+            lines.append(f"链接：{html_url}")
+        message = _join_message_lines(lines)
+        return message if include_url else _remove_urls(message)
+
+    if event_name == "pull_request_review":
+        item = payload.get("pull_request") or {}
+        review = payload.get("review") or {}
+        number = item.get("number") or "?"
+        state = _clean_text(review.get("state"), 40).lower()
+        reviewer = _login(review.get("user")) or sender
+        lines = [
+            f"{prefix} PR #{number} {_review_action_label(action, state)}",
+            f"标题：{_clean_text(item.get('title'), 220)}",
+            f"结果：{REVIEW_STATES.get(state, state or '未知')}",
+            f"评审人：{reviewer}",
+        ]
+        excerpt = _comment_excerpt(review, action)
+        if excerpt:
+            lines.append(f"摘要：{excerpt}")
+        html_url = _clean_text(review.get("html_url") or item.get("html_url"), 500)
+        if include_url and html_url:
+            lines.append(f"链接：{html_url}")
+        message = _join_message_lines(lines)
+        return message if include_url else _remove_urls(message)
+
+    if event_name == "pull_request_review_comment":
+        item = payload.get("pull_request") or {}
+        comment = payload.get("comment") or {}
+        number = item.get("number") or "?"
+        action_label = REVIEW_COMMENT_ACTIONS.get(
+            action, f"代码评审评论状态已变更（{action}）"
+        )
+        reviewer = _login(comment.get("user")) or sender
+        path = _clean_text(comment.get("path"), 180)
+        line_number = comment.get("line") or comment.get("original_line")
+        location = f"{path}:{line_number}" if path and line_number else path
+        lines = [
+            f"{prefix} PR #{number} {action_label}",
+            f"标题：{_clean_text(item.get('title'), 220)}",
+            f"评审人：{reviewer}",
+        ]
+        if location:
+            lines.append(f"位置：{location}")
+        excerpt = _comment_excerpt(comment, action)
+        if excerpt:
+            lines.append(f"摘要：{excerpt}")
+        html_url = _clean_text(
+            comment.get("html_url") if action != "deleted" else item.get("html_url"),
+            500,
+        )
+        if include_url and html_url:
+            lines.append(f"链接：{html_url}")
+        message = _join_message_lines(lines)
+        return message if include_url else _remove_urls(message)
 
     if event_name == "release":
         release = payload.get("release") or {}
@@ -431,19 +596,33 @@ def main() -> int:
     run_url = f"{server_url}/{repository}/actions/runs/{run_id}" if run_id else ""
     include_url = _is_true(os.environ.get("QQ_INCLUDE_URL", "true"))
 
-    message = build_notification(
-        event_name, payload, repository, actor, run_url, include_url=include_url
-    )
+    prepared_path = os.environ.get("QQ_PREPARED_MESSAGE_PATH")
+    if prepared_path:
+        event_name, message = _read_prepared_message(Path(prepared_path), repository)
+        action = "prepared"
+    else:
+        message = build_notification(
+            event_name, payload, repository, actor, run_url, include_url=include_url
+        )
+        action = _clean_text(payload.get("action") or "manual", 60)
 
-    action = _clean_text(payload.get("action") or "manual", 60)
+        output_path = os.environ.get("QQ_MESSAGE_OUTPUT_PATH")
+        if output_path:
+            _write_prepared_message(Path(output_path), event_name, repository, message)
+            print(f"QQ notification collected: event={event_name}, action={action}")
+            return 0
+
     if _is_true(os.environ.get("QQ_DRY_RUN")):
         print(f"QQ notification dry run passed: event={event_name}, action={action}")
         return 0
 
-    if not run_id:
-        raise ConfigurationError("GITHUB_RUN_ID is required for relay deduplication")
+    delivery_id = _clean_text(os.environ.get("QQ_DELIVERY_ID") or run_id, 160)
+    if not delivery_id:
+        raise ConfigurationError("A delivery ID is required for relay deduplication")
     relay_url, relay_token = _required_environment()
-    response = send_relay_message(relay_url, relay_token, repository, run_id, message)
+    response = send_relay_message(
+        relay_url, relay_token, repository, delivery_id, message
+    )
     message_id = _clean_text(response.get("message_id"), 160)
     duplicate = bool(response.get("duplicate"))
     url_removed = bool(response.get("url_removed"))

--- a/script/github/test_notify_qq.py
+++ b/script/github/test_notify_qq.py
@@ -5,6 +5,7 @@ import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError
 
@@ -199,6 +200,171 @@ class NotificationFormattingTest(unittest.TestCase):
         self.assertIn("/discussions/12", message)
         self.assertNotIn("discussion body must stay private", message)
 
+    def test_issue_comment_includes_bounded_excerpt(self):
+        payload = {
+            "action": "created",
+            "issue": {
+                "number": 21,
+                "title": "Cannot save datasource",
+                "html_url": "https://github.com/OtterMind/Chat2DB/issues/21",
+            },
+            "comment": {
+                "body": "[CQ:at,qq=all] first line\nsecond line "
+                + "x" * 220
+                + "TAIL_SECRET",
+                "html_url": "https://github.com/OtterMind/Chat2DB/issues/21#issuecomment-1",
+                "user": {"login": "reporter"},
+            },
+            "sender": {"login": "reporter"},
+        }
+
+        message = notify_qq.build_notification(
+            "issue_comment",
+            payload,
+            "OtterMind/Chat2DB",
+            "reporter",
+            "",
+            include_url=True,
+        )
+
+        self.assertIn("Issue #21 已评论", message)
+        self.assertIn("标题：Cannot save datasource", message)
+        self.assertIn("评论者：reporter", message)
+        self.assertIn("摘要：[CQ :at,qq=all] first line second line", message)
+        self.assertNotIn("[CQ:", message)
+        self.assertIn("#issuecomment-1", message)
+        self.assertNotIn("TAIL_SECRET", message)
+
+    def test_deleted_pull_request_comment_does_not_echo_body(self):
+        payload = {
+            "action": "deleted",
+            "issue": {
+                "number": 22,
+                "title": "Fix metadata loading",
+                "html_url": "https://github.com/OtterMind/Chat2DB/pull/22",
+                "pull_request": {"url": "https://api.github.com/pulls/22"},
+            },
+            "comment": {
+                "body": "deleted content must not be sent",
+                "html_url": "https://github.com/OtterMind/Chat2DB/pull/22#issuecomment-2",
+                "user": {"login": "reviewer"},
+            },
+            "sender": {"login": "reviewer"},
+        }
+
+        message = notify_qq.build_notification(
+            "issue_comment",
+            payload,
+            "OtterMind/Chat2DB",
+            "reviewer",
+            "",
+            include_url=True,
+        )
+
+        self.assertIn("PR #22 已删除评论", message)
+        self.assertIn("链接：https://github.com/OtterMind/Chat2DB/pull/22", message)
+        self.assertNotIn("摘要：", message)
+        self.assertNotIn("deleted content", message)
+
+    def test_submitted_pull_request_review_states_are_distinct(self):
+        expectations = {
+            "approved": ("评审已批准", "结果：已批准"),
+            "changes_requested": ("评审要求修改", "结果：要求修改"),
+            "commented": ("收到评审评论", "结果：已评论"),
+        }
+
+        for state, expected in expectations.items():
+            with self.subTest(state=state):
+                payload = {
+                    "action": "submitted",
+                    "pull_request": {
+                        "number": 23,
+                        "title": "Improve SQL editor",
+                        "html_url": "https://github.com/OtterMind/Chat2DB/pull/23",
+                    },
+                    "review": {
+                        "state": state,
+                        "body": "Review summary",
+                        "html_url": "https://github.com/OtterMind/Chat2DB/pull/23#pullrequestreview-3",
+                        "user": {"login": "maintainer"},
+                    },
+                    "sender": {"login": "maintainer"},
+                }
+
+                message = notify_qq.build_notification(
+                    "pull_request_review",
+                    payload,
+                    "OtterMind/Chat2DB",
+                    "maintainer",
+                    "",
+                    include_url=True,
+                )
+
+                self.assertIn(f"PR #23 {expected[0]}", message)
+                self.assertIn(expected[1], message)
+                self.assertIn("评审人：maintainer", message)
+                self.assertIn("摘要：Review summary", message)
+
+    def test_dismissed_review_does_not_echo_body(self):
+        payload = {
+            "action": "dismissed",
+            "pull_request": {"number": 24, "title": "Update parser", "html_url": ""},
+            "review": {
+                "state": "dismissed",
+                "body": "obsolete review must not be sent",
+                "user": {"login": "maintainer"},
+            },
+            "sender": {"login": "maintainer"},
+        }
+
+        message = notify_qq.build_notification(
+            "pull_request_review",
+            payload,
+            "OtterMind/Chat2DB",
+            "maintainer",
+            "",
+            include_url=False,
+        )
+
+        self.assertIn("PR #24 评审已撤销", message)
+        self.assertIn("结果：已撤销", message)
+        self.assertNotIn("摘要：", message)
+        self.assertNotIn("obsolete review", message)
+
+    def test_line_review_comment_includes_location_but_not_diff(self):
+        payload = {
+            "action": "created",
+            "pull_request": {
+                "number": 25,
+                "title": "Fix transaction handling",
+                "html_url": "https://github.com/OtterMind/Chat2DB/pull/25",
+            },
+            "comment": {
+                "body": "Please cover the rollback path.",
+                "diff_hunk": "@@ secret source code must not be sent @@",
+                "path": "script/github/notify_qq.py",
+                "line": 120,
+                "html_url": "https://github.com/OtterMind/Chat2DB/pull/25#discussion_r4",
+                "user": {"login": "reviewer"},
+            },
+            "sender": {"login": "reviewer"},
+        }
+
+        message = notify_qq.build_notification(
+            "pull_request_review_comment",
+            payload,
+            "OtterMind/Chat2DB",
+            "reviewer",
+            "",
+            include_url=True,
+        )
+
+        self.assertIn("PR #25 新增代码评审评论", message)
+        self.assertIn("位置：script/github/notify_qq.py:120", message)
+        self.assertIn("摘要：Please cover the rollback path.", message)
+        self.assertIn("#discussion_r4", message)
+        self.assertNotIn("secret source code", message)
+
     def test_untrusted_title_is_bounded_and_control_characters_are_removed(self):
         payload = {
             "action": "edited",
@@ -338,6 +504,149 @@ class RelayClientTest(unittest.TestCase):
 
             with patch.dict(os.environ, environment, clear=True):
                 self.assertEqual(0, notify_qq.main())
+
+    def test_comment_collector_writes_message_without_secrets(self):
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = os.path.join(directory, "event.json")
+            output_path = os.path.join(directory, "artifact", "message.json")
+            with open(event_path, "w", encoding="utf-8") as event_file:
+                json.dump(
+                    {
+                        "action": "created",
+                        "issue": {"number": 31, "title": "Question", "html_url": ""},
+                        "comment": {
+                            "body": "Collected comment",
+                            "html_url": "",
+                            "user": {"login": "contributor"},
+                        },
+                        "sender": {"login": "contributor"},
+                    },
+                    event_file,
+                )
+            environment = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_EVENT_NAME": "issue_comment",
+                "GITHUB_REPOSITORY": "OtterMind/Chat2DB",
+                "GITHUB_ACTOR": "contributor",
+                "GITHUB_RUN_ID": "301",
+                "QQ_MESSAGE_OUTPUT_PATH": output_path,
+            }
+
+            with patch.dict(os.environ, environment, clear=True):
+                self.assertEqual(0, notify_qq.main())
+
+            with open(output_path, encoding="utf-8") as artifact_file:
+                envelope = json.load(artifact_file)
+            self.assertEqual(1, envelope["version"])
+            self.assertEqual("issue_comment", envelope["event_name"])
+            self.assertEqual("OtterMind/Chat2DB", envelope["repository"])
+            self.assertIn("Issue #31 已评论", envelope["message"])
+
+    @patch("notify_qq.send_relay_message")
+    def test_prepared_sender_uses_original_run_as_delivery_id(self, send_message):
+        send_message.return_value = {"message_id": "55"}
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = os.path.join(directory, "workflow-run.json")
+            message_path = os.path.join(directory, "message.json")
+            with open(event_path, "w", encoding="utf-8") as event_file:
+                json.dump({"action": "completed"}, event_file)
+            with open(message_path, "w", encoding="utf-8") as message_file:
+                json.dump(
+                    {
+                        "version": 1,
+                        "event_name": "pull_request_review",
+                        "repository": "OtterMind/Chat2DB",
+                        "message": "[Chat2DB GitHub] PR #32 评审已批准",
+                    },
+                    message_file,
+                )
+            environment = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_EVENT_NAME": "workflow_run",
+                "GITHUB_REPOSITORY": "OtterMind/Chat2DB",
+                "GITHUB_ACTOR": "github-actions",
+                "GITHUB_RUN_ID": "sender-run",
+                "QQ_PREPARED_MESSAGE_PATH": message_path,
+                "QQ_DELIVERY_ID": "collector-run",
+                "QQ_RELAY_URL": "https://qq-relay.example.com/v1/qq/github",
+                "QQ_RELAY_TOKEN": "relay-secret",
+            }
+
+            with patch.dict(os.environ, environment, clear=True):
+                self.assertEqual(0, notify_qq.main())
+
+        send_message.assert_called_once_with(
+            "https://qq-relay.example.com/v1/qq/github",
+            "relay-secret",
+            "OtterMind/Chat2DB",
+            "collector-run",
+            "[Chat2DB GitHub] PR #32 评审已批准",
+        )
+
+    def test_prepared_sender_rejects_wrong_repository(self):
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as message_file:
+            json.dump(
+                {
+                    "version": 1,
+                    "event_name": "issue_comment",
+                    "repository": "attacker/repository",
+                    "message": "untrusted",
+                },
+                message_file,
+            )
+            message_file.flush()
+
+            with self.assertRaises(notify_qq.ConfigurationError):
+                notify_qq._read_prepared_message(
+                    Path(message_file.name), "OtterMind/Chat2DB"
+                )
+
+    def test_prepared_sender_rejects_onebot_cq_code(self):
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as message_file:
+            json.dump(
+                {
+                    "version": 1,
+                    "event_name": "issue_comment",
+                    "repository": "OtterMind/Chat2DB",
+                    "message": "[Chat2DB GitHub] [CQ:at,qq=all]",
+                },
+                message_file,
+            )
+            message_file.flush()
+
+            with self.assertRaises(notify_qq.ConfigurationError):
+                notify_qq._read_prepared_message(
+                    Path(message_file.name), "OtterMind/Chat2DB"
+                )
+
+    def test_prepared_sender_rejects_unallowed_event_and_oversized_message(self):
+        invalid_envelopes = (
+            {
+                "version": 1,
+                "event_name": "workflow_dispatch",
+                "repository": "OtterMind/Chat2DB",
+                "message": "not a collected event",
+            },
+            {
+                "version": 1,
+                "event_name": "issue_comment",
+                "repository": "OtterMind/Chat2DB",
+                "message": "x" * 901,
+            },
+        )
+
+        for envelope in invalid_envelopes:
+            with self.subTest(event_name=envelope["event_name"]):
+                with tempfile.NamedTemporaryFile(
+                    mode="w", encoding="utf-8"
+                ) as message_file:
+                    json.dump(envelope, message_file)
+                    message_file.flush()
+
+                    with self.assertRaises(notify_qq.ConfigurationError):
+                        notify_qq._read_prepared_message(
+                            Path(message_file.name), "OtterMind/Chat2DB"
+                        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Related issue

Closes #2008

## Summary

Add QQ notifications for Issue/PR conversation comments, pull-request review
decisions, and line-level review comments. Fork pull requests use an
unprivileged collector and a trusted `workflow_run` sender so relay secrets are
never exposed to pull-request workflows. Comment excerpts are bounded to 180
characters, deleted text and diff hunks are omitted, and OneBot CQ-code
sequences are neutralized and rejected before delivery.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `python3 script/github/test_notify_qq.py` - 27 tests passed.
  - `python3 script/github/qq_relay/test_relay_server.py` - 13 tests passed.
  - `actionlint .github/workflows/ci.yml .github/workflows/qq-group-notifications.yml .github/workflows/qq-comment-review-events.yml .github/workflows/qq-comment-review-sender.yml` - passed with no findings.
  - `python3 -m py_compile script/github/notify_qq.py script/github/test_notify_qq.py` - passed.
  - `ruby script/github/validate-community-operations.rb` - 9 contribution boundaries validated.
  - `node --test script/github/issue-claim.test.js script/github/sync-community-project.test.js` - 33 tests passed.
  - `git diff --cached --check` - passed.
- Manual verification: N/A before merge. The collector and trusted sender must
  exist on the default branch before a real comment event can exercise the
  two-stage workflow.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A; no product API or stored data changes.
- Database or driver compatibility: N/A; no database or driver changes.
- Network, privacy, or security: The public event workflow has no secrets and
  never executes PR code. The privileged sender validates the artifact version,
  repository, event allowlist, size, message length, control characters, and CQ
  codes before using the existing relay secrets.
- Community / Local / Pro boundary: Repository automation only; no edition
  runtime behavior changes.
- Backward compatibility: Existing direct Issue, PR, Release, Deployment,
  Discussion, and manual notification paths remain unchanged and covered by
  regression tests.

## Reviewer map

- Start here: `.github/workflows/qq-comment-review-events.yml`, then
  `.github/workflows/qq-comment-review-sender.yml` and the comment branches in
  `script/github/notify_qq.py::build_notification`.
- Failure condition: A comment or review event does not produce both successful
  collector and sender runs, leaks deleted/diff content, or accepts an invalid
  artifact or CQ-code sequence.
- Rollback or disable path: Disable the two comment/review workflows or revert
  this PR; existing state notifications continue independently.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with implementation, security design, tests,
documentation, and verification; the resulting changes were reviewed against
the Issue scope and GitHub's fork-workflow security model.
