### PR TITLE
fix(dashboard-store): use shallow equality like sibling stores

### DIFF
--- a/chat2db-community-client/src/store/dashboard/store.ts
+++ b/chat2db-community-client/src/store/dashboard/store.ts
@@ -1,7 +1,9 @@
 import { devtools } from 'zustand/middleware';
 import { DashboardState, initialState } from './initialState';
 import { CommonAction, createCommonAction } from './slices/common/action';
-import { StateCreator, create } from 'zustand';
+import { StateCreator } from 'zustand';
+import { createWithEqualityFn } from 'zustand/traditional';
+import { shallow } from 'zustand/shallow';
 import { SettingAction, createSettingAction } from './slices/setting/action';
 
 export type DashboardAction = CommonAction & SettingAction;
@@ -13,10 +15,11 @@ const createStore: StateCreator<DashboardStore, [['zustand/devtools', never]]> =
   ...createSettingAction(...parameters),
 });
 
-export const useDashboardStore = create(
+export const useDashboardStore = createWithEqualityFn<DashboardStore>()(
   devtools(createStore, {
     name: 'Chat2DB_Dashboard_Store',
   }),
+  shallow,
 );
 
 export const clearDashboardStore = () => {


### PR DESCRIPTION
## Related issue

Closes #2029

## Summary

`useDashboardStore` was created with the plain `create(...)` from `zustand` (default `Object.is` equality) instead of `createWithEqualityFn(... , shallow)`. Every other store in `src/store` uses `createWithEqualityFn` with `shallow`. Without `shallow`, object-return selectors on the dashboard store returned a new object on each state change, so consuming components re-rendered on every dashboard-store mutation regardless of whether the selected fields changed. Migrated to `createWithEqualityFn<DashboardStore>()(devtools(...), shallow)`, matching the sibling stores.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors reported for `store/dashboard/store.ts`.
- Manual verification: same pattern already used by every sibling store (`store/workspace`, `store/tree`, `store/chat`).
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Strictly fewer re-renders; success path unchanged.

## Reviewer map

- Start here: `store/dashboard/store.ts` — imports (`StateCreator`, `createWithEqualityFn`, `shallow`) and the `createWithEqualityFn<DashboardStore>()(... , shallow)` call.
- Failure condition: Components still re-render on every dashboard-store mutation for unchanged selected fields.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.