### PR TITLE
fix(copilot): scope global store subscription to editorSettings

### DIFF
--- a/chat2db-community-client/src/components/SQLEditor/hooks/useCopilot.tsx
+++ b/chat2db-community-client/src/components/SQLEditor/hooks/useCopilot.tsx
@@ -52,7 +52,7 @@ const useCopilot = ({ editorRef, placeholderContentWidget, canAI, aiInputParams,
   }>();
   const editorZoneIdRef = useRef<string | null>(null);
   const overlayWidgetRef = useRef<monaco.editor.IOverlayWidget>();
-  const globalEditorSettings = useGlobalStore().editorSettings;
+  const globalEditorSettings = useGlobalStore((s) => s.editorSettings);
 
   const focusCopilotInput = useCallback((retryCount = 0) => {
     const overlayDom = overlayDomRef.current?.newOverlayDom as HTMLElement | undefined;


### PR DESCRIPTION
## Related issue

Closes #2030

## Summary

`useCopilot` read `useGlobalStore().editorSettings`, which subscribes to the entire global store. The component re-rendered on every global-store change (settings, modals, requests) instead of only when `editorSettings` changed. Changed to a scoped selector: `useGlobalStore((s) => s.editorSettings)`.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `useCopilot.tsx`. (A pre-existing baseline error exists in the unrelated backup file `useCopilot.back.tsx`.)
- Manual verification: A selector call swap; `editorSettings` is a direct field on the global store.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Strictly fewer re-renders; behavior unchanged.

## Reviewer map

- Start here: `components/SQLEditor/hooks/useCopilot.tsx:55` — `useGlobalStore().editorSettings` -> `useGlobalStore((s) => s.editorSettings)`.
- Failure condition: Component still re-renders on unrelated global-store changes.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.