### PR TITLE
fix(ai-setting): scope org store subscription to curOrg

### DIFF
--- a/chat2db-community-client/src/blocks/Setting/AISetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/AISetting/index.tsx
@@ -21,7 +21,7 @@ function capitalizeFirstLetter(string) {
 // openAI
 export default function SettingAI(props: IProps) {
   const { styles } = useStyles();
-  const { curOrg } = useOrgStore();
+  const curOrg = useOrgStore((s) => s.curOrg);
   const [aiConfig, setAiConfig] = useState<IAiConfig>();
 
   // have modification permission?


### PR DESCRIPTION
## Related issue

Closes #2031

## Summary

`AISetting` read `const { curOrg } = useOrgStore();`, subscribing to the entire org store. The component re-rendered on every org-store change instead of only when `curOrg` changed. Changed to a scoped selector: `const curOrg = useOrgStore((s) => s.curOrg);`. Downstream usage (`curOrg?.roleCodes`) is unchanged.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `AISetting/index.tsx`.
- Manual verification: A selector swap; `curOrg` is a direct field on the org store.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Strictly fewer re-renders; behavior unchanged.

## Reviewer map

- Start here: `blocks/Setting/AISetting/index.tsx:24` — `const { curOrg } = useOrgStore();` -> `const curOrg = useOrgStore((s) => s.curOrg);`.
- Failure condition: Component still re-renders on unrelated org-store changes.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.