### PR TITLE
fix(hive): guard split length before indexing column default key

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/main/java/ai/chat2db/plugin/hive/HiveMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/main/java/ai/chat2db/plugin/hive/HiveMetaData.java
@@ -198,7 +198,8 @@ public class HiveMetaData extends DefaultMetaService implements IDbMetaData {
                         String defaultConstraintName = resultSet.getString(2).trim();
                         resultSet.next();
 
-                        key = resultSet.getString(1).trim().split(":")[1];
+                        String[] keyParts = resultSet.getString(1).trim().split(":");
+                        key = keyParts.length > 1 ? keyParts[1] : keyParts[0];
                         value = resultSet.getString(2).trim();
                         int valueIndex = value.indexOf(":");
                         value = value.substring(valueIndex + 1);


### PR DESCRIPTION
## Related issue

Closes #2035

## Summary

In `HiveMetaData`, a DESCRIBE-formatted cell value is split on `:` and the second part taken with `resultSet.getString(1).trim().split(":")[1]`, with no length check. If the cell value lacks a `:`, `split` returns a one-element array and `[1]` throws `ArrayIndexOutOfBoundsException`, aborting metadata retrieval. Guarded the split length, falling back to the whole value when there is no colon (consistent with how `value` is handled just below via `indexOf`/`substring`, which already tolerates a missing `:`).

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `mvn -B -q -f chat2db-community-server/pom.xml -pl chat2db-community-plugins/chat2db-community-hive -am -Dmaven.test.skip=true compile` -> BUILD SUCCESS.
- Manual verification: For a cell `"col:default"`, `keyParts.length > 1` is true and `key = "default"` (unchanged). For a cell `"col"` (no colon), `keyParts.length` is 1 and `key = "col"` instead of throwing.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: Hive metadata parsing no longer crashes on cells lacking `:`; normal cells produce identical `key`.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only changes the failure path from AIOOBE to a graceful fallback; normal path unchanged.

## Reviewer map

- Start here: `HiveMetaData.java:201` — `resultSet.getString(1).trim().split(":")[1]` -> split into `keyParts` and index with a length guard.
- Failure condition: Metadata retrieval still throws AIOOBE on a DESCRIBE cell lacking `:`.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.