### PR TITLE
fix(sqlserver): drop dead Arrays.asList() branch and dedupe FLOAT

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
@@ -280,7 +280,7 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
             }
             return script.toString();
         }
-        if (Arrays.asList(DECIMAL, FLOAT, TIMESTAMP, FLOAT, NUMERIC).contains(type)) {
+        if (Arrays.asList(DECIMAL, FLOAT, TIMESTAMP, NUMERIC).contains(type)) {
             StringBuilder script = new StringBuilder();
             script.append(columnType);
             if (column.getColumnSize() != null && column.getDecimalDigits() == null) {
@@ -291,16 +291,6 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
             return script.toString();
         }
 
-        if (Arrays.asList().contains(type)) {
-            StringBuilder script = new StringBuilder();
-            if (column.getColumnSize() == null) {
-                script.append(columnType);
-            } else {
-                String[] split = columnType.split("TIMESTAMP");
-                script.append("TIMESTAMP").append("(").append(column.getColumnSize()).append(")").append(split[1]);
-            }
-            return script.toString();
-        }
         if (OTHER.equals(columnType)) {
             return column.getColumnType();
         }


### PR DESCRIPTION
## Related issue

Closes #2036

## Summary

In `SqlServerColumnTypeEnum.buildDataType`:
- `if (Arrays.asList().contains(type))` used an empty list, so the branch was unreachable dead code. Inside it, `columnType.split("TIMESTAMP")` was indexed with `[1]` with no length guard, which would throw `ArrayIndexOutOfBoundsException` for any column type lacking the literal `TIMESTAMP` substring if the branch were ever reached. Removed the dead branch.
- The numeric-type branch listed `FLOAT` twice (`Arrays.asList(DECIMAL, FLOAT, TIMESTAMP, FLOAT, NUMERIC)`). Removed the duplicate.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `mvn -B -q -f chat2db-community-server/pom.xml -pl chat2db-community-plugins/chat2db-community-sqlserver -am -Dmaven.test.skip=true compile` -> BUILD SUCCESS.
- Manual verification: The removed branch was unreachable (`Arrays.asList().contains(...)` is always `false`), so no runtime behavior changes. The deduplicated list produces the same `contains` result.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: No behavior change (dead branch removed, duplicate removed).
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Identical behavior.

## Reviewer map

- Start here: `SqlServerColumnTypeEnum.java:283` (dedupe `FLOAT`) and the removed `if (Arrays.asList().contains(type))` block that followed it.
- Failure condition: N/A (dead code removal; no runtime path changes).
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.