### PR TITLE
fix(chat): contain oversized conversation content

### DIFF
--- a/chat2db-community-client/src/pages/main/style.ts
+++ b/chat2db-community-client/src/pages/main/style.ts
@@ -123,6 +123,7 @@ export const useStyles = createStyles(({ css, token }, { sidebarExpanded }: { si
       position: relative;
       flex: 1;
       background-color: ${token.colorBgBase};
+      overflow: auto;
     `,
     componentBox: css`
       width: 100%;


### PR DESCRIPTION
## Related issue

Closes #2047

## Summary

Add an overflow boundary to the shared right-side main content container.

Chat answers intentionally keep code blocks unwrapped, but a very long unbroken SQL line could previously contribute its intrinsic width to the flex layout and expand the entire conversation page. The right content container now owns overflow, so oversized descendants scroll inside the available page area without changing code-wrapping behavior.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn eslint src/pages/main/style.ts --max-warnings=0` - passed.
  - `TSX_TSCONFIG_PATH=<worktree>/chat2db-community-client/tsconfig.json yarn run build:web:community --app_version=5.3.1` - both configured prebuild tests passed and Webpack compiled successfully.
  - `node --check dist/umi.js` - passed.
  - `node --check dist/preload_helper.js` - passed.
  - `git diff --check` - passed.
- Manual verification: The rebuilt Community desktop renderer was loaded in a local Chat2DB Community `5.3.1` JCEF app and reached the Community main screen without new JCEF console errors. The reporter confirmed that the rebuilt `dist/` fixes the long-SQL conversation layout.
- UI evidence: Reporter-confirmed with the rebuilt Community desktop `dist/`; no screenshot is attached to avoid including conversation content.

## Risk and compatibility

- Public API or stored data: N/A. CSS-only change.
- Database or driver compatibility: N/A. No query, driver, or result data changes.
- Network, privacy, or security: N/A. No network or data-flow changes.
- Community / Local / Pro boundary: Community Desktop was verified. The declaration is on the shared main content style and introduces no edition-specific behavior.
- Backward compatibility: Low risk. Normal-size content is unchanged; only overflowing descendants move scrolling to the right content container.

## Reviewer map

- Start here: `chat2db-community-client/src/pages/main/style.ts`, `rightContainer`.
- Failure condition: The right content area no longer fills its flex space, or an existing nested view develops unusable double scrolling.
- Rollback or disable path: Remove the single `overflow: auto` declaration.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for root-cause analysis, the minimal CSS change, verification, and contribution-workflow preparation. The resulting one-line change was reviewed and runtime-tested before submission.
