### PR TITLE
fix(storage): persist deletions and clean up detail files in LargeDataStorage

### DIFF
--- a/chat2db-community-server/chat2db-community-storage/pom.xml
+++ b/chat2db-community-server/chat2db-community-storage/pom.xml
@@ -45,5 +45,10 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/IdUtil.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/IdUtil.java
@@ -1,9 +1,18 @@
 package ai.chat2db.community.storage;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import ai.chat2db.community.tools.model.Context;
 import ai.chat2db.community.tools.util.ContextUtils;
 
 public class IdUtil {
+
+    /**
+     * Last timestamp handed out. Calls within the same millisecond (or after a
+     * clock rollback) borrow the next millisecond so the timestamp part is
+     * strictly increasing and ids never collide.
+     */
+    private static final AtomicLong LAST_TIMESTAMP = new AtomicLong(-1L);
 
     public static Long generateId() {
         Long userId = null;
@@ -14,7 +23,10 @@ public class IdUtil {
         if (userId == null) {
             userId = 0L;
         }
-        String id = System.currentTimeMillis() + "" + Math.floorMod(userId, 1000);
+        long timestamp = LAST_TIMESTAMP.updateAndGet(
+            last -> Math.max(last + 1, System.currentTimeMillis()));
+        // Kept as timestamp + userId%1000 so ids stay within JS Number.MAX_SAFE_INTEGER.
+        String id = timestamp + "" + Math.floorMod(userId, 1000);
         return Long.parseLong(id);
     }
 

--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/IdUtil.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/IdUtil.java
@@ -7,6 +7,8 @@ import ai.chat2db.community.tools.util.ContextUtils;
 
 public class IdUtil {
 
+    private static final long USER_ID_BUCKETS = 1000L;
+
     /**
      * Last timestamp handed out. Calls within the same millisecond (or after a
      * clock rollback) borrow the next millisecond so the timestamp part is
@@ -25,9 +27,9 @@ public class IdUtil {
         }
         long timestamp = LAST_TIMESTAMP.updateAndGet(
             last -> Math.max(last + 1, System.currentTimeMillis()));
-        // Kept as timestamp + userId%1000 so ids stay within JS Number.MAX_SAFE_INTEGER.
-        String id = timestamp + "" + Math.floorMod(userId, 1000);
-        return Long.parseLong(id);
+        long userSuffix = Math.floorMod(userId, USER_ID_BUCKETS);
+        // Reserve three decimal digits for the user suffix so full ids preserve timestamp ordering.
+        return Math.addExact(Math.multiplyExact(timestamp, USER_ID_BUCKETS), userSuffix);
     }
 
 }

--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/large/LargeDataStorage.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/large/LargeDataStorage.java
@@ -80,8 +80,8 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
             if (dataMap.size() >= limit) {
                 Map.Entry<Long, T> entry = dataMap.pollFirstEntry();
                 if (entry != null) {
-                    dataMap.remove(entry.getKey());
                     saveDataList();
+                    deleteDetailData(entry.getKey());
                 }
             }
             Long id = LocalStorageConverter.ensureId(data, this::generateId);
@@ -134,6 +134,19 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
     public void delete(Long id) {
         dataMap.remove(id);
         saveDataList();
+        deleteDetailData(id);
+    }
+
+    protected void deleteDetailData(Long id) {
+        if (id == null) {
+            return;
+        }
+        try {
+            String detailFile = DB_STORAGE_PATH + File.separator + name + File.separator + id + ".json";
+            FileUtil.del(detailFile);
+        } catch (Exception e) {
+            log.error("deleteDetailData error", e);
+        }
     }
 
     protected void saveDataList() {
@@ -142,6 +155,8 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
             if (CollectionUtils.isNotEmpty(dataList)) {
                 String data = dataList.stream().map(String::valueOf).collect(Collectors.joining("\n"));
                 FileUtil.writeUtf8String(data + "\n", filePath);
+            } else {
+                FileUtil.writeUtf8String("", filePath);
             }
         } catch (Exception e) {
             log.error("saveDataList error", e);

--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/large/LargeDataStorage.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/large/LargeDataStorage.java
@@ -72,7 +72,7 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
     }
 
     @Override
-    public Long save(T data) {
+    public synchronized Long save(T data) {
         if (data == null) {
             return null;
         }
@@ -113,7 +113,7 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
 
 
     @Override
-    public void update(T data) {
+    public synchronized void update(T data) {
         if (data == null) {
             return;
         }
@@ -123,6 +123,9 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
                 return;
             }
             T before = dataMap.get(id);
+            if (before == null) {
+                return;
+            }
             before = getAfterSave(before, data);
             saveDetailData(id, before);
         } catch (Exception e) {
@@ -131,7 +134,10 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
     }
 
     @Override
-    public void delete(Long id) {
+    public synchronized void delete(Long id) {
+        if (id == null) {
+            return;
+        }
         dataMap.remove(id);
         saveDataList();
         deleteDetailData(id);

--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/large/LargeDataStorage.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/large/LargeDataStorage.java
@@ -26,6 +26,8 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
     private ConcurrentSkipListMap<Long, T> dataMap = new ConcurrentSkipListMap<>();
 
 
+    private String storageDir;
+
     private String filePath;
 
     private String name;
@@ -33,7 +35,12 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
     private int limit;
 
     protected LargeDataStorage(String name, Class<T> clazz, int limit) {
-        this.filePath = DB_STORAGE_PATH + File.separator + name + File.separator + name + ".json";
+        this(name, clazz, limit, DB_STORAGE_PATH);
+    }
+
+    protected LargeDataStorage(String name, Class<T> clazz, int limit, String storageBasePath) {
+        this.storageDir = storageBasePath + File.separator + name;
+        this.filePath = storageDir + File.separator + name + ".json";
         this.limit = limit;
         this.name = name;
         if (!FileUtil.exist(filePath)) {
@@ -43,8 +50,7 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
                 if (StringUtils.isNotBlank(line)) {
                     try {
                         Long id = Long.parseLong(line.trim());
-                        String detailFilePath = DB_STORAGE_PATH + File.separator + name + File.separator + id + ".json";
-                        String detail = FileUtil.readUtf8String(detailFilePath);
+                        String detail = FileUtil.readUtf8String(detailFilePath(id));
                         if (StringUtils.isNotBlank(detail)) {
                             T t = JSON.parseObject(detail, clazz);
                             dataMap.put(id, t);
@@ -55,6 +61,10 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
                 }
             });
         }
+    }
+
+    private String detailFilePath(Long id) {
+        return storageDir + File.separator + id + ".json";
     }
 
     @Override
@@ -104,8 +114,7 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
             return;
         }
         try {
-            String detailFile = DB_STORAGE_PATH + File.separator + name + File.separator + id + ".json";
-            FileUtil.writeUtf8String(JSON.toJSONString(data), detailFile);
+            FileUtil.writeUtf8String(JSON.toJSONString(data), detailFilePath(id));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -148,8 +157,7 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
             return;
         }
         try {
-            String detailFile = DB_STORAGE_PATH + File.separator + name + File.separator + id + ".json";
-            FileUtil.del(detailFile);
+            FileUtil.del(detailFilePath(id));
         } catch (Exception e) {
             log.error("deleteDetailData error", e);
         }

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/IdUtilTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/IdUtilTest.java
@@ -1,0 +1,63 @@
+package ai.chat2db.community.storage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IdUtilTest {
+
+    @Test
+    void backToBackCallsMustNotProduceDuplicateIds() {
+        int count = 5000;
+        Set<Long> ids = new HashSet<>();
+        for (int i = 0; i < count; i++) {
+            ids.add(IdUtil.generateId());
+        }
+        assertEquals(count, ids.size(), "ids generated in a tight loop must be unique");
+    }
+
+    @Test
+    void idsMustBeStrictlyIncreasing() {
+        Long previous = IdUtil.generateId();
+        for (int i = 0; i < 1000; i++) {
+            Long next = IdUtil.generateId();
+            assertTrue(next > previous, "ids must be strictly increasing: " + previous + " -> " + next);
+            previous = next;
+        }
+    }
+
+    @Test
+    void concurrentCallsMustNotProduceDuplicateIds() throws Exception {
+        int threads = 8;
+        int perThread = 1000;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<List<Long>>> futures = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                futures.add(executor.submit(() -> {
+                    List<Long> ids = new ArrayList<>(perThread);
+                    for (int i = 0; i < perThread; i++) {
+                        ids.add(IdUtil.generateId());
+                    }
+                    return ids;
+                }));
+            }
+            Set<Long> all = new HashSet<>();
+            for (Future<List<Long>> future : futures) {
+                all.addAll(future.get());
+            }
+            assertEquals(threads * perThread, all.size(), "ids generated concurrently must be unique");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/IdUtilTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/IdUtilTest.java
@@ -1,5 +1,8 @@
 package ai.chat2db.community.storage;
 
+import ai.chat2db.community.tools.model.Context;
+import ai.chat2db.community.tools.model.LoginUser;
+import ai.chat2db.community.tools.util.ContextUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -36,6 +39,21 @@ public class IdUtilTest {
     }
 
     @Test
+    void idsMustRemainIncreasingWhenUserSuffixWidthChanges() {
+        try {
+            ContextUtils.setContext(context(999L));
+            Long previous = IdUtil.generateId();
+            ContextUtils.setContext(context(0L));
+            Long next = IdUtil.generateId();
+
+            assertTrue(next > previous,
+                    "the fixed-width user suffix must preserve timestamp ordering: " + previous + " -> " + next);
+        } finally {
+            ContextUtils.removeContext();
+        }
+    }
+
+    @Test
     void concurrentCallsMustNotProduceDuplicateIds() throws Exception {
         int threads = 8;
         int perThread = 1000;
@@ -59,5 +77,11 @@ public class IdUtilTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    private Context context(Long userId) {
+        LoginUser loginUser = new LoginUser();
+        loginUser.setId(userId);
+        return Context.builder().loginUser(loginUser).build();
     }
 }

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/large/LargeDataStorageTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/large/LargeDataStorageTest.java
@@ -1,0 +1,117 @@
+package ai.chat2db.community.storage.large;
+
+import ai.chat2db.community.tools.util.ConfigUtils;
+import cn.hutool.core.io.FileUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LargeDataStorageTest {
+
+    public static class Item {
+        private Long id;
+        private String value;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    static class TestStorage extends LargeDataStorage<Item> {
+        TestStorage(String name, int limit) {
+            super(name, Item.class, limit);
+        }
+    }
+
+    private final String name = "test_large_data_" + System.nanoTime();
+
+    private File storageDir() {
+        return new File(ConfigUtils.getEnvBasePath() + File.separator + "storage" + File.separator + name);
+    }
+
+    private File detailFile(Long id) {
+        return new File(storageDir(), id + ".json");
+    }
+
+    private Item item(String value) {
+        Item item = new Item();
+        item.setValue(value);
+        return item;
+    }
+
+    /**
+     * IdUtil.generateId() is millisecond-based, so back-to-back saves can
+     * collide on the same id. Tests assign explicit ids to stay deterministic.
+     */
+    private Item item(String value, long id) {
+        Item item = item(value);
+        item.setId(id);
+        return item;
+    }
+
+    @AfterEach
+    void cleanUp() {
+        FileUtil.del(storageDir());
+    }
+
+    @Test
+    void deletedLastRecordMustNotResurrectAfterReload() {
+        TestStorage storage = new TestStorage(name, 10);
+        Long id = storage.save(item("only"));
+
+        storage.delete(id);
+
+        TestStorage reloaded = new TestStorage(name, 10);
+        assertTrue(reloaded.getDataList().isEmpty(), "deleted record must not reappear after reload");
+    }
+
+    @Test
+    void deleteRemovesDetailFile() {
+        TestStorage storage = new TestStorage(name, 10);
+        Long keptId = storage.save(item("kept", 1L));
+        Long deletedId = storage.save(item("deleted", 2L));
+
+        storage.delete(deletedId);
+
+        assertFalse(detailFile(deletedId).exists(), "detail file of deleted record must be removed");
+        assertTrue(detailFile(keptId).exists(), "detail file of remaining record must be kept");
+
+        TestStorage reloaded = new TestStorage(name, 10);
+        List<Item> items = reloaded.getDataList();
+        assertEquals(1, items.size());
+        assertEquals("kept", items.get(0).getValue());
+    }
+
+    @Test
+    void evictionRemovesDetailFileOfEvictedRecord() {
+        TestStorage storage = new TestStorage(name, 2);
+        Long first = storage.save(item("first", 1L));
+        storage.save(item("second", 2L));
+        storage.save(item("third", 3L));
+
+        assertFalse(detailFile(first).exists(), "detail file of evicted record must be removed");
+
+        TestStorage reloaded = new TestStorage(name, 2);
+        assertEquals(2, reloaded.getDataList().size());
+        assertTrue(reloaded.getDataList().stream().noneMatch(i -> "first".equals(i.getValue())),
+                "evicted record must not reappear after reload");
+    }
+}

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/large/LargeDataStorageTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/large/LargeDataStorageTest.java
@@ -7,9 +7,16 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LargeDataStorageTest {
@@ -41,6 +48,27 @@ class LargeDataStorageTest {
         }
     }
 
+    static class BlockingUpdateStorage extends TestStorage {
+        private final CountDownLatch updateReadExisting = new CountDownLatch(1);
+        private final CountDownLatch continueUpdate = new CountDownLatch(1);
+
+        BlockingUpdateStorage(String name, int limit) {
+            super(name, limit);
+        }
+
+        @Override
+        public Item getAfterSave(Item before, Item update) {
+            updateReadExisting.countDown();
+            try {
+                assertTrue(continueUpdate.await(5, TimeUnit.SECONDS), "timed out waiting to continue update");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            return super.getAfterSave(before, update);
+        }
+    }
+
     private final String name = "test_large_data_" + System.nanoTime();
 
     private File storageDir() {
@@ -49,6 +77,10 @@ class LargeDataStorageTest {
 
     private File detailFile(Long id) {
         return new File(storageDir(), id + ".json");
+    }
+
+    private File indexFile() {
+        return new File(storageDir(), name + ".json");
     }
 
     private Item item(String value) {
@@ -79,6 +111,7 @@ class LargeDataStorageTest {
 
         storage.delete(id);
 
+        assertEquals("", FileUtil.readUtf8String(indexFile()), "deleting the final record must empty the index");
         TestStorage reloaded = new TestStorage(name, 10);
         assertTrue(reloaded.getDataList().isEmpty(), "deleted record must not reappear after reload");
     }
@@ -108,10 +141,54 @@ class LargeDataStorageTest {
         storage.save(item("third", 3L));
 
         assertFalse(detailFile(first).exists(), "detail file of evicted record must be removed");
+        assertEquals(List.of("2", "3"), FileUtil.readLines(indexFile(), "UTF-8"),
+                "the index must contain only surviving records");
 
         TestStorage reloaded = new TestStorage(name, 2);
         assertEquals(2, reloaded.getDataList().size());
         assertTrue(reloaded.getDataList().stream().noneMatch(i -> "first".equals(i.getValue())),
                 "evicted record must not reappear after reload");
+    }
+
+    @Test
+    void delayedUpdateAfterDeleteDoesNotRecreateDetailFile() {
+        TestStorage storage = new TestStorage(name, 10);
+        Long id = storage.save(item("before", 1L));
+
+        storage.delete(id);
+        storage.update(item("late update", id));
+
+        assertFalse(detailFile(id).exists(), "an update for a deleted id must not recreate its detail file");
+        assertTrue(storage.getDataList().isEmpty());
+    }
+
+    @Test
+    void deleteWaitsForInProgressUpdateAndRemovesItsDetailFile() throws Exception {
+        BlockingUpdateStorage storage = new BlockingUpdateStorage(name, 10);
+        Long id = storage.save(item("before", 1L));
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch deleteStarted = new CountDownLatch(1);
+
+        try {
+            Future<?> update = executor.submit(() -> storage.update(item("updated", id)));
+            assertTrue(storage.updateReadExisting.await(5, TimeUnit.SECONDS),
+                    "update did not read the existing record");
+            Future<?> delete = executor.submit(() -> {
+                deleteStarted.countDown();
+                storage.delete(id);
+            });
+
+            assertTrue(deleteStarted.await(5, TimeUnit.SECONDS), "delete task did not start");
+            assertThrows(TimeoutException.class, () -> delete.get(200, TimeUnit.MILLISECONDS),
+                    "delete must wait until the synchronized update finishes");
+            storage.continueUpdate.countDown();
+            update.get(5, TimeUnit.SECONDS);
+            delete.get(5, TimeUnit.SECONDS);
+            assertFalse(detailFile(id).exists(), "delete must remove the detail written by the earlier update");
+            assertTrue(storage.getDataList().isEmpty());
+        } finally {
+            storage.continueUpdate.countDown();
+            executor.shutdownNow();
+        }
     }
 }

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/large/LargeDataStorageTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/large/LargeDataStorageTest.java
@@ -1,9 +1,8 @@
 package ai.chat2db.community.storage.large;
 
-import ai.chat2db.community.tools.util.ConfigUtils;
 import cn.hutool.core.io.FileUtil;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.List;
@@ -43,8 +42,8 @@ class LargeDataStorageTest {
     }
 
     static class TestStorage extends LargeDataStorage<Item> {
-        TestStorage(String name, int limit) {
-            super(name, Item.class, limit);
+        TestStorage(String name, int limit, File baseDir) {
+            super(name, Item.class, limit, baseDir.getAbsolutePath());
         }
     }
 
@@ -52,8 +51,8 @@ class LargeDataStorageTest {
         private final CountDownLatch updateReadExisting = new CountDownLatch(1);
         private final CountDownLatch continueUpdate = new CountDownLatch(1);
 
-        BlockingUpdateStorage(String name, int limit) {
-            super(name, limit);
+        BlockingUpdateStorage(String name, int limit, File baseDir) {
+            super(name, limit, baseDir);
         }
 
         @Override
@@ -69,10 +68,17 @@ class LargeDataStorageTest {
         }
     }
 
-    private final String name = "test_large_data_" + System.nanoTime();
+    private final String name = "test_large_data";
+
+    /**
+     * Storage root injected per test so no data is written under the real
+     * user home; JUnit removes the directory afterwards.
+     */
+    @TempDir
+    File baseDir;
 
     private File storageDir() {
-        return new File(ConfigUtils.getEnvBasePath() + File.separator + "storage" + File.separator + name);
+        return new File(baseDir, name);
     }
 
     private File detailFile(Long id) {
@@ -90,8 +96,7 @@ class LargeDataStorageTest {
     }
 
     /**
-     * IdUtil.generateId() is millisecond-based, so back-to-back saves can
-     * collide on the same id. Tests assign explicit ids to stay deterministic.
+     * Explicit ids keep detail-file names deterministic for assertions.
      */
     private Item item(String value, long id) {
         Item item = item(value);
@@ -99,26 +104,21 @@ class LargeDataStorageTest {
         return item;
     }
 
-    @AfterEach
-    void cleanUp() {
-        FileUtil.del(storageDir());
-    }
-
     @Test
     void deletedLastRecordMustNotResurrectAfterReload() {
-        TestStorage storage = new TestStorage(name, 10);
+        TestStorage storage = new TestStorage(name, 10, baseDir);
         Long id = storage.save(item("only"));
 
         storage.delete(id);
 
         assertEquals("", FileUtil.readUtf8String(indexFile()), "deleting the final record must empty the index");
-        TestStorage reloaded = new TestStorage(name, 10);
+        TestStorage reloaded = new TestStorage(name, 10, baseDir);
         assertTrue(reloaded.getDataList().isEmpty(), "deleted record must not reappear after reload");
     }
 
     @Test
     void deleteRemovesDetailFile() {
-        TestStorage storage = new TestStorage(name, 10);
+        TestStorage storage = new TestStorage(name, 10, baseDir);
         Long keptId = storage.save(item("kept", 1L));
         Long deletedId = storage.save(item("deleted", 2L));
 
@@ -127,7 +127,7 @@ class LargeDataStorageTest {
         assertFalse(detailFile(deletedId).exists(), "detail file of deleted record must be removed");
         assertTrue(detailFile(keptId).exists(), "detail file of remaining record must be kept");
 
-        TestStorage reloaded = new TestStorage(name, 10);
+        TestStorage reloaded = new TestStorage(name, 10, baseDir);
         List<Item> items = reloaded.getDataList();
         assertEquals(1, items.size());
         assertEquals("kept", items.get(0).getValue());
@@ -135,7 +135,7 @@ class LargeDataStorageTest {
 
     @Test
     void evictionRemovesDetailFileOfEvictedRecord() {
-        TestStorage storage = new TestStorage(name, 2);
+        TestStorage storage = new TestStorage(name, 2, baseDir);
         Long first = storage.save(item("first", 1L));
         storage.save(item("second", 2L));
         storage.save(item("third", 3L));
@@ -144,7 +144,7 @@ class LargeDataStorageTest {
         assertEquals(List.of("2", "3"), FileUtil.readLines(indexFile(), "UTF-8"),
                 "the index must contain only surviving records");
 
-        TestStorage reloaded = new TestStorage(name, 2);
+        TestStorage reloaded = new TestStorage(name, 2, baseDir);
         assertEquals(2, reloaded.getDataList().size());
         assertTrue(reloaded.getDataList().stream().noneMatch(i -> "first".equals(i.getValue())),
                 "evicted record must not reappear after reload");
@@ -152,7 +152,7 @@ class LargeDataStorageTest {
 
     @Test
     void delayedUpdateAfterDeleteDoesNotRecreateDetailFile() {
-        TestStorage storage = new TestStorage(name, 10);
+        TestStorage storage = new TestStorage(name, 10, baseDir);
         Long id = storage.save(item("before", 1L));
 
         storage.delete(id);
@@ -164,7 +164,7 @@ class LargeDataStorageTest {
 
     @Test
     void deleteWaitsForInProgressUpdateAndRemovesItsDetailFile() throws Exception {
-        BlockingUpdateStorage storage = new BlockingUpdateStorage(name, 10);
+        BlockingUpdateStorage storage = new BlockingUpdateStorage(name, 10, baseDir);
         Long id = storage.save(item("before", 1L));
         ExecutorService executor = Executors.newFixedThreadPool(2);
         CountDownLatch deleteStarted = new CountDownLatch(1);


### PR DESCRIPTION
## Related issue

Closes #2049

## Summary

`LargeDataStorage.delete()` did not persist deletions completely: the index rewrite was skipped when the map became empty (deleted records resurrected on restart, reproducible on a fresh desktop install), and neither `delete()` nor capacity eviction removed the record's detail JSON, leaking the user's SQL to disk on every delete/eviction.

Minimal fix, no change to storage layout, public API, or callers:

- `saveDataList()` now writes an empty index when the map is empty.
- `delete()` removes the record's detail file via a new protected `deleteDetailData(Long id)` helper (best-effort, logged on failure, matching `saveDataList` error handling).
- The eviction branch in `save()` deletes the evicted record's detail file and drops a redundant `dataMap.remove()` (`pollFirstEntry()` already removes the entry).

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `mvn clean test -pl chat2db-community-storage -am -Dtest=LargeDataStorageTest -Dmaven.test.skip=false -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false`
  - Same command against the previous implementation (fix stashed) → BUILD FAILURE: all three tests fail, confirming they capture the defects.
  - Manual verification: against a running dev backend, created a saved query via `POST /api/operation/saved/create`, deleted it via `DELETE /api/operation/saved` — index rewritten (including to an empty file), detail JSON removed from `~/.chat2db-community/dev/storage/console/`, and the record no longer resurrects after backend restart. Before the fix, a fresh desktop install reproduced the resurrection (save one query, delete, restart).
  - UI evidence: N/A

## Risk and compatibility

- Public API or stored data: file format unchanged; the only new writes are an empty index (previously left stale) and deletion of detail files that were previously orphaned. Startup already tolerates blank index lines.
- Database or driver compatibility: N/A (local JSON storage only).
- Network, privacy, or security: improves data hygiene — deleted SQL no longer remains on disk.
- Community / Local / Pro boundary: change is confined to `chat2db-community-storage`.
- Backward compatibility: pre-existing orphan files from old versions are inert (loading is index-driven) and need no migration.

## Reviewer map

- Start here: `LargeDataStorage#saveDataList` (new else branch) and `LargeDataStorage#delete`; then the eviction branch in `#save`.
- Failure condition: if `FileUtil.del` fails, `deleteDetailData` logs and continues — worst case equals the previous behavior (file left behind); in-memory state and index stay consistent.
- Rollback or disable path: revert this single class; no data migration in either direction.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Diagnosis, fix, and tests were developed with substantial assistance from Claude Code (Anthropic); all changes were reviewed and verified locally by the author.