### PR TITLE
fix(postgresql): use double quotes for view names and add DOT in comment SQL

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/builder/PostgreSQLSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/builder/PostgreSQLSqlBuilder.java
@@ -441,7 +441,7 @@ public class PostgreSQLSqlBuilder extends DefaultSqlBuilder {
         }
         String viewName = modifyView.getViewName();
         if (StringUtils.isNotBlank(viewName)) {
-            createViewSqlBuilder.append(SQLConstants.BACK_QUOTE).append(viewName).append(SQLConstants.BACK_QUOTE);
+            createViewSqlBuilder.append(SQLConstants.DOUBLE_QUOTE).append(viewName).append(SQLConstants.DOUBLE_QUOTE);
         } else {
             createViewSqlBuilder.append(UNDEFINED_KEYWORD);
         }
@@ -458,11 +458,15 @@ public class PostgreSQLSqlBuilder extends DefaultSqlBuilder {
         String comment = modifyView.getComment();
         if (StringUtils.isNotBlank(comment)) {
             createViewSqlBuilder.append(SQLConstants.LINE_SEPARATOR);
-            createViewSqlBuilder.append(SQL_COMMENT_VIEW)
-                    .append(SQLConstants.DOUBLE_QUOTE).append(schemaName).append(SQLConstants.DOUBLE_QUOTE)
-                    .append(SQLConstants.DOUBLE_QUOTE).append(viewName).append(SQLConstants.DOUBLE_QUOTE)
+            createViewSqlBuilder.append(SQL_COMMENT_VIEW).append(SQLConstants.SPACE);
+            if (StringUtils.isNotBlank(schemaName)) {
+                createViewSqlBuilder.append(SQLConstants.DOUBLE_QUOTE).append(schemaName).append(SQLConstants.DOUBLE_QUOTE)
+                        .append(SQLConstants.DOT);
+            }
+            createViewSqlBuilder.append(SQLConstants.DOUBLE_QUOTE).append(viewName).append(SQLConstants.DOUBLE_QUOTE)
                     .append(SQLConstants.SQL_IS_LOWER)
-                    .append(comment).append(SQLConstants.SEMICOLON);
+                    .append(SQLConstants.SINGLE_QUOTE).append(comment).append(SQLConstants.SINGLE_QUOTE)
+                    .append(SQLConstants.SEMICOLON);
         }
         return createViewSqlBuilder.toString();
     }


### PR DESCRIPTION
## Summary

Fixes 2 bugs in PostgreSQL view creation (`PostgreSQLSqlBuilder.buildCreateView()`):

1. **View name quoting**: backtick (`` ` ``) → double quote (`"`) — PostgreSQL uses double quotes for identifier quoting, not backticks
2. **Comment SQL**: added missing `.` separator between schema and view name — was producing `"schema""view"` instead of `"schema"."view"`

Split from #1926 per review feedback.