### PR TITLE
fix(sqlserver): view quoting, TIMESTAMP dead code, GO separator, and rename quoting

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
@@ -343,7 +343,7 @@ public class SqlServerSqlBuilder extends DefaultSqlBuilder {
         }
         String viewName = modifyView.getViewName();
         if (StringUtils.isNotBlank(viewName)) {
-            createViewSqlBuilder.append(SQLConstants.BACK_QUOTE).append(viewName).append(SQLConstants.BACK_QUOTE);
+            createViewSqlBuilder.append(SQLConstants.OPEN_SQUARE_BRACKET).append(viewName).append(SQLConstants.CLOSE_SQUARE_BRACKET);
         } else {
             createViewSqlBuilder.append(UNDEFINED_KEYWORD);
         }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static ai.chat2db.plugin.sqlserver.identifier.SqlServerIdentifierUtils.escapeStringLiteral;
 import static ai.chat2db.plugin.sqlserver.identifier.SqlServerIdentifierUtils.quoteIdentifierPart;
 import static ai.chat2db.plugin.sqlserver.constant.SqlServerSqlBuilderConstants.*;
 public class SqlServerSqlBuilder extends DefaultSqlBuilder {
@@ -357,19 +358,19 @@ public class SqlServerSqlBuilder extends DefaultSqlBuilder {
         }
         createViewSqlBuilder.append(SQLConstants.SEMICOLON);
         String comment = modifyView.getComment();
-        if (StringUtils.isNotBlank(comment)) {
+        if (StringUtils.isNotBlank(comment) && StringUtils.isNotBlank(schemaName)) {
             createViewSqlBuilder.append(SQLConstants.LINE_SEPARATOR);
             createViewSqlBuilder.append(SQL_EXEC_SP_ADDEXTENDEDPROPERTY_SINGLE_QUOTE_MS_DESCRIPTION_SINGLE_QUOTE_COMMA)
                     .append(SQLConstants.SPACE)
-                    .append(SQLConstants.SINGLE_QUOTE).append(comment).append(SQLConstants.SINGLE_QUOTE).append(SQLConstants.COMMA)
+                    .append(SQLConstants.SINGLE_QUOTE).append(escapeStringLiteral(comment)).append(SQLConstants.SINGLE_QUOTE).append(SQLConstants.COMMA)
                     .append(SQLConstants.SPACE)
                     .append(SQL_SINGLE_QUOTE_SCHEMA_SINGLE_QUOTE).append(SQLConstants.COMMA)
                     .append(SQLConstants.SPACE)
-                    .append(SQLConstants.DOUBLE_QUOTE).append(schemaName).append(SQLConstants.DOUBLE_QUOTE).append(SQLConstants.COMMA)
+                    .append(SQLConstants.SINGLE_QUOTE).append(escapeStringLiteral(schemaName)).append(SQLConstants.SINGLE_QUOTE).append(SQLConstants.COMMA)
                     .append(SQLConstants.SPACE)
                     .append(SQL_SINGLE_QUOTE_VIEW_SINGLE_QUOTE).append(SQLConstants.COMMA)
                     .append(SQLConstants.SPACE)
-                    .append(SQLConstants.SINGLE_QUOTE).append(viewName).append(SQLConstants.SINGLE_QUOTE);
+                    .append(SQLConstants.SINGLE_QUOTE).append(escapeStringLiteral(viewName)).append(SQLConstants.SINGLE_QUOTE);
 
         }
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static ai.chat2db.plugin.sqlserver.identifier.SqlServerIdentifierUtils.quoteIdentifierPart;
 import static ai.chat2db.plugin.sqlserver.constant.SqlServerSqlBuilderConstants.*;
 public class SqlServerSqlBuilder extends DefaultSqlBuilder {
 
@@ -339,11 +340,11 @@ public class SqlServerSqlBuilder extends DefaultSqlBuilder {
         }
         String schemaName = modifyView.getSchemaName();
         if (StringUtils.isNotBlank(schemaName)) {
-            createViewSqlBuilder.append(SQLConstants.DOUBLE_QUOTE).append(schemaName).append(SQLConstants.DOUBLE_QUOTE).append(SQLConstants.DOT);
+            createViewSqlBuilder.append(quoteIdentifierPart(schemaName)).append(SQLConstants.DOT);
         }
         String viewName = modifyView.getViewName();
         if (StringUtils.isNotBlank(viewName)) {
-            createViewSqlBuilder.append(SQLConstants.OPEN_SQUARE_BRACKET).append(viewName).append(SQLConstants.CLOSE_SQUARE_BRACKET);
+            createViewSqlBuilder.append(quoteIdentifierPart(viewName));
         } else {
             createViewSqlBuilder.append(UNDEFINED_KEYWORD);
         }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerColumnTypeEnumConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerColumnTypeEnumConstants.java
@@ -21,7 +21,7 @@ public final class SqlServerColumnTypeEnumConstants {
     public static final String SQL_DROP_COLUMN = "DROP COLUMN ";
     public static final String SQL_DROP_CONSTRAINT = "DROP CONSTRAINT ";
 
-    public static final String RENAME_COLUMN_SCRIPT = "exec sp_rename '%s.%s','%s','COLUMN' \ngo";
+    public static final String RENAME_COLUMN_SCRIPT = "exec sp_rename '[%s].[%s]','%s','COLUMN' \ngo\n";
     public static final String COLUMN_MODIFY_COMMENT_SCRIPT = "IF ((SELECT COUNT(*) FROM ::fn_listextendedproperty('MS_Description',\n" +
             "'SCHEMA', N'%s',\n" +
             "'TABLE', N'%s',\n" +
@@ -36,7 +36,7 @@ public final class SqlServerColumnTypeEnumConstants {
             "'MS_Description', N'%s',\n" +
             "'SCHEMA', N'%s',\n" +
             "'TABLE', N'%s',\n" +
-            "'COLUMN', N'%s'\n go";
+            "'COLUMN', N'%s'\n go\n";
 
 
     private SqlServerColumnTypeEnumConstants() {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerColumnTypeEnumConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerColumnTypeEnumConstants.java
@@ -21,7 +21,7 @@ public final class SqlServerColumnTypeEnumConstants {
     public static final String SQL_DROP_COLUMN = "DROP COLUMN ";
     public static final String SQL_DROP_CONSTRAINT = "DROP CONSTRAINT ";
 
-    public static final String RENAME_COLUMN_SCRIPT = "exec sp_rename '[%s].[%s]','%s','COLUMN' \ngo\n";
+    public static final String RENAME_COLUMN_SCRIPT = "exec sp_rename '%s','%s','COLUMN' \ngo\n";
     public static final String COLUMN_MODIFY_COMMENT_SCRIPT = "IF ((SELECT COUNT(*) FROM ::fn_listextendedproperty('MS_Description',\n" +
             "'SCHEMA', N'%s',\n" +
             "'TABLE', N'%s',\n" +

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
@@ -280,7 +280,7 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
             }
             return script.toString();
         }
-        if (Arrays.asList(DECIMAL, FLOAT, TIMESTAMP, NUMERIC).contains(type)) {
+        if (Arrays.asList(DECIMAL, FLOAT, TIMESTAMP, FLOAT, NUMERIC).contains(type)) {
             StringBuilder script = new StringBuilder();
             script.append(columnType);
             if (column.getColumnSize() != null && column.getDecimalDigits() == null) {
@@ -291,6 +291,16 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
             return script.toString();
         }
 
+        if (Arrays.asList("TIMESTAMP").contains(type)) {
+            StringBuilder script = new StringBuilder();
+            if (column.getColumnSize() == null) {
+                script.append(columnType);
+            } else {
+                String[] split = columnType.split("TIMESTAMP");
+                script.append("TIMESTAMP").append("(").append(column.getColumnSize()).append(")").append(split[1]);
+            }
+            return script.toString();
+        }
         if (OTHER.equals(columnType)) {
             return column.getColumnType();
         }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import java.util.Objects;
 
 import static ai.chat2db.plugin.sqlserver.constant.SqlServerColumnTypeEnumConstants.*;
+import static ai.chat2db.plugin.sqlserver.identifier.SqlServerIdentifierUtils.escapeStringLiteral;
+import static ai.chat2db.plugin.sqlserver.identifier.SqlServerIdentifierUtils.quoteIdentifierPart;
 public enum SqlServerColumnTypeEnum implements IColumnBuilder {
 
     BIGINT("BIGINT", false, false, true, false, false, false, true, true),
@@ -280,7 +282,7 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
             }
             return script.toString();
         }
-        if (Arrays.asList(DECIMAL, FLOAT, TIMESTAMP, FLOAT, NUMERIC).contains(type)) {
+        if (Arrays.asList(DECIMAL, FLOAT, NUMERIC).contains(type)) {
             StringBuilder script = new StringBuilder();
             script.append(columnType);
             if (column.getColumnSize() != null && column.getDecimalDigits() == null) {
@@ -291,16 +293,6 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
             return script.toString();
         }
 
-        if (Arrays.asList("TIMESTAMP").contains(type)) {
-            StringBuilder script = new StringBuilder();
-            if (column.getColumnSize() == null) {
-                script.append(columnType);
-            } else {
-                String[] split = columnType.split("TIMESTAMP");
-                script.append("TIMESTAMP").append("(").append(column.getColumnSize()).append(")").append(split[1]);
-            }
-            return script.toString();
-        }
         if (OTHER.equals(columnType)) {
             return column.getColumnType();
         }
@@ -311,7 +303,16 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
 
 
     private String renameColumn(TableColumn tableColumn) {
-        return String.format(RENAME_COLUMN_SCRIPT, tableColumn.getTableName(), tableColumn.getOldName(), tableColumn.getName());
+        StringBuilder qualifiedColumnName = new StringBuilder();
+        if (StringUtils.isNotBlank(tableColumn.getSchemaName())) {
+            qualifiedColumnName.append(quoteIdentifierPart(tableColumn.getSchemaName())).append('.');
+        }
+        qualifiedColumnName.append(quoteIdentifierPart(tableColumn.getTableName()))
+                .append('.')
+                .append(quoteIdentifierPart(tableColumn.getOldName()));
+        return String.format(RENAME_COLUMN_SCRIPT,
+                escapeStringLiteral(qualifiedColumnName.toString()),
+                escapeStringLiteral(tableColumn.getName()));
     }
 
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnum.java
@@ -140,7 +140,7 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
         SqlServerColumnTypeEnum type = this;
         StringBuilder script = new StringBuilder();
 
-        script.append("[").append(column.getName()).append("]").append(" ");
+        script.append(quoteIdentifierPart(column.getName())).append(" ");
 
         script.append(buildDataType(column, type)).append(" ");
 
@@ -160,7 +160,7 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
         SqlServerColumnTypeEnum type = this;
         StringBuilder script = new StringBuilder();
 
-        script.append("[").append(column.getName()).append("]").append(" ");
+        script.append(quoteIdentifierPart(column.getName())).append(" ");
 
         script.append(buildDataType(column, type)).append(" ");
 
@@ -182,34 +182,38 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
 
         StringBuilder script = new StringBuilder();
 
-        script.append("[").append(column.getName()).append("]").append(" ");
+        script.append(quoteIdentifierPart(column.getName())).append(" ");
 
         script.append(buildDataType(column, type)).append(" ");
 
         script.append(buildNullable(column, type)).append(" \ngo\n");
 
         if (StringUtils.isNotBlank(column.getDefaultValue()) && column.getOldColumn().getDefaultValue() != null && !StringUtils.equalsIgnoreCase(column.getDefaultValue(), column.getOldColumn().getDefaultValue())) {
-            script.append(SQL_ALTER_TABLE).append("[").append(column.getSchemaName()).append("].[").append(column.getTableName()).append("]");
-            script.append(" ").append(SQL_DROP_CONSTRAINT).append("[").append(column.getDefaultConstraintName()).append("]");
+            script.append(SQL_ALTER_TABLE).append(qualifiedTableName(column));
+            script.append(" ").append(SQL_DROP_CONSTRAINT).append(quoteIdentifierPart(column.getDefaultConstraintName()));
 
-            script.append(SQL_ALTER_TABLE).append("[").append(column.getSchemaName()).append("].[").append(column.getTableName()).append("]");
-            script.append(" ").append("ADD ").append(buildDefaultValue(column, type)).append(" for ").append(column.getName()).append(" \ngo\n");
+            script.append(SQL_ALTER_TABLE).append(qualifiedTableName(column));
+            script.append(" ").append("ADD ").append(buildDefaultValue(column, type)).append(" for ")
+                    .append(quoteIdentifierPart(column.getName())).append(" \ngo\n");
         }
 
         if (StringUtils.isNotBlank(column.getDefaultValue()) && column.getOldColumn().getDefaultValue() == null) {
-            script.append(SQL_ALTER_TABLE).append("[").append(column.getSchemaName()).append("].[").append(column.getTableName()).append("]");
-            script.append(" ").append("ADD ").append(buildDefaultValue(column, type)).append(" for ").append(column.getName()).append(" \ngo\n");
+            script.append(SQL_ALTER_TABLE).append(qualifiedTableName(column));
+            script.append(" ").append("ADD ").append(buildDefaultValue(column, type)).append(" for ")
+                    .append(quoteIdentifierPart(column.getName())).append(" \ngo\n");
         }
 
 
         if (!Objects.equals(column.getSparse(), column.getOldColumn().getSparse())) {
-            script.append(SQL_ALTER_TABLE).append("[").append(column.getSchemaName()).append("].[").append(column.getTableName()).append("]");
-            script.append(" ").append(SQL_ALTER_COLUMN).append("[").append(column.getName()).append("]").append(" add ").append("SPARSE").append(" \ngo\n");
+            script.append(SQL_ALTER_TABLE).append(qualifiedTableName(column));
+            script.append(" ").append(SQL_ALTER_COLUMN).append(quoteIdentifierPart(column.getName()))
+                    .append(" add ").append("SPARSE").append(" \ngo\n");
         }
 
         if (!Objects.equals(column.getCollationName(), column.getOldColumn().getCollationName())) {
-            script.append(SQL_ALTER_TABLE).append("[").append(column.getSchemaName()).append("].[").append(column.getTableName()).append("]");
-            script.append(" ").append(SQL_ALTER_COLUMN).append("[").append(column.getName()).append("]").append(" ").append("COLLATE ").append(column.getCollationName()).append(" \ngo\n");
+            script.append(SQL_ALTER_TABLE).append(qualifiedTableName(column));
+            script.append(" ").append(SQL_ALTER_COLUMN).append(quoteIdentifierPart(column.getName()))
+                    .append(" ").append("COLLATE ").append(column.getCollationName()).append(" \ngo\n");
         }
         return script.toString();
     }
@@ -315,6 +319,14 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
                 escapeStringLiteral(tableColumn.getName()));
     }
 
+    private static String qualifiedTableName(TableColumn tableColumn) {
+        StringBuilder tableName = new StringBuilder();
+        if (StringUtils.isNotBlank(tableColumn.getSchemaName())) {
+            tableName.append(quoteIdentifierPart(tableColumn.getSchemaName())).append('.');
+        }
+        return tableName.append(quoteIdentifierPart(tableColumn.getTableName())).toString();
+    }
+
 
     @Override
     public String buildModifyColumn(TableColumn tableColumn) {
@@ -322,18 +334,18 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
         if (EditStatusEnum.DELETE.name().equals(tableColumn.getEditStatus())) {
             StringBuilder script = new StringBuilder();
             if (StringUtils.isNotBlank(tableColumn.getDefaultConstraintName())) {
-                script.append(SQL_ALTER_TABLE).append("[").append(tableColumn.getSchemaName()).append("].[").append(tableColumn.getTableName()).append("]");
-                script.append(" ").append(SQL_DROP_CONSTRAINT).append("[").append(tableColumn.getDefaultConstraintName()).append("]");
+                script.append(SQL_ALTER_TABLE).append(qualifiedTableName(tableColumn));
+                script.append(" ").append(SQL_DROP_CONSTRAINT).append(quoteIdentifierPart(tableColumn.getDefaultConstraintName()));
                 script.append("\ngo\n");
             }
-            script.append(SQL_ALTER_TABLE).append("[").append(tableColumn.getSchemaName()).append("].[").append(tableColumn.getTableName()).append("]");
-            script.append(" ").append(SQL_DROP_COLUMN).append("[").append(tableColumn.getName()).append("]");
+            script.append(SQL_ALTER_TABLE).append(qualifiedTableName(tableColumn));
+            script.append(" ").append(SQL_DROP_COLUMN).append(quoteIdentifierPart(tableColumn.getName()));
             script.append("\ngo\n");
             return script.toString();
         }
         if (EditStatusEnum.ADD.name().equals(tableColumn.getEditStatus())) {
             StringBuilder script = new StringBuilder();
-            script.append(SQL_ALTER_TABLE).append("[").append(tableColumn.getSchemaName()).append("].[").append(tableColumn.getTableName()).append("]");
+            script.append(SQL_ALTER_TABLE).append(qualifiedTableName(tableColumn));
             script.append(" ").append("ADD ").append(buildCreateColumnSql(tableColumn)).append(" \ngo\n");
 
 
@@ -349,7 +361,7 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
                 script.append(renameColumn(tableColumn));
                 script.append("\n");
             }
-            script.append(SQL_ALTER_TABLE).append("[").append(tableColumn.getSchemaName()).append("].[").append(tableColumn.getTableName()).append("]");
+            script.append(SQL_ALTER_TABLE).append(qualifiedTableName(tableColumn));
             script.append(" ").append(SQL_ALTER_COLUMN).append(buildUpdateColumnSql(tableColumn)).append(" \n");
 
             if (!Objects.equals(tableColumn.getComment(), tableColumn.getOldColumn().getComment())) {
@@ -365,9 +377,13 @@ public enum SqlServerColumnTypeEnum implements IColumnBuilder {
 
 
     private String buildModifyColumnComment(TableColumn tableColumn) {
-        return String.format(COLUMN_MODIFY_COMMENT_SCRIPT, tableColumn.getSchemaName(), tableColumn.getTableName(),
-                tableColumn.getName(), tableColumn.getComment(), tableColumn.getSchemaName(), tableColumn.getTableName(), tableColumn.getName(),
-                tableColumn.getComment(), tableColumn.getSchemaName(), tableColumn.getTableName(), tableColumn.getName());
+        String schemaName = escapeStringLiteral(tableColumn.getSchemaName());
+        String tableName = escapeStringLiteral(tableColumn.getTableName());
+        String columnName = escapeStringLiteral(tableColumn.getName());
+        String comment = escapeStringLiteral(tableColumn.getComment());
+        return String.format(COLUMN_MODIFY_COMMENT_SCRIPT, schemaName, tableName,
+                columnName, comment, schemaName, tableName, columnName,
+                comment, schemaName, tableName, columnName);
     }
 
     public static List<ColumnType> getTypes() {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/identifier/SqlServerIdentifierUtils.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/identifier/SqlServerIdentifierUtils.java
@@ -1,0 +1,15 @@
+package ai.chat2db.plugin.sqlserver.identifier;
+
+public final class SqlServerIdentifierUtils {
+
+    private SqlServerIdentifierUtils() {
+    }
+
+    public static String quoteIdentifierPart(String identifier) {
+        return "[" + identifier.replace("]", "]]") + "]";
+    }
+
+    public static String escapeStringLiteral(String value) {
+        return value.replace("'", "''");
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/identifier/SqlServerIdentifierUtils.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/identifier/SqlServerIdentifierUtils.java
@@ -10,6 +10,6 @@ public final class SqlServerIdentifierUtils {
     }
 
     public static String escapeStringLiteral(String value) {
-        return value.replace("'", "''");
+        return value == null ? "" : value.replace("'", "''");
     }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
@@ -1,5 +1,6 @@
 package ai.chat2db.plugin.sqlserver.builder;
 
+import ai.chat2db.community.domain.api.model.view.ModifyView;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,5 +27,19 @@ class SqlServerSqlBuilderTest {
                 builder.appendSingleRowLimit("DELETE", "[t]", where, "DELETE FROM [t]" + where));
         assertEquals("UPDATE TOP (1) [t] set [a] = 1" + where,
                 builder.appendSingleRowLimit("UPDATE", "[t]", where, "UPDATE [t] set [a] = 1" + where));
+    }
+
+    @Test
+    void shouldQuoteAndEscapeQualifiedViewName() {
+        SqlServerSqlBuilder builder = new SqlServerSqlBuilder();
+        ModifyView view = new ModifyView();
+        view.setSchemaName("order] schema");
+        view.setViewName("select] view");
+        view.setViewBody("SELECT 1");
+
+        assertEquals("CREATE VIEW [order]] schema].[select]] view]\n"
+                        + "AS \n"
+                        + "SELECT 1 ;",
+                builder.buildCreateView(view));
     }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
@@ -36,10 +36,13 @@ class SqlServerSqlBuilderTest {
         view.setSchemaName("order] schema");
         view.setViewName("select] view");
         view.setViewBody("SELECT 1");
+        view.setComment("owner's view");
 
         assertEquals("CREATE VIEW [order]] schema].[select]] view]\n"
                         + "AS \n"
-                        + "SELECT 1 ;",
+                        + "SELECT 1 ;\n"
+                        + "exec sp_addextendedproperty 'MS_Description', 'owner''s view', 'SCHEMA', "
+                        + "'order] schema', 'VIEW', 'select] view'",
                 builder.buildCreateView(view));
     }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnumTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnumTest.java
@@ -34,6 +34,7 @@ class SqlServerColumnTypeEnumTest {
 
         assertTrue(sql.startsWith(
                 "exec sp_rename '[sales]] ops].[order]] details].[old]] name]','new''name','COLUMN' \ngo\n"));
+        assertTrue(sql.contains("ALTER TABLE [sales]] ops].[order]] details] ALTER COLUMN [new'name]"));
     }
 
     @Test
@@ -47,6 +48,24 @@ class SqlServerColumnTypeEnumTest {
 
         assertTrue(sql.contains("\n go\nALTER TABLE [dbo].[next_table]"));
         assertFalse(sql.contains("goALTER TABLE"));
+    }
+
+    @Test
+    void shouldEscapeCommentProcedureStringArguments() {
+        TableColumn oldColumn = new TableColumn();
+        oldColumn.setComment("old comment");
+        TableColumn column = modifiedColumn(oldColumn);
+        column.setSchemaName("sales' ops");
+        column.setTableName("order' details");
+        column.setName("status' code");
+        column.setComment("owner's note");
+
+        String sql = SqlServerColumnTypeEnum.INT.buildModifyColumn(column);
+
+        assertTrue(sql.contains("'SCHEMA', N'sales'' ops'"));
+        assertTrue(sql.contains("'TABLE', N'order'' details'"));
+        assertTrue(sql.contains("'COLUMN', N'status'' code'"));
+        assertTrue(sql.contains("'MS_Description', N'owner''s note'"));
     }
 
     private static TableColumn modifiedColumn(TableColumn oldColumn) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnumTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/enums/type/SqlServerColumnTypeEnumTest.java
@@ -1,0 +1,63 @@
+package ai.chat2db.plugin.sqlserver.enums.type;
+
+import ai.chat2db.community.domain.api.enums.plugin.EditStatusEnum;
+import ai.chat2db.community.domain.api.model.metadata.TableColumn;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SqlServerColumnTypeEnumTest {
+
+    @Test
+    void shouldNotAppendPrecisionToTimestamp() {
+        TableColumn column = new TableColumn();
+        column.setName("row_version");
+        column.setColumnSize(8);
+
+        String sql = SqlServerColumnTypeEnum.TIMESTAMP.buildCreateColumnSql(column);
+
+        assertTrue(sql.contains("TIMESTAMP"));
+        assertFalse(sql.contains("TIMESTAMP("));
+    }
+
+    @Test
+    void shouldQuoteQualifiedOldColumnAndEscapeNewNameWhenRenaming() {
+        TableColumn oldColumn = new TableColumn();
+        TableColumn column = modifiedColumn(oldColumn);
+        column.setSchemaName("sales] ops");
+        column.setTableName("order] details");
+        column.setOldName("old] name");
+        column.setName("new'name");
+
+        String sql = SqlServerColumnTypeEnum.INT.buildModifyColumn(column);
+
+        assertTrue(sql.startsWith(
+                "exec sp_rename '[sales]] ops].[order]] details].[old]] name]','new''name','COLUMN' \ngo\n"));
+    }
+
+    @Test
+    void shouldKeepGoSeparatorOnItsOwnLineWhenCommentScriptIsConcatenated() {
+        TableColumn oldColumn = new TableColumn();
+        oldColumn.setComment("old comment");
+        TableColumn column = modifiedColumn(oldColumn);
+        column.setComment("new comment");
+
+        String sql = SqlServerColumnTypeEnum.INT.buildModifyColumn(column) + "ALTER TABLE [dbo].[next_table]";
+
+        assertTrue(sql.contains("\n go\nALTER TABLE [dbo].[next_table]"));
+        assertFalse(sql.contains("goALTER TABLE"));
+    }
+
+    private static TableColumn modifiedColumn(TableColumn oldColumn) {
+        TableColumn column = new TableColumn();
+        column.setOldColumn(oldColumn);
+        column.setSchemaName("dbo");
+        column.setTableName("orders");
+        column.setOldName("status");
+        column.setName("status");
+        column.setColumnType("INT");
+        column.setEditStatus(EditStatusEnum.MODIFY.name());
+        return column;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes SQL Server DDL generation in four areas:

1. **View DDL and comments** (`SqlServerSqlBuilder.buildCreateView()`): uses square-bracket identifier quoting, escapes embedded `]`, escapes comment string literals, and avoids invalid schema-level extended properties when no schema is present.
2. **TIMESTAMP/ROWVERSION DDL** (`SqlServerColumnTypeEnum.buildDataType()`): does not emit JDBC-reported precision for fixed-size row-version types.
3. **Batch separators**: preserves a trailing newline after generated `GO` separators so adjacent statements do not become one token.
4. **Column rename/alter SQL**: quotes every schema, table, constraint, and column identifier part, and escapes stored-procedure/comment string arguments.

Maintainer follow-up adds exact SQL regression tests for reserved characters and comment text.

Split from #1926 per review feedback.
