### PR TITLE
fix(ai-button): scope AI store subscription to showPanel

### DIFF
--- a/chat2db-community-client/src/blocks/AI/components/AIButton/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AIButton/index.tsx
@@ -9,7 +9,7 @@ interface AIButtonProps {
 const AIButton = (props: AIButtonProps) => {
   const { onClick, size = 'lg' } = props;
   const { styles } = useStyles();
-  const { showPanel } = useAIStore((s) => s);
+  const showPanel = useAIStore((s) => s.showPanel);
   return (
     <IconButton
       type="primary"


### PR DESCRIPTION
## Related issue

Closes #2060

## Summary

`AIButton` read `const { showPanel } = useAIStore((s) => s);`. The selector `(s) => s` returns the entire AI store, so the button re-rendered on every AI-store mutation (every streaming token, every message) instead of only when `showPanel` changed. Changed to a scoped selector: `const showPanel = useAIStore((s) => s.showPanel);`.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `AIButton/index.tsx`.
- Manual verification: A selector swap; `showPanel` is a direct field on the AI store. Downstream usage (`isActive={showPanel}`) is unchanged.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Strictly fewer re-renders; behavior unchanged.

## Reviewer map

- Start here: `blocks/AI/components/AIButton/index.tsx:12` — `useAIStore((s) => s)` -> `useAIStore((s) => s.showPanel)`.
- Failure condition: Button still re-renders on unrelated AI-store changes.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.