### PR TITLE
fix(xterm): dispose Terminal on unmount

### DIFF
--- a/chat2db-community-client/src/components/Xterm/index.tsx
+++ b/chat2db-community-client/src/components/Xterm/index.tsx
@@ -68,6 +68,11 @@ export default forwardRef((props: IProps, ref: ForwardedRef<IXtermRef>) => {
     initXterm();
     return () => {
       window.removeEventListener('resize', resizeFitAddon);
+      // Dispose the Terminal (and its loaded FitAddon / onData listener)
+      // so the instance, DOM, and renderer are torn down on unmount.
+      xtermRef.current?.dispose();
+      xtermRef.current = null;
+      fitAddonRef.current = null;
     };
   }, []);
 


### PR DESCRIPTION
## Related issue

Closes #2059

## Summary

The `Xterm` mount `useEffect` called `initXterm()` which creates a `new Terminal()`, loads a `FitAddon`, registers `xterm.onData(...)`, and calls `xterm.open(...)`. The cleanup only removed the window `resize` listener — it never called `xterm.dispose()`, so every mount/unmount leaked a full Terminal instance (DOM, renderer, buffers, internal timers), plus the `onData` disposable and the FitAddon. Added `xtermRef.current?.dispose()` to the cleanup (`dispose()` also disposes loaded addons and event listeners), and reset the refs.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `Xterm/index.tsx`.
  - `npx eslint src/components/Xterm/index.tsx` — no errors.
- Manual verification: On unmount, `xterm.dispose()` is now called, tearing down the Terminal, the loaded FitAddon, and the `onData` listener.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only adds cleanup on unmount; mount/render behavior unchanged.

## Reviewer map

- Start here: `components/Xterm/index.tsx` — the `useEffect([], )` cleanup now calls `xtermRef.current?.dispose()` and resets `xtermRef`/`fitAddonRef` to null.
- Failure condition: Terminal instances still leak across mount/unmount.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.