### PR TITLE
fix(notification-nav): guard on-mount async queries against unmount

### DIFF
--- a/chat2db-community-client/src/components/NotificationNav/index.tsx
+++ b/chat2db-community-client/src/components/NotificationNav/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Drawer, Flex, Popover } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { runtimeEditionConfig } from '@/constants/runtimeEdition';
 import i18n from '@/i18n';
@@ -27,11 +27,16 @@ const NotificationButton = ({ drawerMode, open: externalOpen, onClose }: Notific
   const [popNoSOpen, setNoSPopOpen] = useState(false);
   const [popNoSData, setNoSPopData] = useState<NotificationVO | null>(null);
   const [modalSizeWidth, setModalSizeWidth] = useState<number>();
+  const mountedRef = useRef(true);
 
   useEffect(() => {
+    mountedRef.current = true;
     queryNotificationList();
     queryUnreadCount();
     queryPopNotification();
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   useEffect(() => {
@@ -54,18 +59,21 @@ const NotificationButton = ({ drawerMode, open: externalOpen, onClose }: Notific
 
   const queryUnreadCount = () => {
     notificationService.queryUnreadCount().then((res) => {
+      if (!mountedRef.current) return;
       setHasUnread(res > 0);
     });
   };
 
   const queryNotificationList = () => {
     notificationService.queryNotificationList({ pageNo: 1, pageSize: 50 }).then((res) => {
+      if (!mountedRef.current) return;
       setList(res.data);
     });
   };
 
   const queryPopNotification = async () => {
     const res = await notificationService.queryPopNotification();
+    if (!mountedRef.current) return;
     // Check localStorage for notifications already displayed, distinguished by ID.
     const popedNotificationId = localStorage.getItem(runtimeEditionConfig.notificationPopupStorageKey);
     // If the notification has not been shown, display it when valid.


### PR DESCRIPTION
## Related issue

Closes #2071

## Summary

`NotificationNav` fires three queries on mount (`queryNotificationList`, `queryUnreadCount`, `queryPopNotification`) that resolve into `setState` calls (`setList`, `setHasUnread`, `setSPopOpen`, `setSPopData`, `setNoSPopOpen`, `setNoSPopData`) with no mounted guard or `AbortController`. If the component unmounted before the awaits resolved, `setState` fired on an unmounted component. Added a `mountedRef` (`useRef(true)`, set `false` in the mount effect's cleanup) and an early `return` before `setState` in each query function.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `NotificationNav/index.tsx`.
  - `npx eslint src/components/NotificationNav/index.tsx` — no errors.
- Manual verification: On unmount before the on-mount queries resolve, the `mountedRef.current === false` guard skips the `setState` calls. The mount effect sets `mountedRef.current = true` on (re)mount and `false` on cleanup (StrictMode-safe).
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only skips `setState` after unmount; mounted behavior unchanged.

## Reviewer map

- Start here: `components/NotificationNav/index.tsx` — `mountedRef = useRef(true)`, the mount `useEffect` sets it true and clears it in cleanup, and each of `queryUnreadCount`/`queryNotificationList`/`queryPopNotification` early-returns when `!mountedRef.current`.
- Failure condition: setState still fires on an unmounted component during on-mount queries.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.