### PR TITLE
fix(canvas-table): unmount cell-editor React root on end

### DIFF
--- a/chat2db-community-client/src/blocks/CanvasTable/editor/InputIEditor/index.tsx
+++ b/chat2db-community-client/src/blocks/CanvasTable/editor/InputIEditor/index.tsx
@@ -181,6 +181,8 @@ class InputEditor {
   container: HTMLElement | null = null;
   /** Editor element frame content */
   inputContainer: HTMLDivElement | null = null;
+  /** React root for the editor content; unmounted in onEnd to avoid leaks. */
+  root: ReturnType<typeof ReactDOM.createRoot> | null = null;
   /** Ref of input box */
   inputRef: any = React.createRef();
   /** onEnd successful callback */
@@ -199,7 +201,8 @@ class InputEditor {
     inputContainer.style.position = 'absolute';
     this.inputContainer = inputContainer;
     this.container?.appendChild(inputContainer);
-    ReactDOM.createRoot(inputContainer).render(
+    this.root = ReactDOM.createRoot(inputContainer);
+    this.root.render(
       <InputReact textarea={this.textarea} defaultValue={value} ref={this.inputRef} />,
     );
   }
@@ -243,6 +246,8 @@ class InputEditor {
       this.container.removeChild(this.inputContainer);
     }
     this.inputContainer = null;
+    this.root?.unmount();
+    this.root = null;
   }
 
   isEditorElement(target) {
@@ -385,7 +390,8 @@ class DateEditor extends InputEditor {
     inputContainer.style.position = 'absolute';
     this.inputContainer = inputContainer;
     this.container?.appendChild(inputContainer);
-    ReactDOM.createRoot(inputContainer).render(
+    this.root = ReactDOM.createRoot(inputContainer);
+    this.root.render(
       <DateInputReact
         defaultValue={value}
         mode={this.mode}


### PR DESCRIPTION
## Related issue

Closes #2070

## Summary

In `InputIEditor`, `createElement` called `ReactDOM.createRoot(inputContainer).render(...)` inline and discarded the root reference. `onEnd` only detached the DOM node (`removeChild`) — the React fiber tree, state, effects, and handlers inside the rendered component were never torn down, leaking on every cell-edit open/close cycle. Now the root is stored on the instance (`this.root`) and `unmount()`ed in `onEnd` (and `this.root` nulled). Applied at both createElement sites: the base `InputEditor` and `DateEditor.createElement` (the date editor inherits the base `onEnd`, and `createElement` is only invoked when `inputContainer` is null, so there is no double-create that would orphan a prior root).

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `InputIEditor/index.tsx`.
  - `npx eslint src/blocks/CanvasTable/editor/InputIEditor/index.tsx` — no errors.
- Manual verification: On `onEnd`, `this.root?.unmount()` is now called (tearing down the React tree), and `this.root` is nulled. `createElement` is guarded by `if (!this.inputContainer)` so it is not called twice without an intervening `onEnd`.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only adds cleanup on `onEnd`; edit/create behavior unchanged.

## Reviewer map

- Start here: `blocks/CanvasTable/editor/InputIEditor/index.tsx` — new `root` field on `InputEditor`; both `createElement` sites store `this.root = ReactDOM.createRoot(...)` then `this.root.render(...)`; `onEnd` calls `this.root?.unmount()` and nulls it.
- Failure condition: React roots still leak across cell-edit open/close.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.