### PR TITLE
fix(db2): skip column comment for dropped columns in ALTER

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-db2/src/main/java/ai/chat2db/plugin/db2/builder/DB2SqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-db2/src/main/java/ai/chat2db/plugin/db2/builder/DB2SqlBuilder.java
@@ -11,6 +11,7 @@ import ai.chat2db.community.domain.api.model.metadata.Table;
 import ai.chat2db.community.domain.api.model.metadata.TableColumn;
 import ai.chat2db.community.domain.api.model.metadata.TableIndex;
 import ai.chat2db.community.domain.api.config.TableBuilderConfig;
+import ai.chat2db.community.domain.api.enums.plugin.EditStatusEnum;
 import org.apache.commons.lang3.StringUtils;
 
 import static ai.chat2db.plugin.db2.constant.DB2SqlBuilderConstants.*;
@@ -109,7 +110,8 @@ public class DB2SqlBuilder extends DefaultSqlBuilder {
                     continue;
                 }
                 script.append(SQLConstants.TAB).append(typeEnum.buildModifyColumn(tableColumn)).append(SQLConstants.SEMICOLON_LINE_SEPARATOR);
-                if (StringUtils.isNotBlank(tableColumn.getComment())) {
+                if (StringUtils.isNotBlank(tableColumn.getComment())
+                        && !EditStatusEnum.DELETE.name().equals(tableColumn.getEditStatus())) {
                     script.append(SQLConstants.LINE_SEPARATOR).append(buildComment(tableColumn)).append(SQLConstants.SEMICOLON_LINE_SEPARATOR);
                 }
             }


### PR DESCRIPTION
## Related issue

Closes #2078

## Summary

`DB2SqlBuilder.buildAlterTable` appended a `COMMENT ON COLUMN` whenever the column's comment was non-blank, including for a `DELETE`-status column. For such a column, `buildModifyColumn` emits `ALTER TABLE ... DROP COLUMN "c"`, then the code appended `COMMENT ON COLUMN "schema"."table"."c" IS '...'` for the just-dropped column, producing invalid SQL. Added the `&& !EditStatusEnum.DELETE.name().equals(tableColumn.getEditStatus())` guard (and the `EditStatusEnum` import), mirroring Oracle (`OracleSqlBuilder.java:184-185`) and DM.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `mvn -B -q -f chat2db-community-server/pom.xml -pl chat2db-community-plugins/chat2db-community-db2 -am -Dmaven.test.skip=true compile` -> BUILD SUCCESS.
- Manual verification: For ADD/MODIFY columns with a comment, the COMMENT clause is still emitted (unchanged). For DROP columns, the COMMENT clause is now skipped, avoiding the invalid statement.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A — only changes generated ALTER text for DROP columns.
- Database or driver compatibility: DB2 ALTER no longer emits an invalid COMMENT for dropped columns; other paths unchanged.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only fixes invalid SQL; no API change.

## Reviewer map

- Start here: `DB2SqlBuilder.buildAlterTable` — comment condition now `StringUtils.isNotBlank(tableColumn.getComment()) && !EditStatusEnum.DELETE.name().equals(tableColumn.getEditStatus())`; new `EditStatusEnum` import.
- Failure condition: ALTER for a DROP column still appends a COMMENT ON COLUMN for the dropped column.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.