### PR TITLE
fix(oracle): separate schema/view with a dot in CREATE VIEW comment

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilder.java
@@ -322,7 +322,7 @@ public class OracleSqlBuilder extends DefaultSqlBuilder {
             createViewSqlBuilder.append(SQLConstants.LINE_SEPARATOR);
             createViewSqlBuilder.append(SQL_COMMENT_TABLE)
                     .append(SQLConstants.DOUBLE_QUOTE).append(schemaName).append(SQLConstants.DOUBLE_QUOTE)
-                    .append(SQLConstants.DOUBLE_QUOTE).append(viewName).append(SQLConstants.DOUBLE_QUOTE)
+                    .append(SQLConstants.DOUBLE_QUOTE_DOT_DOUBLE_QUOTE).append(viewName).append(SQLConstants.DOUBLE_QUOTE)
                     .append(SQLConstants.SQL_IS_LOWER)
                     .append(comment).append(SQLConstants.SEMICOLON);
         }


### PR DESCRIPTION
## Related issue

Closes #2079

## Summary

In `OracleSqlBuilder.buildCreateView`, the `COMMENT ON TABLE` clause (when a view comment is set) emitted `"schema""viewName"` — schema and view quoted back-to-back with no `.` separator, which Oracle parses as a single malformed identifier instead of `"schema"."viewName"`. Replaced the `DOUBLE_QUOTE` preceding `viewName` with `DOUBLE_QUOTE_DOT_DOUBLE_QUOTE`, matching the sibling `buildTableComment` (`:155`) in the same file.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `mvn -B -q -f chat2db-community-server/pom.xml -pl chat2db-community-plugins/chat2db-community-oracle -am -Dmaven.test.skip=true compile` -> BUILD SUCCESS.
- Manual verification: The comment clause now emits `comment on table "schema"."viewName" IS '...'` instead of `"schema""viewName"`, matching `buildTableComment`.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A — only changes generated DDL text.
- Database or driver compatibility: Oracle view comment clause now produces valid syntax; previously malformed.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only fixes previously-invalid generated SQL; no API change.

## Reviewer map

- Start here: `OracleSqlBuilder.buildCreateView` comment clause — `DOUBLE_QUOTE` before `viewName` -> `DOUBLE_QUOTE_DOT_DOUBLE_QUOTE` (line ~325), mirroring `buildTableComment`.
- Failure condition: The COMMENT ON TABLE clause still lacks the schema/view dot.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.