### PR TITLE
fix(chat-question-template): guard example-prompt fetch against unmount

### DIFF
--- a/chat2db-community-client/src/pages/main/chat/chatQuestionTemplate/index.tsx
+++ b/chat2db-community-client/src/pages/main/chat/chatQuestionTemplate/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { useStyles } from './style';
 import chatService from '@/service/chat';
 import { ChatExamplePrompt } from '@/typings/chat';
@@ -13,14 +13,19 @@ interface IProps {
 export default memo<IProps>(({ onSendQuestionTemplate }) => {
   const { styles } = useStyles();
   const [explamePromptList, setExamplePromptList] = useState<ChatExamplePrompt[]>([]);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
+    mountedRef.current = true;
     queryExamplePrompt();
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   const queryExamplePrompt = async () => {
     const res = await chatService.queryChatExamplePrompt({});
-    if (res) {
+    if (res && mountedRef.current) {
       setExamplePromptList(res);
     }
   };


### PR DESCRIPTION
## Related issue

Closes #2081

## Summary

In `chatQuestionTemplate`, a mount-only `useEffect` called `queryExamplePrompt`, which `await`s `chatService.queryChatExamplePrompt({})` and then calls `setExamplePromptList(res)` with no mounted guard. If the component unmounted before the promise resolved, `setState` fired on an unmounted component. Added a `mountedRef` (`useRef(true)`, set `false` in the mount effect's cleanup) and guard `if (res && mountedRef.current)` before `setState`, mirroring the NotificationNav pattern.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `chatQuestionTemplate/index.tsx`.
  - `npx eslint src/pages/main/chat/chatQuestionTemplate/index.tsx` — no errors.
- Manual verification: On unmount before the fetch resolves, `mountedRef.current === false` skips the `setExamplePromptList` call.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only skips `setState` after unmount; mounted behavior unchanged.

## Reviewer map

- Start here: `pages/main/chat/chatQuestionTemplate/index.tsx` — `mountedRef = useRef(true)`, mount `useEffect` sets it true and clears it in cleanup, and `queryExamplePrompt` guards `if (res && mountedRef.current)`.
- Failure condition: `setExamplePromptList` still fires on an unmounted component during the on-mount fetch.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.