### PR TITLE
fix(plugin-menu-list): guard plugin-list fetch against unmount

### DIFF
--- a/chat2db-community-client/src/pages/main/plugin/PluginMenuList/index.tsx
+++ b/chat2db-community-client/src/pages/main/plugin/PluginMenuList/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import PageTitle from '@/components/PageTitle';
 import pluginService from '@/service/plugin';
 import { IPluginItem } from '@/typings/plugin';
@@ -15,6 +15,7 @@ interface PluginMenuListProps {
 const PluginMenuList = ({ curPlugin, onClick }: PluginMenuListProps) => {
   const [pluginList, setPluginList] = useState<IPluginItem[]>([]);
   const { styles } = useStyles();
+  const mountedRef = useRef(true);
 
   const { curUser } = useUserStore((s) => ({
     curUser: s.curUser,
@@ -23,11 +24,16 @@ const PluginMenuList = ({ curPlugin, onClick }: PluginMenuListProps) => {
   const isVip = useMemo(() => curUser?.vip || curUser?.activated, [curUser?.vip, curUser?.activated]);
 
   useEffect(() => {
+    mountedRef.current = true;
     queryPluginList();
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   const queryPluginList = async () => {
     const res = await pluginService.queryPluginList();
+    if (!mountedRef.current) return;
     setPluginList(res);
 
     if (!curPlugin && res[0]) {


### PR DESCRIPTION
## Related issue

Closes #2082

## Summary

In `PluginMenuList`, a mount-only `useEffect` called `queryPluginList`, which `await`s `pluginService.queryPluginList()` and then calls `setPluginList(res)` with no mounted guard. If the component unmounted before the promise resolved, `setState` fired on an unmounted component. Added a `mountedRef` (`useRef(true)`, set `false` in the mount effect's cleanup) and an early `return` after the `await` before `setPluginList`, mirroring the NotificationNav pattern.

Note: the empty-deps effect also closes over `curPlugin`/`isVip` (a stale-closure concern), but the unmount guard is the unambiguous fix here; the stale-closure issue is out of scope for this PR.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `PluginMenuList/index.tsx`.
  - `npx eslint src/pages/main/plugin/PluginMenuList/index.tsx` — no errors.
- Manual verification: On unmount before the fetch resolves, `mountedRef.current === false` skips the `setPluginList` call.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only skips `setState` after unmount; mounted behavior unchanged.

## Reviewer map

- Start here: `pages/main/plugin/PluginMenuList/index.tsx` — `mountedRef = useRef(true)`, mount `useEffect` sets it true and clears it in cleanup, and `queryPluginList` early-returns when `!mountedRef.current` after the await.
- Failure condition: `setPluginList` still fires on an unmounted component during the on-mount fetch.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.