### PR TITLE
docs(readme): add Powered by OtterMind.ai link under logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 </div>
 
 <div align="center">
+  <a href="https://ottermind.ai">Powered by OtterMind.ai</a>
+</div>
+
+<div align="center">
   <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>
   <a href="./README_CN.md"><img alt="简体中文版自述文件" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
   <a href="./README_JA.md"><img alt="日本語のREADME" src="https://img.shields.io/badge/日本語-d9d9d9"></a>

--- a/README_CN.md
+++ b/README_CN.md
@@ -4,6 +4,10 @@
 </div>
 
 <div align="center">
+  <a href="https://ottermind.ai">Powered by OtterMind.ai</a>
+</div>
+
+<div align="center">
   <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>
   <a href="./README_CN.md"><img alt="简体中文版自述文件" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
   <a href="./README_JA.md"><img alt="日本語のREADME" src="https://img.shields.io/badge/日本語-d9d9d9"></a>

--- a/README_ES.md
+++ b/README_ES.md
@@ -4,6 +4,10 @@
 </div>
 
 <div align="center">
+  <a href="https://ottermind.ai">Powered by OtterMind.ai</a>
+</div>
+
+<div align="center">
   <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>
   <a href="./README_CN.md"><img alt="简体中文版自述文件" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
   <a href="./README_JA.md"><img alt="日本語のREADME" src="https://img.shields.io/badge/日本語-d9d9d9"></a>

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,6 +4,10 @@
 </div>
 
 <div align="center">
+  <a href="https://ottermind.ai">Powered by OtterMind.ai</a>
+</div>
+
+<div align="center">
   <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>
   <a href="./README_CN.md"><img alt="简体中文版自述文件" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
   <a href="./README_JA.md"><img alt="日本語のREADME" src="https://img.shields.io/badge/日本語-d9d9d9"></a>

--- a/README_KO.md
+++ b/README_KO.md
@@ -4,6 +4,10 @@
 </div>
 
 <div align="center">
+  <a href="https://ottermind.ai">Powered by OtterMind.ai</a>
+</div>
+
+<div align="center">
   <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>
   <a href="./README_CN.md"><img alt="简体中文版自述文件" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
   <a href="./README_JA.md"><img alt="日本語のREADME" src="https://img.shields.io/badge/日本語-d9d9d9"></a>


### PR DESCRIPTION
Add a centered "Powered by OtterMind.ai" line (linking to https://ottermind.ai) below the logo at the top of README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dxS1jKu1QAEuRysnmYSBC