### PR TITLE
docs(readme): unify Powered by OtterMind line across all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="./icon.png" alt="Chat2DB" width="100">
   <div align="center">
-  Powered by  <a href="https://ottermind.ai">OtterMind.ai</a>
+  Powered by  <a href="https://ottermind.ai">OtterMind</a>
 </div>
   <br/>
   <p><strong>An AI-powered database client and SQL workspace for developers, DBAs, analysts, and data teams.</strong></p>

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,10 +1,10 @@
 <div align="center">
   <img src="./icon.png" alt="Chat2DB" width="100">
-  <p><strong>面向开发者、DBA、分析师和数据团队的 AI 驱动数据库客户端与 SQL 工作空间。</strong></p>
+  <div align="center">
+  Powered by  <a href="https://ottermind.ai">OtterMind.ai</a>
 </div>
-
-<div align="center">
-  <a href="https://ottermind.ai">Powered by OtterMind.ai</a>
+  <br/>
+  <p><strong>面向开发者、DBA、分析师和数据团队的 AI 驱动数据库客户端与 SQL 工作空间。</strong></p>
 </div>
 
 <div align="center">

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="./icon.png" alt="Chat2DB" width="100">
   <div align="center">
-  Powered by  <a href="https://ottermind.ai">OtterMind.ai</a>
+  Powered by  <a href="https://ottermind.ai">OtterMind</a>
 </div>
   <br/>
   <p><strong>面向开发者、DBA、分析师和数据团队的 AI 驱动数据库客户端与 SQL 工作空间。</strong></p>

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="./icon.png" alt="Chat2DB" width="100">
   <div align="center">
-  Powered by  <a href="https://ottermind.ai">OtterMind.ai</a>
+  Powered by  <a href="https://ottermind.ai">OtterMind</a>
 </div>
   <br/>
   <p><strong>Un cliente de bases de datos y espacio de trabajo SQL con IA para desarrolladores, administradores de bases de datos, analistas y equipos de datos.</strong></p>

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,10 +1,10 @@
 <div align="center">
   <img src="./icon.png" alt="Chat2DB" width="100">
-  <p><strong>Un cliente de bases de datos y espacio de trabajo SQL con IA para desarrolladores, administradores de bases de datos, analistas y equipos de datos.</strong></p>
+  <div align="center">
+  Powered by  <a href="https://ottermind.ai">OtterMind.ai</a>
 </div>
-
-<div align="center">
-  <a href="https://ottermind.ai">Powered by OtterMind.ai</a>
+  <br/>
+  <p><strong>Un cliente de bases de datos y espacio de trabajo SQL con IA para desarrolladores, administradores de bases de datos, analistas y equipos de datos.</strong></p>
 </div>
 
 <div align="center">

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,10 +1,10 @@
 <div align="center">
   <img src="./icon.png" alt="Chat2DB" width="100">
-  <p><strong>開発者、DBA、アナリスト、データチーム向けの AI 搭載データベースクライアント兼 SQL ワークスペースです。</strong></p>
+  <div align="center">
+  Powered by  <a href="https://ottermind.ai">OtterMind.ai</a>
 </div>
-
-<div align="center">
-  <a href="https://ottermind.ai">Powered by OtterMind.ai</a>
+  <br/>
+  <p><strong>開発者、DBA、アナリスト、データチーム向けの AI 搭載データベースクライアント兼 SQL ワークスペースです。</strong></p>
 </div>
 
 <div align="center">

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="./icon.png" alt="Chat2DB" width="100">
   <div align="center">
-  Powered by  <a href="https://ottermind.ai">OtterMind.ai</a>
+  Powered by  <a href="https://ottermind.ai">OtterMind</a>
 </div>
   <br/>
   <p><strong>開発者、DBA、アナリスト、データチーム向けの AI 搭載データベースクライアント兼 SQL ワークスペースです。</strong></p>

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="./icon.png" alt="Chat2DB" width="100">
   <div align="center">
-  Powered by  <a href="https://ottermind.ai">OtterMind.ai</a>
+  Powered by  <a href="https://ottermind.ai">OtterMind</a>
 </div>
   <br/>
   <p><strong>개발자, DBA, 분석가 및 데이터 팀을 위한 AI 기반 데이터베이스 클라이언트이자 SQL 워크스페이스입니다.</strong></p>

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,10 +1,10 @@
 <div align="center">
   <img src="./icon.png" alt="Chat2DB" width="100">
-  <p><strong>개발자, DBA, 분석가 및 데이터 팀을 위한 AI 기반 데이터베이스 클라이언트이자 SQL 워크스페이스입니다.</strong></p>
+  <div align="center">
+  Powered by  <a href="https://ottermind.ai">OtterMind.ai</a>
 </div>
-
-<div align="center">
-  <a href="https://ottermind.ai">Powered by OtterMind.ai</a>
+  <br/>
+  <p><strong>개발자, DBA, 분석가 및 데이터 팀을 위한 AI 기반 데이터베이스 클라이언트이자 SQL 워크스페이스입니다.</strong></p>
 </div>
 
 <div align="center">


### PR DESCRIPTION
Align the four localized READMEs (CN/JA/ES/KO) with README.md's header style from #2091, and shorten the link text from "OtterMind.ai" to "OtterMind" in all five READMEs. The centered "Powered by OtterMind" line (linking to https://ottermind.ai) sits directly under the logo inside the header block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dxS1jKu1QAEuRysnmYSBC