### PR TITLE
fix(dm): fall back for the single failing index in exportTable, not all

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-dm/src/main/java/ai/chat2db/plugin/dm/DMDBManager.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-dm/src/main/java/ai/chat2db/plugin/dm/DMDBManager.java
@@ -141,10 +141,10 @@ public class DMDBManager extends DefaultDBManager implements IDbManager {
                             }
                         });
                     } catch (Exception e) {
-                        log.warn("Failed to get the DDL of the index.");
-                        for (TableIndex tableIndex : indexes) {
-                            DMIndexTypeEnum indexTypeEnum = DMIndexTypeEnum.getByType(tableIndex.getType());
-                            ddlBuilder.append("\n").append(indexTypeEnum.buildIndexScript(tableIndex)).append(";");
+                        log.warn("Failed to get the DDL of the index: {}", indexName, e);
+                        DMIndexTypeEnum indexTypeEnum = DMIndexTypeEnum.getByType(index.getType());
+                        if (indexTypeEnum != null) {
+                            ddlBuilder.append("\n").append(indexTypeEnum.buildIndexScript(index)).append(";");
                         }
                     }
                 }


### PR DESCRIPTION
## Related issue

Closes #2093

## Summary

In `DMDBManager.exportTable`, when the DDL fetch for a single index failed, the `catch` block re-emitted `buildIndexScript` for **every** index in the table (`for (TableIndex tableIndex : indexes)`), producing duplicate/wrong DDL (including indexes the outer loop intentionally skips), and skipped the null-guard on `getByType` (NPE on an unrecognized index type). Mirrored the sibling `DMMetaData.tableDDL`: operate on the single failing `index` (the loop variable) with a null-guard.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `mvn -B -q -f chat2db-community-server/pom.xml -pl chat2db-community-plugins/chat2db-community-dm -am -Dmaven.test.skip=true compile` -> BUILD SUCCESS.
- Manual verification: On a single-index DDL fetch failure, the fallback now appends DDL for that one index only (with a null-guard), matching `DMMetaData.tableDDL`; no longer re-emits all indexes or NPEs on an unrecognized type.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A — only changes generated export DDL on the failure path.
- Database or driver compatibility: DM export no longer duplicates/all-index fallbacks or NPEs on the failure path; success path unchanged.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only fixes corrupt output on the failure path; no API change.

## Reviewer map

- Start here: `DMDBManager.exportTable` index-DDL `catch` — `for (tableIndex : indexes)` replaced with the single `index` + `if (indexTypeEnum != null)` guard, mirroring `DMMetaData.tableDDL`.
- Failure condition: A single index DDL fetch failure still appends all indexes' DDL (or NPEs).
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.