### PR TITLE
fix(result-set): clear pending mouseenter timeout in useHeaderTooltip cleanup

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/hooks/useHeaderTooltip.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/hooks/useHeaderTooltip.tsx
@@ -67,6 +67,7 @@ const useHeaderTooltip = ({ tableInstance }: { tableInstance: ITableInstance | n
     });
 
     return () => {
+      clearMouseenterTimeout();
       tableInstance.off(mouseenter_cell_id);
       tableInstance.off(mouseleave_cell_id);
       tableInstance.off(mouseleave_table);


### PR DESCRIPTION
## Related issue

Closes #2098

## Summary

In `useHeaderTooltip`, the effect scheduled `mouseenterTimeout = setTimeout(..., 1000)` and defined a `clearMouseenterTimeout` helper, but the effect cleanup only unregistered the three table event handlers — it did not clear the pending timeout. On unmount (or `tableInstance` change) while a 1s hover timer was pending, the callback fired and called `contextMenuRef?.current?.openDropdown(...)` against a possibly-stale/unmounted ref. Added `clearMouseenterTimeout()` to the cleanup (the helper already exists in scope).

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `useHeaderTooltip.tsx`.
  - `npx eslint src/blocks/SearchResult/components/ResultSetTable/hooks/useHeaderTooltip.tsx` — no errors.
- Manual verification: On unmount/`tableInstance` change while a hover timeout is pending, the timeout is now cleared; the `openDropdown` callback no longer fires against a stale ref.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only adds cleanup; behavior unchanged otherwise.

## Reviewer map

- Start here: `blocks/SearchResult/components/ResultSetTable/hooks/useHeaderTooltip.tsx` — `clearMouseenterTimeout();` added to the effect cleanup return.
- Failure condition: A pending mouseenter timeout still fires after unmount.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.