### PR TITLE
fix(er-modal): skip initLayout setState after dispose

### DIFF
--- a/chat2db-community-client/src/blocks/ERModal/index.tsx
+++ b/chat2db-community-client/src/blocks/ERModal/index.tsx
@@ -140,6 +140,7 @@ const ERModal = forwardRef((props: IProps, ref: ForwardedRef<ERModalRef>) => {
 
   // Customize the initLayout function.
   useEffect(() => {
+    let disposed = false;
     const initLayout = async () => {
       if (!erModalData) {
         return;
@@ -163,12 +164,18 @@ const ERModal = forwardRef((props: IProps, ref: ForwardedRef<ERModalRef>) => {
         console.error('initLayout error', error);
       }
 
+      if (disposed) {
+        return;
+      }
       setNodes(laidOutNodes);
       setEdges(laidOutEdges);
       setLoading(false);
     };
 
     initLayout();
+    return () => {
+      disposed = true;
+    };
   }, [erModalData]);
 
   // Add a handler for the end of node dragging.


### PR DESCRIPTION
## Related issue

Closes #2107

## Summary

In `ERModal`, the `initLayout` effect `await`s `getLaidOutElements(...)` and then calls `setNodes`/`setEdges`/`setLoading(false)` with no disposed guard. If the modal closed (unmount) or `erModalData` changed during the await, the setters fired on an unmounted/stale component. Added a `let disposed = false` (set `true` in the effect cleanup) and an early `return` before the setters, mirroring the `LocalSQLFileTree` disposed pattern.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `npx tsc --noEmit -p chat2db-community-client/tsconfig.json` — no errors for `ERModal/index.tsx`.
  - `npx eslint src/blocks/ERModal/index.tsx` — no errors.
- Manual verification: On unmount or `erModalData` change during the layout `await`, the setters are skipped (`disposed === true`). Normal layout application is unchanged.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only skips setState after dispose; mounted behavior unchanged.

## Reviewer map

- Start here: `blocks/ERModal/index.tsx` `initLayout` effect — `let disposed = false`, cleanup sets it `true`, and an `if (disposed) return;` guard before `setNodes`/`setEdges`/`setLoading`.
- Failure condition: initLayout still calls setState on an unmounted/stale component.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.