### PR TITLE
fix(snowflake): null-guard getByType and use Objects.equals for incrementValue

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/main/java/ai/chat2db/plugin/snowflake/builder/SnowflakeSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/main/java/ai/chat2db/plugin/snowflake/builder/SnowflakeSqlBuilder.java
@@ -9,6 +9,7 @@ import ai.chat2db.community.domain.api.model.metadata.TableColumn;
 import ai.chat2db.community.domain.api.model.metadata.TableIndex;
 import ai.chat2db.community.domain.api.config.TableBuilderConfig;
 import org.apache.commons.lang3.StringUtils;
+import java.util.Objects;
 
 import static ai.chat2db.plugin.snowflake.constant.SnowflakeSqlBuilderConstants.*;
 public class SnowflakeSqlBuilder extends DefaultSqlBuilder {
@@ -33,6 +34,9 @@ public class SnowflakeSqlBuilder extends DefaultSqlBuilder {
                 continue;
             }
             SnowflakeColumnTypeEnum typeEnum = SnowflakeColumnTypeEnum.getByType(column.getColumnType());
+            if (typeEnum == null) {
+                continue;
+            }
             script.append(SQLConstants.TAB).append(typeEnum.buildCreateColumnSql(column)).append(SQLConstants.COMMA_LINE_SEPARATOR);
         }
         for (TableIndex tableIndex : table.getIndexList()) {
@@ -40,6 +44,9 @@ public class SnowflakeSqlBuilder extends DefaultSqlBuilder {
                 continue;
             }
             SnowflakeIndexTypeEnum mysqlIndexTypeEnum = SnowflakeIndexTypeEnum.getByType(tableIndex.getType());
+            if (mysqlIndexTypeEnum == null) {
+                continue;
+            }
             script.append(SQLConstants.TAB).append(SQLConstants.EMPTY).append(mysqlIndexTypeEnum.buildIndexScript(tableIndex)).append(SQLConstants.COMMA_LINE_SEPARATOR);
         }
 
@@ -94,12 +101,15 @@ public class SnowflakeSqlBuilder extends DefaultSqlBuilder {
                 script.append(SQLConstants.TAB).append(SQL_SET_COMMENT).append(SQLConstants.SINGLE_QUOTE).append(newTable.getComment()).append(SQLConstants.SINGLE_QUOTE).append(SQLConstants.COMMA_LINE_SEPARATOR);
             }
         }
-        if (oldTable.getIncrementValue() != newTable.getIncrementValue()) {
+        if (!Objects.equals(oldTable.getIncrementValue(), newTable.getIncrementValue())) {
             script.append(SQLConstants.TAB).append(SQL_AUTO_INCREMENT_EQUAL).append(newTable.getIncrementValue()).append(SQLConstants.COMMA_LINE_SEPARATOR);
         }
         for (TableColumn tableColumn : newTable.getColumnList()) {
             if (StringUtils.isNotBlank(tableColumn.getEditStatus()) && StringUtils.isNotBlank(tableColumn.getColumnType()) && StringUtils.isNotBlank(tableColumn.getName())) {
                 SnowflakeColumnTypeEnum typeEnum = SnowflakeColumnTypeEnum.getByType(tableColumn.getColumnType());
+                if (typeEnum == null) {
+                    continue;
+                }
                 script.append(SQLConstants.TAB).append(typeEnum.buildModifyColumn(tableColumn)).append(SQLConstants.COMMA_LINE_SEPARATOR);
             }
         }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/main/java/ai/chat2db/plugin/snowflake/builder/SnowflakeSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/main/java/ai/chat2db/plugin/snowflake/builder/SnowflakeSqlBuilder.java
@@ -9,6 +9,7 @@ import ai.chat2db.community.domain.api.model.metadata.TableColumn;
 import ai.chat2db.community.domain.api.model.metadata.TableIndex;
 import ai.chat2db.community.domain.api.config.TableBuilderConfig;
 import org.apache.commons.lang3.StringUtils;
+
 import java.util.Objects;
 
 import static ai.chat2db.plugin.snowflake.constant.SnowflakeSqlBuilderConstants.*;
@@ -33,20 +34,14 @@ public class SnowflakeSqlBuilder extends DefaultSqlBuilder {
             if (StringUtils.isBlank(column.getName()) || StringUtils.isBlank(column.getColumnType())) {
                 continue;
             }
-            SnowflakeColumnTypeEnum typeEnum = SnowflakeColumnTypeEnum.getByType(column.getColumnType());
-            if (typeEnum == null) {
-                continue;
-            }
+            SnowflakeColumnTypeEnum typeEnum = requireColumnType(column.getColumnType());
             script.append(SQLConstants.TAB).append(typeEnum.buildCreateColumnSql(column)).append(SQLConstants.COMMA_LINE_SEPARATOR);
         }
         for (TableIndex tableIndex : table.getIndexList()) {
             if (StringUtils.isBlank(tableIndex.getName()) || StringUtils.isBlank(tableIndex.getType())) {
                 continue;
             }
-            SnowflakeIndexTypeEnum mysqlIndexTypeEnum = SnowflakeIndexTypeEnum.getByType(tableIndex.getType());
-            if (mysqlIndexTypeEnum == null) {
-                continue;
-            }
+            SnowflakeIndexTypeEnum mysqlIndexTypeEnum = requireIndexType(tableIndex.getType());
             script.append(SQLConstants.TAB).append(SQLConstants.EMPTY).append(mysqlIndexTypeEnum.buildIndexScript(tableIndex)).append(SQLConstants.COMMA_LINE_SEPARATOR);
         }
 
@@ -106,10 +101,7 @@ public class SnowflakeSqlBuilder extends DefaultSqlBuilder {
         }
         for (TableColumn tableColumn : newTable.getColumnList()) {
             if (StringUtils.isNotBlank(tableColumn.getEditStatus()) && StringUtils.isNotBlank(tableColumn.getColumnType()) && StringUtils.isNotBlank(tableColumn.getName())) {
-                SnowflakeColumnTypeEnum typeEnum = SnowflakeColumnTypeEnum.getByType(tableColumn.getColumnType());
-                if (typeEnum == null) {
-                    continue;
-                }
+                SnowflakeColumnTypeEnum typeEnum = requireColumnType(tableColumn.getColumnType());
                 script.append(SQLConstants.TAB).append(typeEnum.buildModifyColumn(tableColumn)).append(SQLConstants.COMMA_LINE_SEPARATOR);
             }
         }
@@ -122,5 +114,20 @@ public class SnowflakeSqlBuilder extends DefaultSqlBuilder {
         return script.toString();
     }
 
-}
+    private SnowflakeColumnTypeEnum requireColumnType(String columnType) {
+        SnowflakeColumnTypeEnum typeEnum = SnowflakeColumnTypeEnum.getByType(columnType);
+        if (typeEnum == null) {
+            throw new IllegalArgumentException("Unsupported Snowflake column type: " + columnType);
+        }
+        return typeEnum;
+    }
 
+    private SnowflakeIndexTypeEnum requireIndexType(String indexType) {
+        SnowflakeIndexTypeEnum typeEnum = SnowflakeIndexTypeEnum.getByType(indexType);
+        if (typeEnum == null) {
+            throw new IllegalArgumentException("Unsupported Snowflake index type: " + indexType);
+        }
+        return typeEnum;
+    }
+
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/test/java/ai/chat2db/plugin/snowflake/builder/SnowflakeSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/test/java/ai/chat2db/plugin/snowflake/builder/SnowflakeSqlBuilderTest.java
@@ -1,0 +1,66 @@
+package ai.chat2db.plugin.snowflake.builder;
+
+import ai.chat2db.community.domain.api.config.TableBuilderConfig;
+import ai.chat2db.community.domain.api.model.metadata.Table;
+import ai.chat2db.community.domain.api.model.metadata.TableColumn;
+import ai.chat2db.community.domain.api.model.metadata.TableIndex;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SnowflakeSqlBuilderTest {
+
+    private final SnowflakeSqlBuilder builder = new SnowflakeSqlBuilder();
+
+    @Test
+    void buildCreateTableRejectsUnknownColumnTypeWithoutDroppingColumn() {
+        Table table = tableWithColumn("UNKNOWN_TYPE");
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> builder.buildCreateTable(table, new TableBuilderConfig()));
+
+        assertTrue(error.getMessage().contains("UNKNOWN_TYPE"));
+    }
+
+    @Test
+    void buildCreateTableRejectsUnknownIndexTypeWithoutDroppingIndex() {
+        Table table = tableWithColumn("VARCHAR");
+        TableIndex index = new TableIndex();
+        index.setName("idx_users_name");
+        index.setType("UNKNOWN_INDEX");
+        table.setIndexList(Collections.singletonList(index));
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> builder.buildCreateTable(table, new TableBuilderConfig()));
+
+        assertTrue(error.getMessage().contains("UNKNOWN_INDEX"));
+    }
+
+    @Test
+    void buildAlterTableDoesNotAlterEqualBoxedIncrementValues() {
+        Table oldTable = tableWithColumn("VARCHAR");
+        Table newTable = tableWithColumn("VARCHAR");
+        oldTable.setIncrementValue(Long.valueOf(1000));
+        newTable.setIncrementValue(Long.valueOf(1000));
+
+        String sql = builder.buildAlterTable(oldTable, newTable);
+
+        assertFalse(sql.contains("AUTOINCREMENT"));
+    }
+
+    private Table tableWithColumn(String columnType) {
+        TableColumn column = new TableColumn();
+        column.setName("name");
+        column.setColumnType(columnType);
+
+        Table table = new Table();
+        table.setName("users");
+        table.setColumnList(Collections.singletonList(column));
+        table.setIndexList(Collections.emptyList());
+        return table;
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #2131

## Summary

Fixes two correctness issues in `SnowflakeSqlBuilder`:

1. Equal boxed `Long` increment values are now compared with `Objects.equals`, preventing a spurious `AUTOINCREMENT` alteration caused by reference comparison.
2. Unknown Snowflake column or index metadata no longer causes a null dereference or gets silently omitted from generated DDL. The builder now fails fast with an `IllegalArgumentException` that includes the unsupported type. Silent omission would produce apparently successful but incomplete table DDL.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `mvn -pl chat2db-community-plugins/chat2db-community-snowflake -am -Dmaven.test.skip=false -DskipTests=false -Dtest=SnowflakeSqlBuilderTest -Dsurefire.failIfNoSpecifiedTests=false test` - passed.
  - `SnowflakeSqlBuilderTest` - 3 tests passed: unknown column type, unknown index type, and equal boxed increment values.
- Manual verification: Reviewed all three `getByType` call sites to confirm that unsupported metadata cannot be silently dropped from CREATE or ALTER output.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A; no API or persistence changes.
- Database or driver compatibility: Recognized Snowflake types retain existing behavior. Unsupported metadata now returns a specific error instead of an NPE or incomplete DDL.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A; this is isolated to the Community Snowflake plugin.
- Backward compatibility: Corrects erroneous DDL generation. Callers that supplied unsupported types now receive a descriptive exception.

## Reviewer map

- Start here: `SnowflakeSqlBuilder.requireColumnType`, `requireIndexType`, and `SnowflakeSqlBuilderTest`.
- Failure condition: Equal increment values emit `AUTOINCREMENT`, or unsupported types are omitted without an error.
- Rollback or disable path: Revert the two commits in this PR.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The original contribution used Claude Code. A maintainer used Codex to correct the unsupported-metadata behavior and add regression coverage.
