### PR TITLE
fix(on-mount): guard more async fetches against setState after unmount

### DIFF
--- a/chat2db-community-client/src/blocks/Setting/ApiKeys/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/ApiKeys/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { useStyles } from './style';
 import SettingSubsection from '../SettingSubsection';
 import i18n, { i18nElement } from '@/i18n';
@@ -23,6 +23,7 @@ export default memo<IProps>((props) => {
   const [loading, setLoading] = useState(false);
   const [apiKeys, setApiKeys] = useState<ApiKeyDetail[]>([]);
   const [currentApiKey, setCurrentApiKey] = useState<ApiKeyDetail | null>(null);
+  const mountedRef = useRef(true);
 
   const { openUnifiedConfirmationModal, appUrlConfig } = useGlobalStore((state) => {
     return {
@@ -32,7 +33,11 @@ export default memo<IProps>((props) => {
   });
 
   useEffect(() => {
+    mountedRef.current = true;
     getApiKeyList();
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   const renderDescribe = () => {
@@ -52,6 +57,7 @@ export default memo<IProps>((props) => {
     apiKeysServices
       .getApiKeyList()
       .then((res) => {
+        if (!mountedRef.current) return;
         setApiKeys(res);
       });
   };

--- a/chat2db-community-client/src/blocks/Setting/ApiKeys/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/ApiKeys/index.tsx
@@ -10,6 +10,7 @@ import dayjs from 'dayjs';
 import { copyToClipboard } from '@/utils';
 import { useGlobalStore } from '@/store/global';
 import AntdTable from '@/components/AntdTable';
+import { beginLatestRequest, invalidateLatestRequest, isLatestRequest } from '@/utils/latestRequest';
 
 interface IProps {
   className?: string;
@@ -23,7 +24,7 @@ export default memo<IProps>((props) => {
   const [loading, setLoading] = useState(false);
   const [apiKeys, setApiKeys] = useState<ApiKeyDetail[]>([]);
   const [currentApiKey, setCurrentApiKey] = useState<ApiKeyDetail | null>(null);
-  const mountedRef = useRef(true);
+  const requestGenerationRef = useRef(0);
 
   const { openUnifiedConfirmationModal, appUrlConfig } = useGlobalStore((state) => {
     return {
@@ -33,10 +34,9 @@ export default memo<IProps>((props) => {
   });
 
   useEffect(() => {
-    mountedRef.current = true;
     getApiKeyList();
     return () => {
-      mountedRef.current = false;
+      invalidateLatestRequest(requestGenerationRef);
     };
   }, []);
 
@@ -54,10 +54,11 @@ export default memo<IProps>((props) => {
   };
 
   const getApiKeyList = () => {
+    const requestGeneration = beginLatestRequest(requestGenerationRef);
     apiKeysServices
       .getApiKeyList()
       .then((res) => {
-        if (!mountedRef.current) return;
+        if (!isLatestRequest(requestGenerationRef, requestGeneration)) return;
         setApiKeys(res);
       });
   };

--- a/chat2db-community-client/src/blocks/Setting/DeviceCer/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/DeviceCer/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useStyles } from './style';
 import SettingSubsection from '../SettingSubsection';
 import { Form, Input, Select, Button, Typography, Flex, Popconfirm } from 'antd';
@@ -23,8 +23,14 @@ const DeviceCer = () => {
   const { appUrlConfig } = useGlobalStore((state) => ({
     appUrlConfig: state.appUrlConfig,
   }));
+  const mountedRef = useRef(true);
+
   useEffect(() => {
+    mountedRef.current = true;
     queryLicenseInfo();
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   const handleFormValuesChange = (changedValues: any, allValues: any) => {
@@ -47,6 +53,7 @@ const DeviceCer = () => {
     const filterArr = res.filter((t) => t.canGenerateCer);
     const canSelectArr = filterArr.filter((t) => t.licenseBindCount < t.licenseAvailableCount);
     const canNotSelectArr = filterArr.filter((t) => t.licenseBindCount >= t.licenseAvailableCount);
+    if (!mountedRef.current) return;
     setLicenseList([...canSelectArr, ...canNotSelectArr]);
   };
 

--- a/chat2db-community-client/src/blocks/Setting/DeviceCer/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/DeviceCer/index.tsx
@@ -11,6 +11,7 @@ import { copyToClipboard } from '@/utils';
 import { Dot } from 'lucide-react';
 import { useGlobalStore } from '@/store/global';
 import { openWebPage } from '@/utils/url';
+import { beginLatestRequest, invalidateLatestRequest, isLatestRequest } from '@/utils/latestRequest';
 
 const DeviceCer = () => {
   const { styles } = useStyles();
@@ -23,13 +24,12 @@ const DeviceCer = () => {
   const { appUrlConfig } = useGlobalStore((state) => ({
     appUrlConfig: state.appUrlConfig,
   }));
-  const mountedRef = useRef(true);
+  const requestGenerationRef = useRef(0);
 
   useEffect(() => {
-    mountedRef.current = true;
     queryLicenseInfo();
     return () => {
-      mountedRef.current = false;
+      invalidateLatestRequest(requestGenerationRef);
     };
   }, []);
 
@@ -49,11 +49,12 @@ const DeviceCer = () => {
   };
 
   const queryLicenseInfo = async () => {
+    const requestGeneration = beginLatestRequest(requestGenerationRef);
     const res = await LicenseService.getLicenseList();
     const filterArr = res.filter((t) => t.canGenerateCer);
     const canSelectArr = filterArr.filter((t) => t.licenseBindCount < t.licenseAvailableCount);
     const canNotSelectArr = filterArr.filter((t) => t.licenseBindCount >= t.licenseAvailableCount);
-    if (!mountedRef.current) return;
+    if (!isLatestRequest(requestGenerationRef, requestGeneration)) return;
     setLicenseList([...canSelectArr, ...canNotSelectArr]);
   };
 

--- a/chat2db-community-client/src/blocks/Setting/McpSetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/McpSetting/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, Form, Input, Popconfirm, Switch } from 'antd';
 import { staticMessage } from '@chat2db/ui';
 import i18n from '@/i18n';
@@ -11,6 +11,7 @@ import { useStyles } from '../BaseSetting/style';
 export default function McpSetting() {
   const { styles } = useStyles();
   const [token, setToken] = useState('');
+  const mountedRef = useRef(true);
   const { enableMcp, setBaseSetting } = useGlobalStore((state) => {
     return {
       enableMcp: state.baseSetting.enableMcp,
@@ -19,7 +20,15 @@ export default function McpSetting() {
   });
 
   useEffect(() => {
-    jcefApi.getMcpToken().then(setToken);
+    mountedRef.current = true;
+    jcefApi.getMcpToken().then((t) => {
+      if (mountedRef.current) {
+        setToken(t);
+      }
+    });
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   function changeMcpEnabled(checked: boolean) {

--- a/chat2db-community-client/src/blocks/Setting/McpSetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/McpSetting/index.tsx
@@ -7,11 +7,12 @@ import { useGlobalStore } from '@/store/global';
 import { copyToClipboard } from '@/utils/copy';
 import SettingSubsection from '../SettingSubsection';
 import { useStyles } from '../BaseSetting/style';
+import { beginLatestRequest, invalidateLatestRequest, isLatestRequest } from '@/utils/latestRequest';
 
 export default function McpSetting() {
   const { styles } = useStyles();
   const [token, setToken] = useState('');
-  const mountedRef = useRef(true);
+  const requestGenerationRef = useRef(0);
   const { enableMcp, setBaseSetting } = useGlobalStore((state) => {
     return {
       enableMcp: state.baseSetting.enableMcp,
@@ -20,14 +21,14 @@ export default function McpSetting() {
   });
 
   useEffect(() => {
-    mountedRef.current = true;
+    const requestGeneration = beginLatestRequest(requestGenerationRef);
     jcefApi.getMcpToken().then((t) => {
-      if (mountedRef.current) {
+      if (isLatestRequest(requestGenerationRef, requestGeneration)) {
         setToken(t);
       }
     });
     return () => {
-      mountedRef.current = false;
+      invalidateLatestRequest(requestGenerationRef);
     };
   }, []);
 

--- a/chat2db-community-client/src/blocks/Setting/NetworkProxySetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/NetworkProxySetting/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, Form, Input, InputNumber, Radio, Select, Tooltip } from 'antd';
 import { CircleHelp } from 'lucide-react';
 import { staticMessage } from '@chat2db/ui';
@@ -29,9 +29,12 @@ export default function NetworkProxySetting() {
   const [testing, setTesting] = useState(false);
   const [restartRequired, setRestartRequired] = useState(false);
   const mode = Form.useWatch('mode', form);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
+    mountedRef.current = true;
     networkProxyService.get().then((settings) => {
+      if (!mountedRef.current) return;
       const nextSettings = {
         ...defaultProxySettings,
         ...settings,
@@ -42,6 +45,9 @@ export default function NetworkProxySetting() {
       });
       setRestartRequired(!!nextSettings.restartRequired);
     });
+    return () => {
+      mountedRef.current = false;
+    };
   }, [form]);
 
   async function saveSettings() {

--- a/chat2db-community-client/src/blocks/Setting/NetworkProxySetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/NetworkProxySetting/index.tsx
@@ -12,6 +12,7 @@ import networkProxyService, {
 import SettingSubsection from '../SettingSubsection';
 import { useStyles as useBaseStyles } from '../BaseSetting/style';
 import { useStyles } from './style';
+import { beginLatestRequest, invalidateLatestRequest, isLatestRequest } from '@/utils/latestRequest';
 
 const defaultProxySettings: INetworkProxySettings = {
   mode: NetworkProxyMode.NO_PROXY,
@@ -29,12 +30,12 @@ export default function NetworkProxySetting() {
   const [testing, setTesting] = useState(false);
   const [restartRequired, setRestartRequired] = useState(false);
   const mode = Form.useWatch('mode', form);
-  const mountedRef = useRef(true);
+  const requestGenerationRef = useRef(0);
 
   useEffect(() => {
-    mountedRef.current = true;
+    const requestGeneration = beginLatestRequest(requestGenerationRef);
     networkProxyService.get().then((settings) => {
-      if (!mountedRef.current) return;
+      if (!isLatestRequest(requestGenerationRef, requestGeneration)) return;
       const nextSettings = {
         ...defaultProxySettings,
         ...settings,
@@ -46,7 +47,7 @@ export default function NetworkProxySetting() {
       setRestartRequired(!!nextSettings.restartRequired);
     });
     return () => {
-      mountedRef.current = false;
+      invalidateLatestRequest(requestGenerationRef);
     };
   }, [form]);
 

--- a/chat2db-community-client/src/components/ChangeAiTableInfo/index.tsx
+++ b/chat2db-community-client/src/components/ChangeAiTableInfo/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useStyles } from './style';
 import i18n from '@/i18n';
 import { ToolbarBtn, LoadingGracile, staticMessage } from '@chat2db/ui';
@@ -44,8 +44,14 @@ export default memo<IProps>((props) => {
   const [submitLoading] = useState(false);
   const [dataSource, setDataSource, getDataSource] = useSyncState<any[]>([]);
 
+  const mountedRef = useRef(true);
+
   useEffect(() => {
+    mountedRef.current = true;
     getTableComment();
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   const getTableComment = () => {
@@ -89,6 +95,7 @@ export default memo<IProps>((props) => {
         tableName,
         refresh: true,
       }).then((sqlRes) => {
+        if (!mountedRef.current) return;
         const findColumnAlias = (columnName: string) => {
           return aiRes.tableCommentExt?.columnAlias?.find((item) => item.columnName === columnName) || {};
         };

--- a/chat2db-community-client/src/components/ChangeAiTableInfo/index.tsx
+++ b/chat2db-community-client/src/components/ChangeAiTableInfo/index.tsx
@@ -11,6 +11,7 @@ import { EditableCellType } from '@/blocks/EditableAntdTable/components/InputEdi
 import { cloneDeep } from 'lodash';
 import useSyncState from '@/hooks/useSyncState';
 import { DataCollectionElementType } from '@/constants/aiDataCollection';
+import { beginLatestRequest, invalidateLatestRequest, isLatestRequest } from '@/utils/latestRequest';
 
 interface IProps {
   className?: string;
@@ -44,17 +45,17 @@ export default memo<IProps>((props) => {
   const [submitLoading] = useState(false);
   const [dataSource, setDataSource, getDataSource] = useSyncState<any[]>([]);
 
-  const mountedRef = useRef(true);
+  const requestGenerationRef = useRef(0);
 
   useEffect(() => {
-    mountedRef.current = true;
     getTableComment();
     return () => {
-      mountedRef.current = false;
+      invalidateLatestRequest(requestGenerationRef);
     };
   }, []);
 
   const getTableComment = () => {
+    const requestGeneration = beginLatestRequest(requestGenerationRef);
     setColumnAlias(null);
     setBasicInfo(null);
     form.resetFields();
@@ -95,7 +96,7 @@ export default memo<IProps>((props) => {
         tableName,
         refresh: true,
       }).then((sqlRes) => {
-        if (!mountedRef.current) return;
+        if (!isLatestRequest(requestGenerationRef, requestGeneration)) return;
         const findColumnAlias = (columnName: string) => {
           return aiRes.tableCommentExt?.columnAlias?.find((item) => item.columnName === columnName) || {};
         };

--- a/chat2db-community-client/src/components/ViewTable/index.tsx
+++ b/chat2db-community-client/src/components/ViewTable/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useEffect } from 'react';
+import { memo, useState, useEffect, useRef } from 'react';
 import SearchResult from '@/blocks/SearchResult';
 import { processResultDataList } from '@/utils/database';
 import { IManageResultData, IViewTableParams } from '@/typings';
@@ -16,15 +16,21 @@ const ViewTable = memo<IProps>((props) => {
   const { viewTableParams } = props;
   const { styles } = useStyles();
   const [resultDataList, setResultDataList] = useState<IManageResultData[]>();
+  const mountedRef = useRef(true);
   const { executing, executeSQL, stopExecuteSQL } = useViewTable();
 
   useEffect(() => {
+    mountedRef.current = true;
     if (viewTableParams) {
       executeSQL(viewTableParams).then((data) => {
+        if (!mountedRef.current) return;
         const _resultDataList = processResultDataList(data, viewTableParams);
         setResultDataList(_resultDataList);
       });
     }
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   return (

--- a/chat2db-community-client/src/components/ViewTable/index.tsx
+++ b/chat2db-community-client/src/components/ViewTable/index.tsx
@@ -6,6 +6,7 @@ import { Spin } from 'antd';
 import i18n from '@/i18n';
 import useViewTable from '@/hooks/useViewTable';
 import { useStyles } from './style';
+import { beginLatestRequest, invalidateLatestRequest, isLatestRequest } from '@/utils/latestRequest';
 
 interface IProps {
   className?: string;
@@ -16,20 +17,20 @@ const ViewTable = memo<IProps>((props) => {
   const { viewTableParams } = props;
   const { styles } = useStyles();
   const [resultDataList, setResultDataList] = useState<IManageResultData[]>();
-  const mountedRef = useRef(true);
+  const requestGenerationRef = useRef(0);
   const { executing, executeSQL, stopExecuteSQL } = useViewTable();
 
   useEffect(() => {
-    mountedRef.current = true;
     if (viewTableParams) {
+      const requestGeneration = beginLatestRequest(requestGenerationRef);
       executeSQL(viewTableParams).then((data) => {
-        if (!mountedRef.current) return;
+        if (!isLatestRequest(requestGenerationRef, requestGeneration)) return;
         const _resultDataList = processResultDataList(data, viewTableParams);
         setResultDataList(_resultDataList);
       });
     }
     return () => {
-      mountedRef.current = false;
+      invalidateLatestRequest(requestGenerationRef);
     };
   }, []);
 


### PR DESCRIPTION
## Related issue

Closes #2135

## Summary

Six components start an asynchronous request from a mount effect and can write component-local state after unmount. The original patch used a mounted boolean, but that boolean cannot distinguish React Strict Mode's cleanup/setup cycle: an older request can resolve after the next setup has set the boolean back to `true`.

This revision reuses the request-generation helper introduced by #2118. Every mount request receives a generation token, cleanup invalidates that token, and the response is applied only while it is still the latest generation. This prevents stale work from an earlier mount or Strict Mode setup from updating the current component instance.

Applied across:

- `components/ChangeAiTableInfo/index.tsx`
- `components/ViewTable/index.tsx`
- `blocks/Setting/McpSetting/index.tsx`
- `blocks/Setting/NetworkProxySetting/index.tsx`
- `blocks/Setting/DeviceCer/index.tsx`
- `blocks/Setting/ApiKeys/index.tsx`

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- `yarn test:verification-code-countdown` - passed, including the shared latest-request lifecycle contract.
- `yarn eslint <the six changed files>` - passed.
- `yarn build:web:community` - passed, including the existing prebuild tests.
- `git diff --check origin/main...HEAD` - passed.
- Net diff against the current `main` contains only the six components listed above.

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Mounted behavior is unchanged; only stale responses from an invalidated request generation are ignored.

## Reviewer map

- Start with the six component effects and their calls to `beginLatestRequest`, `isLatestRequest`, and `invalidateLatestRequest`.
- Failure condition: a response from an unmounted or superseded mount generation still reaches local state or `form.setFieldsValue`.
- Rollback path: revert this PR; the shared helper remains owned by #2118.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The original fix was produced with Claude Code assistance. The maintainer revision, request-generation integration, verification, and updated PR description were produced with Codex assistance.
