### PR TITLE
fix(kingbase): use double-quote for DROP COLUMN identifier

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/constant/KingBaseColumnTypeEnumConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/constant/KingBaseColumnTypeEnumConstants.java
@@ -17,7 +17,7 @@ public final class KingBaseColumnTypeEnumConstants {
 
     public static final String SQL_ALTER_COLUMN = "ALTER COLUMN \"";
     public static final String SQL_COMMENT_COLUMN = "COMMENT ON COLUMN";
-    public static final String SQL_DROP_COLUMN = "DROP COLUMN `";
+    public static final String SQL_DROP_COLUMN = "DROP COLUMN \"";
 
     private KingBaseColumnTypeEnumConstants() {
     }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/enums/type/KingBaseColumnTypeEnum.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/enums/type/KingBaseColumnTypeEnum.java
@@ -139,7 +139,7 @@ public enum KingBaseColumnTypeEnum implements IColumnBuilder {
     public String buildModifyColumn(TableColumn column) {
 
         if (EditStatusEnum.DELETE.name().equals(column.getEditStatus())) {
-            return StringUtils.join(SQL_DROP_COLUMN, column.getName() + "`");
+            return StringUtils.join(SQL_DROP_COLUMN, column.getName() + "\"");
         }
         if (EditStatusEnum.ADD.name().equals(column.getEditStatus())) {
             return StringUtils.join("ADD COLUMN ", buildCreateColumnSql(column));


### PR DESCRIPTION
## Related issue

Closes #2142

## Summary

KingBase is PostgreSQL-derived and quotes identifiers with double quotes everywhere else (`KingBaseMetaData`, `SQL_ALTER_COLUMN`, `buildCreateColumnSql`). But the DROP-column path used MySQL-style backticks: `SQL_DROP_COLUMN = "DROP COLUMN ``"` and `column.getName() + "``"`, producing `DROP COLUMN ``name``` which is invalid KingBase SQL. Changed both to double-quote quoting, mirroring the PostgreSQL sibling (`PostgreSQLColumnTypeEnumConstants`).

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `mvn -B -q -f chat2db-community-server/pom.xml -pl chat2db-community-plugins/chat2db-community-kingbase -am -Dmaven.test.skip=true compile` -> BUILD SUCCESS.
- Manual verification: DROP COLUMN now emits `DROP COLUMN "name"` (double-quoted), valid KingBase SQL.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A — only changes generated DROP DDL quoting.
- Database or driver compatibility: KingBase DROP COLUMN now produces valid SQL; previously invalid.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: Only fixes invalid SQL; no API change.

## Reviewer map

- Start here: `KingBaseColumnTypeEnumConstants.java:20` — `DROP COLUMN `` -> `DROP COLUMN "`; `KingBaseColumnTypeEnum.java:142` — `column.getName() + "``"` -> `column.getName() + "\""`.
- Failure condition: DROP COLUMN still uses backticks.
- Rollback or disable path: Revert this single commit.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: The fix, verification, and PR description were produced with Claude Code assistance.