### PR TITLE
ci(dependabot): group related dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,52 @@ updates:
     directory: /chat2db-community-client
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      npm-non-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: maven
     directory: /chat2db-community-server
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
+    groups:
+      maven-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      maven-non-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
+    groups:
+      codeql-actions:
+        applies-to: version-updates
+        patterns:
+          - "github/codeql-action/*"
+      actions-non-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Related issue

Closes #2207

## Summary

Group related Dependabot updates to reduce review and CI noise while preserving independent review for major dependency upgrades.

- Group npm and Maven security updates per ecosystem.
- Group npm and Maven patch/minor version updates per ecosystem.
- Keep major version updates as individual pull requests.
- Keep all CodeQL action steps on one revision.
- Group other non-major GitHub Actions updates.
- Raise the version-update pull request limit to 10 so the grouped update and the current major updates can coexist.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - git diff --check - passed.
  - Ruby YAML.safe_load - parsed all three ecosystems and verified each has groups.
- Manual verification: Compared the grouping rules against the current 45 open Dependabot pull requests and the official Dependabot group semantics.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A; no application code or data format changes.
- Database or driver compatibility: N/A; this pull request changes dependency automation only.
- Network, privacy, or security: Security updates remain enabled and are grouped per ecosystem. A failing dependency can block its security group and must then be isolated.
- Community / Local / Pro boundary: Community repository automation only.
- Backward compatibility: N/A; the previous one-pull-request-per-dependency layout is intentionally replaced.

## Reviewer map

- Start here: .github/dependabot.yml
- Failure condition: Dependabot rejects the configuration, does not create grouped pull requests, or groups major version updates.
- Rollback or disable path: Revert this pull request or remove the affected groups block.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex inspected the current Dependabot inventory, drafted the grouping policy, edited the configuration, and ran the reported validation.