### PR TITLE
build(deps): roll up legacy Maven security updates

### DIFF
--- a/chat2db-community-server/chat2db-community-bom/pom.xml
+++ b/chat2db-community-server/chat2db-community-bom/pom.xml
@@ -39,7 +39,7 @@
         <druid.version>1.2.18</druid.version>
         <sa-token.version>1.34.0</sa-token.version>
         <forest.version>1.5.32</forest.version>
-        <okhttp.version>3.14.9</okhttp.version>
+        <okhttp.version>4.9.2</okhttp.version>
         <flyway.version>9.19.4</flyway.version>
         <chatgpt-java.version>1.0.8</chatgpt-java.version>
         <openai-gpt3-java.version>0.12.0</openai-gpt3-java.version>
@@ -67,7 +67,7 @@
         <bouncycastle.version>1.71</bouncycastle.version>
         <jsqlparser.version>4.9</jsqlparser.version>
         <jts.version>1.19.0</jts.version>
-        <tika.version>2.7.0</tika.version>
+        <tika.version>3.2.2</tika.version>
         <calcite.version>1.38.0</calcite.version>
         <poi.version>4.1.2</poi.version>
         <chat2db.maven-antrun-plugin.version>3.0.0</chat2db.maven-antrun-plugin.version>


### PR DESCRIPTION
## Related issue

Refs #2231

## Summary

Rolls the two legacy Maven security pull requests into one reviewable BOM update after Dependabot did not generate a grouped replacement from the current security configuration.

The rollup is based on current `main` and combines the exact Dependabot head commits from #1864 and #1866:

- `org.apache.tika:tika-core`: `2.7.0 -> 3.2.2`
- `com.squareup.okhttp3:okhttp`: `3.14.9 -> 4.9.2`

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `git diff --check origin/main...HEAD`: passed.
  - `mvn -B -ntp -DskipTests validate` with Maven 3.9.12 and Java 17.0.18: passed for all 48 reactor modules.
- Manual verification: Compared the final two-line BOM diff with the closed Dependabot PR heads #1864 and #1866.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No intentional API or stored-data change; runtime library behavior can change at the Tika and OkHttp major-version boundaries.
- Database or driver compatibility: No database-driver version is changed directly.
- Network, privacy, or security: Applies the patched versions proposed by Dependabot. OkHttp changes network-library behavior and Tika changes document parsing behavior, so full CI and focused review are required before merge.
- Community / Local / Pro boundary: Community backend dependency management only.
- Backward compatibility: Tika 2 to 3 and OkHttp 3 to 4 are major upgrades; this PR intentionally remains unmerged pending CI and compatibility review.

## Reviewer map

- Start here: `chat2db-community-server/chat2db-community-bom/pom.xml`.
- Failure condition: Maven package/tests fail, or Tika/OkHttp call sites are incompatible with the upgraded APIs or runtime behavior.
- Rollback or disable path: Revert this PR; the grouped Dependabot configuration from #2208 remains enabled for future updates.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex combined the existing Dependabot commits, verified the final BOM diff, and ran the Maven reactor validation.