### PR TITLE
feat(ui): align Community actions with Lucide icons

### DIFF
--- a/chat2db-community-client/scripts/i18n-source-hashes.json
+++ b/chat2db-community-client/scripts/i18n-source-hashes.json
@@ -27,7 +27,7 @@
       "stream.ts": "8418dd25b0fd54b2ef2b15a2573edf0a4876efb4e69936ff82a157ea5cf42be4",
       "team.ts": "eb1fb03bdfeb93169ef1d2e347deb5b95071c10c8c93c35cfe2cb5b6606779ea",
       "userGuide.ts": "0103ba35af95a3a0ff7a414130b68a7dd5f5f8196e59cd951631ac2090cb04fe",
-      "workspace.ts": "ce4873c3181233fec85e3fd177c3a147760e94852734699442f1248277744040"
+      "workspace.ts": "846c4ea2acd392fa026473cf216bfaf3f62c1a4355be872efa939aa199468c8d"
     },
     "ko-KR": {
       "ai.ts": "391a6e14c58d8401bf3bc245eca5bdd4b66efd8225a877bfbbcae01a1c1c019a",
@@ -54,7 +54,7 @@
       "stream.ts": "8418dd25b0fd54b2ef2b15a2573edf0a4876efb4e69936ff82a157ea5cf42be4",
       "team.ts": "eb1fb03bdfeb93169ef1d2e347deb5b95071c10c8c93c35cfe2cb5b6606779ea",
       "userGuide.ts": "0103ba35af95a3a0ff7a414130b68a7dd5f5f8196e59cd951631ac2090cb04fe",
-      "workspace.ts": "ce4873c3181233fec85e3fd177c3a147760e94852734699442f1248277744040"
+      "workspace.ts": "846c4ea2acd392fa026473cf216bfaf3f62c1a4355be872efa939aa199468c8d"
     }
   }
 }

--- a/chat2db-community-client/src/blocks/AI/components/AICascaderSource/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AICascaderSource/index.tsx
@@ -11,6 +11,7 @@ import { findNode } from '@/utils';
 import { IconfontSvg } from '@chat2db/ui';
 import { Cascader, Tooltip } from 'antd';
 import { useMemo } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { useStyles } from './style';
 
 export type IAICascaderData = IDBContextInfo | DataCollectionContextInfo | null;
@@ -298,7 +299,7 @@ const AICascaderSource = (props: IProps) => {
       loadData={loadData}
       onChange={handleChange}
       optionRender={optionRender}
-      suffixIcon={<IconfontSvg code="icon-chevron-bottom" size={12} />}
+      suffixIcon={<ChevronDown size={12} />}
       prefix={
         cascaderValue.length === 0 ? (
           <div className={styles.displayRenderPlus}>

--- a/chat2db-community-client/src/blocks/AI/components/AICascaderSource/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AICascaderSource/index.tsx
@@ -299,7 +299,7 @@ const AICascaderSource = (props: IProps) => {
       loadData={loadData}
       onChange={handleChange}
       optionRender={optionRender}
-      suffixIcon={<ChevronDown size={12} />}
+      suffixIcon={<ChevronDown size={14} />}
       prefix={
         cascaderValue.length === 0 ? (
           <div className={styles.displayRenderPlus}>

--- a/chat2db-community-client/src/blocks/AI/components/AIModelSelect/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelSelect/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Select } from 'antd';
-import { PlusOutlined, RightOutlined } from '@ant-design/icons';
+import { PlusOutlined } from '@ant-design/icons';
+import { ChevronRight } from 'lucide-react';
 import { useStyles } from './style';
 import i18n from '@/i18n';
 import { useAIStore } from '@/store/ai/store';
@@ -81,7 +82,7 @@ const AIModelSelect = ({
           <span className={styles.customModelTitle}>{customModelText || i18n('setting.modelConfig.entry')}</span>
           <span className={styles.customModelHint}>{i18n('setting.modelConfig.entryHint')}</span>
         </span>
-        <RightOutlined className={styles.customModelArrow} />
+        <ChevronRight className={styles.customModelArrow} size={14} />
       </div>
     ) : null;
   const optionsWithCustomModelEntry = appendCustomModelEntryOption(

--- a/chat2db-community-client/src/blocks/AI/components/AIModelSelect/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelSelect/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Select } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
-import { ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useStyles } from './style';
 import i18n from '@/i18n';
 import { useAIStore } from '@/store/ai/store';
@@ -103,6 +103,7 @@ const AIModelSelect = ({
       options={optionsWithCustomModelEntry}
       size="small"
       placeholder={i18n('ai.select.model')}
+      suffixIcon={<ChevronDown size={14} />}
       onDropdownVisibleChange={handleDropdownVisibleChange}
     />
   );

--- a/chat2db-community-client/src/blocks/BI/Chart/form/components/ComboAxisSelect/index.tsx
+++ b/chat2db-community-client/src/blocks/BI/Chart/form/components/ComboAxisSelect/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { Select, Dropdown } from 'antd';
 import { IChartItem } from '@/typings';
 import { newFormattedSqlExecuteData } from '@/utils/dashboard';
@@ -125,7 +126,7 @@ const ComboAxisSelectItem = (props: IItemProps) => {
       {
         key: 'move-up',
         label: i18n('common.button.moveUp'),
-        icon: <IconfontSvg code="icon-up-arrow" />,
+        icon: <ChevronUp size={16} />,
         onClick: () => {
           onAction?.('move-up');
         },
@@ -133,7 +134,7 @@ const ComboAxisSelectItem = (props: IItemProps) => {
       {
         key: 'move-down',
         label: i18n('common.button.moveDown'),
-        icon: <IconfontSvg code="icon-down-arrow" />,
+        icon: <ChevronDown size={16} />,
         onClick: () => {
           onAction?.('move-down');
         },

--- a/chat2db-community-client/src/blocks/Chat/MessageRender/Analyzing/index.tsx
+++ b/chat2db-community-client/src/blocks/Chat/MessageRender/Analyzing/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useMemo, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { useStyles } from './style';
 import { Spin } from 'antd';
 import { AnswerPartsStatus, AnswerPartsType } from '@/constants/chat';
@@ -78,7 +79,7 @@ export default memo<IProps>((props) => {
           {loading ? renderAnalyzing() : renderAnalyzed()}
           {/* {renderAnalyzing()} */}
           <span className={cx(styles.fold, { [styles.unfold]: !hiddenAnalyze })}>
-            <IconfontSvg size={12} code="icon-chevron-bottom" />
+            <ChevronDown size={12} />
           </span>
         </div>
       </div>

--- a/chat2db-community-client/src/blocks/NewTree/components/TitleRender/index.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/components/TitleRender/index.tsx
@@ -7,6 +7,7 @@ import { setFocusedContent, getFocusedContent } from '@/store/common/copyFocused
 import { switchIcon, treeConfig } from '../../treeConfig';
 import LoadingGracile from '@/components/Loading/LoadingGracile';
 import { type ThemeAppearance } from 'antd-style';
+import { User, Users } from 'lucide-react';
 import { ContextMenuRef } from '@/components/ContextMenu';
 import Filtration from '../Filtration';
 import { splitSearchHighlight } from './highlightSearchText';
@@ -140,6 +141,14 @@ const TitleRender = (props: IProps) => {
           code={nodeData?.decorativeParams?.pinned ? pinnedTableIcon : tableIcon}
         />
       );
+    }
+
+    if (nodeData.treeNodeType === TreeNodeType.DATABASE_ACCOUNTS) {
+      return <Users className={styles.customizeIcon} size={19} />;
+    }
+
+    if (nodeData.treeNodeType === TreeNodeType.DATABASE_ACCOUNT) {
+      return <User className={cx(styles.customizeIconIsLeaf, styles.customizeIcon)} size={19} />;
     }
 
     if (isExpanded && switchIcon[nodeData.treeNodeType]!.unfoldIcon) {

--- a/chat2db-community-client/src/blocks/NewTree/components/TitleRender/index.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/components/TitleRender/index.tsx
@@ -7,7 +7,7 @@ import { setFocusedContent, getFocusedContent } from '@/store/common/copyFocused
 import { switchIcon, treeConfig } from '../../treeConfig';
 import LoadingGracile from '@/components/Loading/LoadingGracile';
 import { type ThemeAppearance } from 'antd-style';
-import { User, Users } from 'lucide-react';
+import { ChevronRight, User, Users } from 'lucide-react';
 import { ContextMenuRef } from '@/components/ContextMenu';
 import Filtration from '../Filtration';
 import { splitSearchHighlight } from './highlightSearchText';
@@ -102,10 +102,9 @@ const TitleRender = (props: IProps) => {
     }
 
     return (
-      <IconfontSvg
+      <ChevronRight
         className={cx(styles.switcherIcon, { [styles.unfoldSwitcherIcon]: isExpanded })}
         size={13}
-        code="icon-chevron-right"
       />
     );
   };

--- a/chat2db-community-client/src/blocks/PersonalCenter/components/OfflineAvatar/index.tsx
+++ b/chat2db-community-client/src/blocks/PersonalCenter/components/OfflineAvatar/index.tsx
@@ -3,7 +3,12 @@ import { useGlobalStore } from '@/store/global';
 import Logo from '@/components/Logo';
 import { Tooltip } from 'antd';
 
-const OfflineAvatar = () => {
+interface OfflineAvatarProps {
+  logoSize?: number;
+  triggerSize?: number;
+}
+
+const OfflineAvatar = ({ logoSize = 36, triggerSize = logoSize }: OfflineAvatarProps) => {
   const { setSettingPageActiveTab } = useGlobalStore((state) => {
     return {
       setSettingPageActiveTab: state.setSettingPageActiveTab,
@@ -14,8 +19,18 @@ const OfflineAvatar = () => {
   };
   return (
     <Tooltip title={i18n('setting.title.setting')} placement="right">
-      <div onClick={handleClick} style={{ cursor: 'pointer' }}>
-        <Logo size={36} />
+      <div
+        onClick={handleClick}
+        style={{
+          alignItems: 'center',
+          cursor: 'pointer',
+          display: 'flex',
+          height: triggerSize,
+          justifyContent: 'center',
+          width: triggerSize,
+        }}
+      >
+        <Logo size={logoSize} />
       </div>
     </Tooltip>
   );

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExportBar/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExportBar/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo } from 'react';
 import { Dropdown, MenuProps, Space } from 'antd';
-import { DownOutlined } from '@ant-design/icons';
+import { ChevronDown } from 'lucide-react';
 import { ExportSizeEnum, ExportTypeEnum } from '@/typings/resultTable';
 import i18n from '@/i18n';
 import sqlService, { IExportParams } from '@/service/sql';
@@ -92,7 +92,7 @@ export default memo<IProps>((props) => {
     <Dropdown destroyPopupOnHide menu={{ items: exportDropdownItems }} trigger={['click']}>
       <Space className={styles.exportBar}>
         {i18n('common.text.export')}
-        <DownOutlined />
+        <ChevronDown size={14} />
       </Space>
     </Dropdown>
   );

--- a/chat2db-community-client/src/blocks/SearchResult/components/FESearch/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/FESearch/index.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
   useCallback,
 } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import i18n from '@/i18n';
 import { useStyles } from './style';
 import { SearchComponent } from '@visactor/vtable-search';
@@ -178,7 +179,7 @@ const FESearch = forwardRef((props: IProps, ref: ForwardedRef<FESearchRef>) => {
             iconSize: 18,
             borderRadius: 3,
           }}
-          code="icon-up-arrow"
+          icon={ChevronUp}
           title={i18n('workspace.searchResult.prev')}
           onClick={handleJumpPrev}
         />
@@ -188,7 +189,7 @@ const FESearch = forwardRef((props: IProps, ref: ForwardedRef<FESearchRef>) => {
             iconSize: 18,
             borderRadius: 3,
           }}
-          code="icon-down-arrow"
+          icon={ChevronDown}
           title={i18n('workspace.searchResult.next')}
           onClick={handleJumpNext}
         />

--- a/chat2db-community-client/src/blocks/Setting/BaseSetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/BaseSetting/index.tsx
@@ -10,6 +10,7 @@ import { settingSelectors } from '@/store/global/selectors';
 import { refreshPage } from '@/utils';
 import { PrimaryColors, primaryColorsScales, PrimaryGradient, Swatches, ThemeAppearance } from '@chat2db/ui';
 import { Form, Input, Select } from 'antd';
+import { ChevronDown } from 'lucide-react';
 import { useMemo } from 'react';
 import SettingSubsection from '../SettingSubsection';
 import { useStyles } from './style';
@@ -148,7 +149,13 @@ export default function BaseSetting() {
       </div>
       <div>
         <SettingSubsection title={i18n('setting.title.language')} describe={i18n('setting.title.languageDescribe')} />
-        <Select value={curLanguage} style={{ width: 140 }} onChange={changeLang} options={curLanguageOptions} />
+        <Select
+          value={curLanguage}
+          style={{ width: 140 }}
+          onChange={changeLang}
+          options={curLanguageOptions}
+          suffixIcon={<ChevronDown size={14} />}
+        />
       </div>
       <div>
         <SettingSubsection
@@ -175,6 +182,7 @@ export default function BaseSetting() {
               setCustomFontSize(e);
             }}
             options={customFontSizeOptions}
+            suffixIcon={<ChevronDown size={14} />}
           />
           {/* </Form.Item> */}
         </Form>

--- a/chat2db-community-client/src/blocks/Setting/EditorSetting/InteractiveSelect.tsx
+++ b/chat2db-community-client/src/blocks/Setting/EditorSetting/InteractiveSelect.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import { Select } from 'antd';
+import { ChevronDown } from 'lucide-react';
 
 const InteractiveSelect = ({ onChange, options, ...props }) => {
   const [open, setOpen] = useState(false);
@@ -51,6 +52,7 @@ const InteractiveSelect = ({ onChange, options, ...props }) => {
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
       options={options}
+      suffixIcon={<ChevronDown size={14} />}
     />
   );
 };

--- a/chat2db-community-client/src/blocks/Setting/EditorSetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/EditorSetting/index.tsx
@@ -6,7 +6,6 @@ import { useCommonStyle } from '../commonStyle';
 import { Form, InputNumber, Radio, Col, Row, Input, Select, Switch } from 'antd';
 import { useGlobalStore } from '@/store/global';
 
-import { InfoCircleOutlined } from '@ant-design/icons';
 import { DEFAULT_EDITOR_SETTINGS, MonacoEditor, editorFontFamily, editorThemes } from '@/components/SQLEditor';
 import exampleSQL from '@/components/SQLEditor/data/example.sql';
 import InteractiveSelect from './InteractiveSelect';
@@ -92,7 +91,6 @@ function EditorSettings() {
             style={{ width: '50%', minWidth: '160px' }}
             tooltip={{
               title: i18n('monaco.theme.tooltip'),
-              icon: <InfoCircleOutlined />,
             }}
           >
             <InteractiveSelect

--- a/chat2db-community-client/src/blocks/Setting/EditorSetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/EditorSetting/index.tsx
@@ -14,6 +14,7 @@ import { osNow } from '@/utils';
 import { v4 as uuid } from 'uuid';
 import { databaseMap } from '@/constants';
 import { useUpdateEffect } from 'ahooks';
+import { ChevronDown } from 'lucide-react';
 
 const THEMES = Object.entries(editorThemes).map(([key]) => ({ label: key, value: key }));
 const FONT_FAMILIES = Object.entries(editorFontFamily).map(([key, value]) => ({ label: key, value }));
@@ -172,6 +173,7 @@ function EditorSettings() {
           <Col span={12}>
             <Form.Item name="renderLineHighlight" label={i18n('monaco.renderLineHighlight')}>
               <Select
+                suffixIcon={<ChevronDown size={14} />}
                 options={['line', 'none', 'gutter', 'all'].map((value) => ({
                   label: value.toUpperCase(),
                   value,
@@ -189,6 +191,7 @@ function EditorSettings() {
             <Form.Item name="completion" label={i18n('monaco.completion.all')}>
               <Select
                 mode="multiple"
+                suffixIcon={<ChevronDown size={14} />}
                 options={Object.values(databaseMap).map((value) => ({
                   label: value.name,
                   value: value.code,

--- a/chat2db-community-client/src/blocks/Setting/ShortcutSetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/ShortcutSetting/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Button, Table, Tag, type TableProps } from 'antd';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { staticMessage } from '@chat2db/ui';
 import { useStyles } from './style';
 import { useGlobalStore } from '@/store/global';
@@ -193,7 +194,9 @@ export default function ShortcutSetting() {
           return (
             <section key={group.scope} className={styles.groupSection}>
               <Button type="text" className={styles.groupHeader} onClick={() => toggleGroup(group.scope)}>
-                <span className={styles.groupArrow}>{collapsed ? '>' : 'v'}</span>
+                <span className={styles.groupArrow}>
+                  {collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+                </span>
                 <span className={styles.groupTitle}>{i18n(group.title)}</span>
               </Button>
               {!collapsed && (

--- a/chat2db-community-client/src/blocks/Setting/ShortcutSetting/style.ts
+++ b/chat2db-community-client/src/blocks/Setting/ShortcutSetting/style.ts
@@ -46,11 +46,13 @@ export const useStyles = createStyles(({ css, token }) => {
       }
     `,
     groupArrow: css`
-      width: 12px;
+      align-items: center;
       color: ${token.colorTextSecondary};
-      font-size: ${token.fontSizeSM}px;
-      line-height: 1;
-      text-align: center;
+      display: flex;
+      flex: 0 0 14px;
+      height: 14px;
+      justify-content: center;
+      width: 14px;
     `,
     groupTitle: css`
       margin: 0;

--- a/chat2db-community-client/src/components/Pagination/index.tsx
+++ b/chat2db-community-client/src/components/Pagination/index.tsx
@@ -6,7 +6,8 @@ import _ from 'lodash';
 import { IconButton, ToolbarBtn } from '@chat2db/ui';
 import LoadingGracile from '@/components/Loading/LoadingGracile';
 import { useStyles } from './style';
-import { CheckOutlined, DownOutlined } from '@ant-design/icons';
+import { CheckOutlined } from '@ant-design/icons';
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
 import { RESULT_PAGE_SIZE_OPTIONS } from '@/constants/pagination';
 import { useGlobalStore } from '@/store/global';
 import { settingSelectors } from '@/store/global/selectors';
@@ -224,13 +225,13 @@ export default function Pagination(props: IProps) {
   return (
     <div className={styles.paginationWrapper}>
       <IconButton
-        code="icon-paging-start"
+        icon={ChevronsLeft}
         disabled={handleIsDisabled('first')}
         size="sm"
         onClick={() => handleClickIcon('first')}
       />
       <IconButton
-        code="icon-paging-left"
+        icon={ChevronLeft}
         disabled={handleIsDisabled('pre')}
         size="sm"
         onClick={() => handleClickIcon('pre')}
@@ -246,13 +247,13 @@ export default function Pagination(props: IProps) {
         onChange={onInputNumberChange}
       />
       <IconButton
-        code="icon-paging-right"
+        icon={ChevronRight}
         disabled={handleIsDisabled('next')}
         size="sm"
         onClick={() => handleClickIcon('next')}
       />
       <IconButton
-        code="icon-paging-end"
+        icon={ChevronsRight}
         disabled={handleIsDisabled('last')}
         size="sm"
         onClick={() => handleClickIcon('last')}
@@ -266,7 +267,7 @@ export default function Pagination(props: IProps) {
       >
         <div className={styles.selectSize}>
           {paginationConfig?.pageSize ?? 200}
-          <DownOutlined />
+          <ChevronDown size={14} />
         </div>
       </Dropdown>
       {props.onClickTotalBtn ? (

--- a/chat2db-community-client/src/components/SQLEditor/editor/MonacoEditor/ContentDiffViewer.tsx
+++ b/chat2db-community-client/src/components/SQLEditor/editor/MonacoEditor/ContentDiffViewer.tsx
@@ -16,6 +16,10 @@ export interface ContentDiffInlineView {
 }
 
 type DiffLineKind = ContentDiffKind.Deleted | ContentDiffKind.Added;
+type ToolbarIcon = { iconCode: string } | { lucidePath: string };
+
+const LUCIDE_CHEVRON_DOWN_PATH = 'm6 9 6 6 6-6';
+const LUCIDE_CHEVRON_UP_PATH = 'm18 15-6-6-6 6';
 
 export const createContentDiffInlineView = (
   editor: monaco.editor.IStandaloneCodeEditor,
@@ -26,10 +30,26 @@ export const createContentDiffInlineView = (
   const panel = document.createElement('div');
   const toolbar = document.createElement('div');
   const body = document.createElement('div');
-  const revertButton = createToolbarIconButton('content-diff-inline-action', 'icon-huigun', 'Revert this change');
-  const nextButton = createToolbarIconButton('content-diff-inline-action', 'icon-down-arrow', 'Next change');
-  const previousButton = createToolbarIconButton('content-diff-inline-action', 'icon-up-arrow', 'Previous change');
-  const closeButton = createToolbarIconButton('content-diff-inline-close', 'icon-close', 'Close diff');
+  const revertButton = createToolbarIconButton(
+    'content-diff-inline-action',
+    { iconCode: 'icon-huigun' },
+    'Revert this change',
+  );
+  const nextButton = createToolbarIconButton(
+    'content-diff-inline-action',
+    { lucidePath: LUCIDE_CHEVRON_DOWN_PATH },
+    'Next change',
+  );
+  const previousButton = createToolbarIconButton(
+    'content-diff-inline-action',
+    { lucidePath: LUCIDE_CHEVRON_UP_PATH },
+    'Previous change',
+  );
+  const closeButton = createToolbarIconButton(
+    'content-diff-inline-close',
+    { iconCode: 'icon-close' },
+    'Close diff',
+  );
   const lineHeight = editor.getOption(monaco.editor.EditorOption.lineHeight) || 20;
   const heightInPx = Math.min(Math.max(value.heightInLines * lineHeight + 36, 96), 360);
   const panelWidth = getPanelWidth(editor, value);
@@ -128,19 +148,27 @@ export const createContentDiffInlineView = (
   return { dispose };
 };
 
-const createToolbarIconButton = (className: string, iconCode: string, title: string) => {
+const createToolbarIconButton = (className: string, iconDefinition: ToolbarIcon, title: string) => {
   const button = document.createElement('button');
   const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  const use = document.createElementNS('http://www.w3.org/2000/svg', 'use');
 
   button.type = 'button';
   button.className = className;
   button.title = title;
   icon.classList.add('content-diff-inline-action-icon');
   icon.setAttribute('aria-hidden', 'true');
-  use.setAttribute('href', `#${iconCode}`);
-  use.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', `#${iconCode}`);
-  icon.appendChild(use);
+  if ('lucidePath' in iconDefinition) {
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    icon.classList.add('content-diff-inline-action-icon-lucide');
+    icon.setAttribute('viewBox', '0 0 24 24');
+    path.setAttribute('d', iconDefinition.lucidePath);
+    icon.appendChild(path);
+  } else {
+    const use = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+    use.setAttribute('href', `#${iconDefinition.iconCode}`);
+    use.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', `#${iconDefinition.iconCode}`);
+    icon.appendChild(use);
+  }
   button.appendChild(icon);
 
   return button;

--- a/chat2db-community-client/src/components/SQLEditor/editor/MonacoEditor/index.less
+++ b/chat2db-community-client/src/components/SQLEditor/editor/MonacoEditor/index.less
@@ -218,6 +218,14 @@
   fill: currentcolor;
 }
 
+.content-diff-inline-action-icon-lucide {
+  fill: none;
+  stroke: currentcolor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .content-diff-inline-action:hover,
 .content-diff-inline-close:hover {
   color: #fff;

--- a/chat2db-community-client/src/components/SelectBoundInfo/index.tsx
+++ b/chat2db-community-client/src/components/SelectBoundInfo/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, memo, Fragment } from 'react';
+import { ChevronRight } from 'lucide-react';
 import { Dropdown, Input } from 'antd';
 import { useStyles } from './style';
 import { TreeNodeType, databaseMap, DatabaseTypeCode } from '@/constants';
@@ -379,7 +380,7 @@ const DropdownItem = memo((props: DropdownProps) => {
             className={styles.toolbarBtn}
             prefixIcon={currentIcon}
             text={eachOption?.label || `<${eachOption.treeNodeType}>`}
-            suffixIcon={<IconfontSvg size="xs" className={styles.suffixIcon} code="icon-chevron-right" />}
+            suffixIcon={<ChevronRight size={14} className={styles.suffixIcon} />}
           />
         </Dropdown>
       ) : (
@@ -387,7 +388,7 @@ const DropdownItem = memo((props: DropdownProps) => {
           className={styles.toolbarBtn}
           prefixIcon={currentIcon}
           text={eachOption?.label || `<${eachOption.treeNodeType}>`}
-          suffixIcon={<IconfontSvg size="xs" className={styles.suffixIcon} code="icon-chevron-right" />}
+          suffixIcon={<ChevronRight size={14} className={styles.suffixIcon} />}
         />
       )}
     </Fragment>

--- a/chat2db-community-client/src/components/SplitPaneUnpack/index.tsx
+++ b/chat2db-community-client/src/components/SplitPaneUnpack/index.tsx
@@ -1,6 +1,6 @@
-import React, { memo, useMemo, useRef, useEffect, useState } from 'react';
+import React, { memo, useRef, useEffect, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useStyles } from './style';
-import { IconfontSvg } from '@chat2db/ui';
 
 interface IProps {
   className?: string;
@@ -28,9 +28,7 @@ export default memo<IProps>((props) => {
     };
   }, [direction]);
 
-  const iconCode = useMemo(() => {
-    return size === 0 ? 'icon-chevron-up' : 'icon-chevron-bottom';
-  }, [size]);
+  const DirectionIcon = size === 0 ? ChevronUp : ChevronDown;
 
   const handleClick = () => {
     if (size === 0) {
@@ -44,7 +42,7 @@ export default memo<IProps>((props) => {
     <div className={cx(styles.splitPaneUnpack, className)} ref={splitPaneUnpackRef}>
       <div className="operatingHandleBox">
         <div className="operatingHandle" onClick={handleClick}>
-          <IconfontSvg className="operatingHandleIcon" code={iconCode} size="xs" />
+          <DirectionIcon className="operatingHandleIcon" size={14} />
         </div>
       </div>
       {children}

--- a/chat2db-community-client/src/components/Tabs/index.tsx
+++ b/chat2db-community-client/src/components/Tabs/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useEffect, useState, useRef } from 'react';
+import { ChevronDown } from 'lucide-react';
 import Iconfont from '@/components/Iconfont';
 import { IconButton, IconfontSvg } from '@chat2db/ui';
 import { Popover, Dropdown } from 'antd';
@@ -838,7 +839,7 @@ export default memo<IProps>((props) => {
               trigger={['click']}
             >
               <div className={styles.moreTabsButton}>
-                <IconfontSvg code="icon-chevron-bottom" size="xs" />
+                <ChevronDown size={14} />
               </div>
             </Dropdown>
           </div>

--- a/chat2db-community-client/src/i18n/en-US/workspace.ts
+++ b/chat2db-community-client/src/i18n/en-US/workspace.ts
@@ -227,6 +227,7 @@ export default {
   'workspace.localSqlFileTree.newFile': 'New SQL file',
   'workspace.localSqlFileTree.newFolder': 'New folder',
   'workspace.localSqlFileTree.refresh': 'Refresh',
+  'workspace.localSqlFileTree.expandAll': 'Expand all',
   'workspace.localSqlFileTree.collapseAll': 'Collapse all',
   'workspace.localSqlFileTree.moreActions': 'More actions',
   'workspace.localSqlFileTree.open': 'Open',

--- a/chat2db-community-client/src/i18n/es-ES/workspace.ts
+++ b/chat2db-community-client/src/i18n/es-ES/workspace.ts
@@ -227,6 +227,7 @@ export default {
   'workspace.localSqlFileTree.newFile': 'Nuevo archivo SQL',
   'workspace.localSqlFileTree.newFolder': 'Nueva carpeta',
   'workspace.localSqlFileTree.refresh': 'Actualizar',
+  'workspace.localSqlFileTree.expandAll': 'Expandir todo',
   'workspace.localSqlFileTree.collapseAll': 'Contraer todo',
   'workspace.localSqlFileTree.moreActions': 'Más acciones',
   'workspace.localSqlFileTree.open': 'Abrir',

--- a/chat2db-community-client/src/i18n/ja-JP/workspace.ts
+++ b/chat2db-community-client/src/i18n/ja-JP/workspace.ts
@@ -227,6 +227,7 @@ export default {
   'workspace.localSqlFileTree.newFile': 'SQLファイルを新規作成',
   'workspace.localSqlFileTree.newFolder': 'フォルダーを新規作成',
   'workspace.localSqlFileTree.refresh': '更新',
+  'workspace.localSqlFileTree.expandAll': 'すべて展開',
   'workspace.localSqlFileTree.collapseAll': 'すべて折りたたむ',
   'workspace.localSqlFileTree.moreActions': 'その他の操作',
   'workspace.localSqlFileTree.open': '開く',

--- a/chat2db-community-client/src/i18n/ko-KR/workspace.ts
+++ b/chat2db-community-client/src/i18n/ko-KR/workspace.ts
@@ -226,6 +226,7 @@ export default {
   'workspace.localSqlFileTree.newFile': '새 SQL 파일',
   'workspace.localSqlFileTree.newFolder': '새 폴더',
   'workspace.localSqlFileTree.refresh': '새로 고침',
+  'workspace.localSqlFileTree.expandAll': '모두 펼치기',
   'workspace.localSqlFileTree.collapseAll': '모두 접기',
   'workspace.localSqlFileTree.moreActions': '추가 작업',
   'workspace.localSqlFileTree.open': '열기',

--- a/chat2db-community-client/src/i18n/zh-CN/workspace.ts
+++ b/chat2db-community-client/src/i18n/zh-CN/workspace.ts
@@ -221,6 +221,7 @@ export default {
   'workspace.localSqlFileTree.newFile': '新建 SQL 文件',
   'workspace.localSqlFileTree.newFolder': '新建文件夹',
   'workspace.localSqlFileTree.refresh': '刷新',
+  'workspace.localSqlFileTree.expandAll': '全部展开',
   'workspace.localSqlFileTree.collapseAll': '全部折叠',
   'workspace.localSqlFileTree.moreActions': '更多操作',
   'workspace.localSqlFileTree.open': '打开',

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -466,11 +466,11 @@ function CommunityMainPage() {
           <div className={styles.bottomNav}>
             {sidebarExpanded ? (
               <div className={styles.navItem} onClick={() => setSettingPageActiveTab('basic')}>
-                <IconfontSvg code="icon-adjustments" className={styles.navItemIcon} size={20} />
+                <IconfontSvg code="icon-adjustments" className={styles.navItemIcon} size={18} />
                 <span className={styles.navItemLabel}>{i18n('setting.title.setting')}</span>
               </div>
             ) : (
-              <OfflineAvatar />
+              <OfflineAvatar logoSize={18} triggerSize={34} />
             )}
           </div>
         )}

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -470,7 +470,7 @@ function CommunityMainPage() {
                 <span className={styles.navItemLabel}>{i18n('setting.title.setting')}</span>
               </div>
             ) : (
-              <OfflineAvatar logoSize={18} triggerSize={34} />
+              <OfflineAvatar logoSize={24} triggerSize={34} />
             )}
           </div>
         )}

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -433,7 +433,7 @@ function CommunityMainPage() {
                   key={item.key}
                   size={{
                     boxSize: 34,
-                    iconSize: 22,
+                    iconSize: 18,
                   }}
                   title={item.name}
                   icon={NavIcon}
@@ -449,7 +449,7 @@ function CommunityMainPage() {
                 className={cx(styles.navItem, isActive && styles.navItemActive)}
                 onClick={() => handleNavItemClick(item)}
               >
-                <NavIcon className={styles.navItemIcon} size={20} />
+                <NavIcon className={styles.navItemIcon} size={18} />
                 <span className={styles.navItemLabel}>{item.name}</span>
               </div>
             );

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -1,5 +1,6 @@
 import { Confetti, IconButton, IconfontSvg } from '@chat2db/ui';
 import { Tooltip, type InputRef } from 'antd';
+import { Layers, LayoutDashboard, MessagesSquare } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import i18n from '@/i18n';
@@ -40,21 +41,21 @@ function CommunityMainPage() {
     () => [
       {
         key: 'stream',
-        icon: 'icon-chat-alt-21',
+        icon: MessagesSquare,
         isLoad: false,
         component: <Stream />,
         name: i18n('stream.nav.title'),
       },
       {
         key: 'workspace',
-        icon: 'icon-gongxiang-',
+        icon: Layers,
         isLoad: false,
         component: <Workspace />,
         name: i18n('workspace.title'),
       },
       {
         key: 'dashboard',
-        icon: 'icon-chart-square-bar',
+        icon: LayoutDashboard,
         isLoad: false,
         component: <Dashboard />,
         name: i18n('dashboard.title'),
@@ -422,6 +423,7 @@ function CommunityMainPage() {
         <div className={styles.navContainer}>
           {navConfig.map((item) => {
             const isActive = item.key === mainPageActiveTab && settingPageActiveTab === false;
+            const NavIcon = item.icon;
 
             if (!sidebarExpanded) {
               return (
@@ -434,7 +436,7 @@ function CommunityMainPage() {
                     iconSize: 22,
                   }}
                   title={item.name}
-                  code={item.icon}
+                  icon={NavIcon}
                   tooltipPlacement="right"
                   onClick={() => handleNavItemClick(item)}
                 />
@@ -447,7 +449,7 @@ function CommunityMainPage() {
                 className={cx(styles.navItem, isActive && styles.navItemActive)}
                 onClick={() => handleNavItemClick(item)}
               >
-                <IconfontSvg code={item.icon} className={styles.navItemIcon} size={20} />
+                <NavIcon className={styles.navItemIcon} size={20} />
                 <span className={styles.navItemLabel}>{item.name}</span>
               </div>
             );

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -1,6 +1,6 @@
 import { Confetti, IconButton, IconfontSvg } from '@chat2db/ui';
 import { Tooltip, type InputRef } from 'antd';
-import { Layers, LayoutDashboard, MessagesSquare } from 'lucide-react';
+import { createLucideIcon, Layers, MessagesSquare } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import i18n from '@/i18n';
@@ -34,6 +34,16 @@ import { useWorkspaceStore } from '@/store/workspace';
 import { isDesktop, isHashHistoryEnv } from '@/utils/env';
 import { checkIsSharePage } from '@/utils/url';
 
+// Backport the official Lucide icon; the direct 0.356 dependency predates this export.
+const ChartNoAxesCombined = createLucideIcon('ChartNoAxesCombined', [
+  ['path', { d: 'M12 16v5', key: 'zza2cw' }],
+  ['path', { d: 'M16 14v7', key: '1g90b9' }],
+  ['path', { d: 'M20 10v11', key: '1iqoj0' }],
+  ['path', { d: 'm22 3-8.646 8.646a.5.5 0 0 1-.708 0L9.354 8.354a.5.5 0 0 0-.707 0L2 15', key: '1fw8x9' }],
+  ['path', { d: 'M4 18v3', key: '1yp0dc' }],
+  ['path', { d: 'M8 14v7', key: 'n3cwzv' }],
+]);
+
 function CommunityMainPage() {
   const [navConfig, setNavConfig] = useState<INavItem[]>([]);
 
@@ -55,7 +65,7 @@ function CommunityMainPage() {
       },
       {
         key: 'dashboard',
-        icon: LayoutDashboard,
+        icon: ChartNoAxesCombined,
         isLoad: false,
         component: <Dashboard />,
         name: i18n('dashboard.title'),

--- a/chat2db-community-client/src/pages/main/components/StreamSidebar/index.tsx
+++ b/chat2db-community-client/src/pages/main/components/StreamSidebar/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { IconButton, IconfontSvg } from '@chat2db/ui';
 import { Button, Input, Modal, Tooltip, type InputRef } from 'antd';
 import dayjs from 'dayjs';
-import { Search } from 'lucide-react';
+import { MessageSquarePlus, Search } from 'lucide-react';
 
 import PortalContextMenu from '@/components/ContextMenu/PortalContextMenu';
 import type { ContextMenuAction, ContextMenuIntent } from '@/components/ContextMenu/core';
@@ -129,7 +129,7 @@ const StreamSidebar = ({
         <Button
           type="primary"
           className={styles.streamNewChatButton}
-          icon={<IconfontSvg code="icon-new-chat" size={16} />}
+          icon={<MessageSquarePlus size={16} />}
           onClick={onNewChat}
         >
           {i18n('stream.panel.newChat')}

--- a/chat2db-community-client/src/pages/main/knowledgeManagement/components/Terminology/index.tsx
+++ b/chat2db-community-client/src/pages/main/knowledgeManagement/components/Terminology/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useMemo, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { useStyles } from './style';
 import PageTitle from '@/components/PageTitle';
 import i18n from '@/i18n';
@@ -509,7 +510,7 @@ export default memo<IProps>((props) => {
           >
             <Button>
               {i18n('knowledgeManagement.label.batchOperation')}
-              <IconfontSvg size="xs" code="icon-chevron-bottom" />
+              <ChevronDown size={14} />
             </Button>
           </Dropdown>
           <Button type="primary" onClick={handleAdd}>

--- a/chat2db-community-client/src/pages/main/organization/components/CreateOrJoinOrgDialog/index.tsx
+++ b/chat2db-community-client/src/pages/main/organization/components/CreateOrJoinOrgDialog/index.tsx
@@ -1,6 +1,7 @@
 import { Modal, Input, TextArea, ModalProps, IconfontSvg, Empty, EmptyImage } from '@chat2db/ui';
 import { Button, Flex, Form, Select } from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronRight } from 'lucide-react';
 import { useStyles } from './style';
 import domesticCity from '@/data/domestic_city.json';
 import abroadCity from '@/data/abroad_city.json';
@@ -134,7 +135,7 @@ const CreateOrJoinOrgDialog = ({ open }: CreateOrJoinOrgDialogProps) => {
               <div className={styles.initItemDesc}>{i18n('team.create.title.desc')}</div>
             </Flex>
           </Flex>
-          <IconfontSvg className={styles.initItemArrow} code="icon-chevron-right" size="xs" />
+          <ChevronRight className={styles.initItemArrow} size={14} />
         </div>
 
         <div
@@ -152,7 +153,7 @@ const CreateOrJoinOrgDialog = ({ open }: CreateOrJoinOrgDialogProps) => {
               <div className={styles.initItemDesc}>{i18n('team.join.title.desc')}</div>
             </Flex>
           </Flex>
-          <IconfontSvg className={styles.initItemArrow} code="icon-chevron-right" size="xs" />
+          <ChevronRight className={styles.initItemArrow} size={14} />
         </div>
       </Flex>
     );

--- a/chat2db-community-client/src/pages/main/organization/components/OrgSelect/index.tsx
+++ b/chat2db-community-client/src/pages/main/organization/components/OrgSelect/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useOrgStore } from '@/store/organization';
 import { IOrganizationVO, OrganizationType } from '@/typings/enterprise/organization';
 import { Dropdown, Flex } from 'antd';
@@ -28,7 +29,7 @@ const OrgSelect = () => {
           <div className={styles.itemTag}>Free</div>
         </div>
         {!!checked && <div>Y</div>}
-        {isBar && <IconfontSvg code="icon-chevron-bottom" size="xs" />}
+        {isBar && <ChevronDown size={14} />}
       </div>
     );
   };
@@ -53,7 +54,7 @@ const OrgSelect = () => {
             {i18n('setting.nav.createOrgJoinOrg')}
           </Flex>
 
-          <IconfontSvg code="icon-chevron-right" size="xs" />
+          <ChevronRight size={14} />
         </div>
       </div>
     );

--- a/chat2db-community-client/src/pages/main/workspace/components/LocalSQLFileTree/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/LocalSQLFileTree/index.tsx
@@ -105,7 +105,7 @@ const SQL_FILE_EXTENSION = '.sql';
 const LOCAL_SQL_DIRECTORY_PATH_STORAGE_KEY = runtimeEditionConfig.localSqlDirectoryPathStorageKey;
 const LOCAL_SQL_DIRECTORY_PATHS_STORAGE_KEY = runtimeEditionConfig.localSqlDirectoryPathsStorageKey;
 const LOCAL_SQL_TOOLBAR_EXPANDED_MIN_WIDTH = 150;
-const LOCAL_SQL_TOOLBAR_BUTTON_SIZE = 'sm';
+const LOCAL_SQL_TOOLBAR_BUTTON_SIZE = { boxSize: 24, iconSize: 16 };
 const LOCAL_SQL_TREE_BASE_INDENT = 0;
 const LOCAL_SQL_TREE_LEVEL_INDENT = 14;
 

--- a/chat2db-community-client/src/pages/main/workspace/components/LocalSQLFileTree/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/LocalSQLFileTree/index.tsx
@@ -4,12 +4,12 @@ import { useSize } from 'ahooks';
 import { Button, Dropdown, Input, Modal, Tooltip, type InputRef, type MenuProps } from 'antd';
 import {
   ChevronRight,
-  ChevronsUp,
-  FilePlus2,
+  FilePlus,
   Folder,
   FolderInput,
   FolderOpen,
   FolderPlus,
+  ListCollapse,
   MoreHorizontal,
   RefreshCw,
 } from 'lucide-react';
@@ -105,7 +105,7 @@ const SQL_FILE_EXTENSION = '.sql';
 const LOCAL_SQL_DIRECTORY_PATH_STORAGE_KEY = runtimeEditionConfig.localSqlDirectoryPathStorageKey;
 const LOCAL_SQL_DIRECTORY_PATHS_STORAGE_KEY = runtimeEditionConfig.localSqlDirectoryPathsStorageKey;
 const LOCAL_SQL_TOOLBAR_EXPANDED_MIN_WIDTH = 150;
-const LOCAL_SQL_TOOLBAR_BUTTON_SIZE = { boxSize: 18, iconSize: 12 };
+const LOCAL_SQL_TOOLBAR_BUTTON_SIZE = 'sm';
 const LOCAL_SQL_TREE_BASE_INDENT = 0;
 const LOCAL_SQL_TREE_LEVEL_INDENT = 14;
 
@@ -1641,7 +1641,7 @@ const LocalSQLFileTree = forwardRef<LocalSQLFileTreeRef, LocalSQLFileTreeProps>(
     ? i18n('workspace.localSqlFileTree.addFolder')
     : i18n('workspace.localSqlFileTree.openFolder');
   const folderActionLoading = rootNodes.length ? addingRoot : selecting;
-  const folderActionIcon = rootNodes.length ? FolderPlus : FolderInput;
+  const folderActionIcon = rootNodes.length ? FolderInput : FolderOpen;
   const showExpandedToolbar = (headerSize?.width || 0) >= LOCAL_SQL_TOOLBAR_EXPANDED_MIN_WIDTH;
   const toolbarMoreItems: MenuProps['items'] = [
     {
@@ -1692,7 +1692,7 @@ const LocalSQLFileTree = forwardRef<LocalSQLFileTreeRef, LocalSQLFileTreeProps>(
               size={LOCAL_SQL_TOOLBAR_BUTTON_SIZE}
               disabled={toolbarDisabled}
               onClick={() => startCreate('file')}
-              icon={FilePlus2}
+              icon={FilePlus}
             />
             <IconButton
               title={i18n('workspace.localSqlFileTree.refresh')}
@@ -1709,14 +1709,14 @@ const LocalSQLFileTree = forwardRef<LocalSQLFileTreeRef, LocalSQLFileTreeProps>(
                   size={LOCAL_SQL_TOOLBAR_BUTTON_SIZE}
                   disabled={toolbarDisabled}
                   onClick={() => startCreate('directory')}
-                  icon={FolderOpen}
+                  icon={FolderPlus}
                 />
                 <IconButton
                   title={i18n('workspace.localSqlFileTree.collapseAll')}
                   size={LOCAL_SQL_TOOLBAR_BUTTON_SIZE}
                   disabled={!rootNodes.length}
                   onClick={collapseAll}
-                  icon={ChevronsUp}
+                  icon={ListCollapse}
                 />
               </>
             ) : (

--- a/chat2db-community-client/src/pages/main/workspace/components/LocalSQLFileTree/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/LocalSQLFileTree/index.tsx
@@ -4,12 +4,13 @@ import { useSize } from 'ahooks';
 import { Button, Dropdown, Input, Modal, Tooltip, type InputRef, type MenuProps } from 'antd';
 import {
   ChevronRight,
+  ChevronsDownUp,
+  ChevronsUpDown,
   FilePlus,
   Folder,
   FolderInput,
   FolderOpen,
   FolderPlus,
-  ListCollapse,
   MoreHorizontal,
   RefreshCw,
 } from 'lucide-react';
@@ -295,6 +296,20 @@ function findTreeNodeWithAncestors(
   return undefined;
 }
 
+function getExpandableDirectoryKeys(nodes: LocalSQLFileTreeNode[]) {
+  const keys: string[] = [];
+
+  nodes.forEach((node) => {
+    if (node.type !== 'directory' || !node.children?.length) {
+      return;
+    }
+    keys.push(node.key);
+    keys.push(...getExpandableDirectoryKeys(node.children));
+  });
+
+  return keys;
+}
+
 function getDefaultCreateName(parent: LocalSQLFileTreeNode, type: LocalSQLFileTreeCreateType) {
   const childNames = new Set((parent.children || []).map((child) => child.name.toLowerCase()));
   const baseName = type === 'file' ? 'untitled' : 'New Folder';
@@ -353,6 +368,8 @@ const LocalSQLFileTree = forwardRef<LocalSQLFileTreeRef, LocalSQLFileTreeProps>(
     }
     return findTreeNode(rootNodes, (node) => node.key === selectedNodeKey);
   }, [rootNodes, selectedNodeKey]);
+  const expandableDirectoryKeys = useMemo(() => getExpandableDirectoryKeys(rootNodes), [rootNodes]);
+  const shouldExpandAll = expandableDirectoryKeys.some((key) => !expandedKeys.includes(key));
 
   const contextMenuNode = contextMenu
     ? findTreeNode(rootNodes, (node) => node.key === contextMenu.targetSnapshot.nodeKey)?.node
@@ -1443,10 +1460,12 @@ const LocalSQLFileTree = forwardRef<LocalSQLFileTreeRef, LocalSQLFileTreeProps>(
         execute: () => refreshDirectory(node),
       }),
       createContextMenuAction({
-        id: 'collapseAll',
-        label: i18n('workspace.localSqlFileTree.collapseAll'),
-        shortcutAction: ShortcutAction.LocalSqlFileTreeCollapseAll,
-        execute: collapseAll,
+        id: shouldExpandAll ? 'expandAll' : 'collapseAll',
+        label: i18n(
+          shouldExpandAll ? 'workspace.localSqlFileTree.expandAll' : 'workspace.localSqlFileTree.collapseAll',
+        ),
+        shortcutAction: shouldExpandAll ? undefined : ShortcutAction.LocalSqlFileTreeCollapseAll,
+        execute: shouldExpandAll ? expandAll : collapseAll,
       }),
       ...mutationItems,
     ];
@@ -1635,6 +1654,14 @@ const LocalSQLFileTree = forwardRef<LocalSQLFileTreeRef, LocalSQLFileTreeProps>(
     setSelectedNodeKey(rootNodes[0].key);
   }
 
+  function expandAll() {
+    if (!expandableDirectoryKeys.length) {
+      return;
+    }
+    setCreatingNode(null);
+    setExpandedKeys((keys) => Array.from(new Set([...keys, ...expandableDirectoryKeys])));
+  }
+
   const toolbarDisabled = !rootNodes.length || !!creatingNode || !!renamingNode;
   const folderActionMode = rootNodes.length ? 'add' : 'replace';
   const folderActionTitle = rootNodes.length
@@ -1651,10 +1678,12 @@ const LocalSQLFileTree = forwardRef<LocalSQLFileTreeRef, LocalSQLFileTreeProps>(
       onClick: () => startCreate('directory'),
     },
     {
-      key: 'collapseAll',
-      label: i18n('workspace.localSqlFileTree.collapseAll'),
+      key: shouldExpandAll ? 'expandAll' : 'collapseAll',
+      label: i18n(
+        shouldExpandAll ? 'workspace.localSqlFileTree.expandAll' : 'workspace.localSqlFileTree.collapseAll',
+      ),
       disabled: !rootNodes.length,
-      onClick: collapseAll,
+      onClick: shouldExpandAll ? expandAll : collapseAll,
     },
   ];
 
@@ -1712,11 +1741,15 @@ const LocalSQLFileTree = forwardRef<LocalSQLFileTreeRef, LocalSQLFileTreeProps>(
                   icon={FolderPlus}
                 />
                 <IconButton
-                  title={i18n('workspace.localSqlFileTree.collapseAll')}
+                  title={i18n(
+                    shouldExpandAll
+                      ? 'workspace.localSqlFileTree.expandAll'
+                      : 'workspace.localSqlFileTree.collapseAll',
+                  )}
                   size={LOCAL_SQL_TOOLBAR_BUTTON_SIZE}
                   disabled={!rootNodes.length}
-                  onClick={collapseAll}
-                  icon={ListCollapse}
+                  onClick={shouldExpandAll ? expandAll : collapseAll}
+                  icon={shouldExpandAll ? ChevronsUpDown : ChevronsDownUp}
                 />
               </>
             ) : (

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceRightEmpty/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceRightEmpty/index.tsx
@@ -1,4 +1,5 @@
 import { memo, Fragment } from 'react';
+import { ChevronRight } from 'lucide-react';
 import { Button } from 'antd';
 import i18n from '@/i18n';
 import { useStyles } from './style';
@@ -95,7 +96,7 @@ export default memo<IProps>((props) => {
           </div>
           <Button type="primary" className={styles.aiCta} onClick={handleGoToAI}>
             {i18n('stream.intro.cta')}
-            <IconfontSvg className={styles.aiCtaArrow} code="icon-right-arrow" size={14} />
+            <ChevronRight className={styles.aiCtaArrow} size={14} />
           </Button>
           <button className={styles.dismissBtn} onClick={handleDismiss}>
             {i18n('stream.intro.dismiss')}


### PR DESCRIPTION
<!--
Thank you for contributing to Chat2DB.

PR title: type(scope): concise summary
Keep every section below. Use N/A when a section does not apply.
Do not include credentials, private URLs, production data, or generated build output.
-->

## Related issue

Closes #2248

<!-- Link the approved Issue that defines the problem or requirement. -->

## Summary

Replace mixed legacy iconfont and Ant Design glyphs with Lucide icons across affected Community navigation, chat, MySQL account tree, pagination, directional controls, and local SQL file surfaces. Dashboard uses `ChartNoAxesCombined`, created from Lucide official node data through `createLucideIcon` because the current direct `lucide-react@0.356.0` dependency predates its named export. Main-navigation glyphs use 18px sizing; file-toolbar actions keep stable 24px boxes with 16px glyphs; and the collapsed Community settings trigger centers its existing 24px Logo in the same 34px target as navigation.

Project-owned directional actions now use Lucide chevrons, including paired chevrons for pagination boundaries. The local-file tree uses one state-aware action: `ChevronsUpDown` expands directory nodes already loaded in the frontend, while `ChevronsDownUp` collapses the tree. It does not recursively fetch unopened directories. Community Web continues to hide the desktop-only Files capability.

## Affected surfaces

<!-- Check every surface affected by this PR. -->

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

<!--
Provide exact commands and their results, plus any manual verification.
For UI changes, attach before/after screenshots or a short recording.
-->

- Commands and results:
  - `yarn install --frozen-lockfile` - passed; lockfile unchanged.
  - Targeted ESLint for all 17 changed TSX files in the directional-icon follow-up - passed.
  - Targeted ESLint for the `CommunityMainPage` Dashboard follow-up - passed.
  - `yarn test:i18n` - passed after updating Spanish and Korean translations and their English source hashes.
  - `yarn run lint` - passed; ESLint and Stylelint completed with zero warnings.
  - `yarn run build:web:community --app_version=0.0.0` - passed; related frontend tests passed and Webpack compiled successfully.
  - `git diff --check` - passed.
- Manual verification: Served the runtime code from an isolated Community Web preview on the final runtime commit; `/workspace` returned HTTP 200 and Webpack hot compilation completed. The final follow-up commit changes only i18n source hashes. Automated browser inspection was unavailable, so final visual review remains manual.
- UI evidence: N/A - screenshots were used during local iteration but are not included in the repository.

## Risk and compatibility

<!-- Describe only the applicable risks. Use N/A with a short reason for the rest. -->

- Public API or stored data: N/A - no API, schema, or persisted-data changes.
- Database or driver compatibility: N/A - no database plugin or driver behavior changes.
- Network, privacy, or security: N/A - presentation and local frontend state changes only.
- Community / Local / Pro boundary: The local-file tree remains backed by Desktop JCEF and the standard Community Web build still hides Files. Expand all only updates keys for directory nodes already present in frontend state.
- Backward compatibility: Existing navigation keys, action boxes, disabled states, and click handlers are preserved. The file-tree action intentionally adds loaded-node expand-all behavior while retaining collapse-all and its existing shortcut.

## Reviewer map

<!-- Point reviewers to the load-bearing change and provide an operational handoff. -->

- Start here: `chat2db-community-client/src/pages/main/workspace/components/LocalSQLFileTree/index.tsx` for the state-aware expand/collapse action, `src/components/Pagination/index.tsx` for boundary navigation, `src/components/SQLEditor/editor/MonacoEditor/ContentDiffViewer.tsx` for imperative Lucide SVG rendering, and `src/pages/main/CommunityMainPage.tsx` for the Dashboard icon mapping and navigation/settings sizing.
- Failure condition: Any icon renders blank, points in the wrong direction, changes control dimensions, causes compact controls to overflow, recursively loads unopened file directories, or changes another runtime's settings Logo size.
- Rollback or disable path: Revert the commits in this PR to restore the prior iconfont and sizing behavior.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used to inspect the affected frontend paths, select and apply Lucide icon mappings, implement the loaded-node expand/collapse state, refine icon sizing, run verification, and prepare the Issue and PR. The resulting diff and runtime boundary were reviewed locally.
