### PR TITLE
fix(diff): repair MySQL functional index SQL

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLog.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLog.java
@@ -11,6 +11,7 @@ import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.DiffToChangeLog;
 
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -18,8 +19,8 @@ import java.util.regex.Pattern;
  */
 final class Chat2dbDiffToChangeLog extends DiffToChangeLog {
 
-    private static final Pattern MYSQL_ESCAPED_CHARSET_LITERAL =
-            Pattern.compile("(?i)(_[a-z0-9]+)\\\\'([^'\\\\\\r\\n]*)\\\\'");
+    private static final Pattern MYSQL_ESCAPED_CHARSET_LITERAL_START =
+            Pattern.compile("(?i)(_[a-z0-9]+)\\\\'");
 
     private final Database targetDatabase;
 
@@ -51,7 +52,7 @@ final class Chat2dbDiffToChangeLog extends DiffToChangeLog {
     private static void normalizeComputedColumns(CreateIndexChange createIndexChange) {
         for (AddColumnConfig column : createIndexChange.getColumns()) {
             if (Boolean.TRUE.equals(column.getComputed()) && column.getName() != null) {
-                String expression = MYSQL_ESCAPED_CHARSET_LITERAL.matcher(column.getName()).replaceAll("$1'$2'");
+                String expression = normalizeCharsetLiterals(column.getName());
                 String trimmedExpression = expression.trim();
                 // Liquibase uses the name verbatim, while MySQL requires an extra pair around expression key parts.
                 if (!trimmedExpression.isEmpty()
@@ -61,5 +62,46 @@ final class Chat2dbDiffToChangeLog extends DiffToChangeLog {
                 column.setName(expression);
             }
         }
+    }
+
+    private static String normalizeCharsetLiterals(String expression) {
+        Matcher matcher = MYSQL_ESCAPED_CHARSET_LITERAL_START.matcher(expression);
+        StringBuilder normalized = new StringBuilder(expression.length());
+        int cursor = 0;
+        while (matcher.find(cursor)) {
+            normalized.append(expression, cursor, matcher.start());
+
+            StringBuilder body = new StringBuilder();
+            int metadataCursor = matcher.end();
+            boolean closed = false;
+            while (metadataCursor < expression.length()) {
+                char decoded = expression.charAt(metadataCursor++);
+                if (decoded == '\\' && metadataCursor < expression.length()) {
+                    decoded = expression.charAt(metadataCursor++);
+                }
+                if (decoded == '\'' && !hasOddTrailingBackslashes(body)) {
+                    normalized.append(matcher.group(1)).append('\'').append(body).append('\'');
+                    cursor = metadataCursor;
+                    closed = true;
+                    break;
+                }
+                body.append(decoded);
+            }
+
+            if (!closed) {
+                normalized.append(expression, matcher.start(), expression.length());
+                return normalized.toString();
+            }
+        }
+        normalized.append(expression, cursor, expression.length());
+        return normalized.toString();
+    }
+
+    private static boolean hasOddTrailingBackslashes(StringBuilder value) {
+        int count = 0;
+        for (int i = value.length() - 1; i >= 0 && value.charAt(i) == '\\'; i--) {
+            count++;
+        }
+        return count % 2 != 0;
     }
 }

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLog.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLog.java
@@ -1,0 +1,65 @@
+package ai.chat2db.community.domain.core.impl.db;
+
+import liquibase.change.AddColumnConfig;
+import liquibase.change.Change;
+import liquibase.change.core.CreateIndexChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.Database;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.diff.DiffResult;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.DiffToChangeLog;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Repairs MySQL computed index metadata before Liquibase serializes the changelog.
+ */
+final class Chat2dbDiffToChangeLog extends DiffToChangeLog {
+
+    private static final Pattern MYSQL_ESCAPED_CHARSET_LITERAL =
+            Pattern.compile("(?i)(_[a-z0-9]+)\\\\'([^'\\\\\\r\\n]*)\\\\'");
+
+    private final Database targetDatabase;
+
+    Chat2dbDiffToChangeLog(DiffResult diffResult, DiffOutputControl diffOutputControl) {
+        super(diffResult, diffOutputControl);
+        this.targetDatabase = diffResult.getComparisonSnapshot().getDatabase();
+    }
+
+    @Override
+    public List<ChangeSet> generateChangeSets() {
+        List<ChangeSet> changeSets = super.generateChangeSets();
+        repairMySqlComputedIndexExpressions(changeSets, targetDatabase);
+        return changeSets;
+    }
+
+    static void repairMySqlComputedIndexExpressions(List<ChangeSet> changeSets, Database targetDatabase) {
+        if (!(targetDatabase instanceof MySQLDatabase)) {
+            return;
+        }
+        for (ChangeSet changeSet : changeSets) {
+            for (Change change : changeSet.getChanges()) {
+                if (change instanceof CreateIndexChange createIndexChange) {
+                    normalizeComputedColumns(createIndexChange);
+                }
+            }
+        }
+    }
+
+    private static void normalizeComputedColumns(CreateIndexChange createIndexChange) {
+        for (AddColumnConfig column : createIndexChange.getColumns()) {
+            if (Boolean.TRUE.equals(column.getComputed()) && column.getName() != null) {
+                String expression = MYSQL_ESCAPED_CHARSET_LITERAL.matcher(column.getName()).replaceAll("$1'$2'");
+                String trimmedExpression = expression.trim();
+                // Liquibase uses the name verbatim, while MySQL requires an extra pair around expression key parts.
+                if (!trimmedExpression.isEmpty()
+                        && !(trimmedExpression.startsWith("(") && trimmedExpression.endsWith(")"))) {
+                    expression = "(" + trimmedExpression + ")";
+                }
+                column.setName(expression);
+            }
+        }
+    }
+}

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLog.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLog.java
@@ -1,107 +1,34 @@
 package ai.chat2db.community.domain.core.impl.db;
 
-import liquibase.change.AddColumnConfig;
-import liquibase.change.Change;
-import liquibase.change.core.CreateIndexChange;
+import ai.chat2db.spi.IDbDiffChangeSetProcessor;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
-import liquibase.database.core.MySQLDatabase;
 import liquibase.diff.DiffResult;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.DiffToChangeLog;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Objects;
 
 /**
- * Repairs MySQL computed index metadata before Liquibase serializes the changelog.
+ * Applies the target database plugin hook before Liquibase serializes the changelog.
  */
 final class Chat2dbDiffToChangeLog extends DiffToChangeLog {
 
-    private static final Pattern MYSQL_ESCAPED_CHARSET_LITERAL_START =
-            Pattern.compile("(?i)(_[a-z0-9]+)\\\\'");
-
     private final Database targetDatabase;
+    private final IDbDiffChangeSetProcessor changeSetProcessor;
 
-    Chat2dbDiffToChangeLog(DiffResult diffResult, DiffOutputControl diffOutputControl) {
+    Chat2dbDiffToChangeLog(DiffResult diffResult, DiffOutputControl diffOutputControl,
+            IDbDiffChangeSetProcessor changeSetProcessor) {
         super(diffResult, diffOutputControl);
         this.targetDatabase = diffResult.getComparisonSnapshot().getDatabase();
+        this.changeSetProcessor = Objects.requireNonNull(changeSetProcessor, "changeSetProcessor");
     }
 
     @Override
     public List<ChangeSet> generateChangeSets() {
         List<ChangeSet> changeSets = super.generateChangeSets();
-        repairMySqlComputedIndexExpressions(changeSets, targetDatabase);
+        changeSetProcessor.process(changeSets, targetDatabase);
         return changeSets;
-    }
-
-    static void repairMySqlComputedIndexExpressions(List<ChangeSet> changeSets, Database targetDatabase) {
-        if (!(targetDatabase instanceof MySQLDatabase)) {
-            return;
-        }
-        for (ChangeSet changeSet : changeSets) {
-            for (Change change : changeSet.getChanges()) {
-                if (change instanceof CreateIndexChange createIndexChange) {
-                    normalizeComputedColumns(createIndexChange);
-                }
-            }
-        }
-    }
-
-    private static void normalizeComputedColumns(CreateIndexChange createIndexChange) {
-        for (AddColumnConfig column : createIndexChange.getColumns()) {
-            if (Boolean.TRUE.equals(column.getComputed()) && column.getName() != null) {
-                String expression = normalizeCharsetLiterals(column.getName());
-                String trimmedExpression = expression.trim();
-                // Liquibase uses the name verbatim, while MySQL requires an extra pair around expression key parts.
-                if (!trimmedExpression.isEmpty()
-                        && !(trimmedExpression.startsWith("(") && trimmedExpression.endsWith(")"))) {
-                    expression = "(" + trimmedExpression + ")";
-                }
-                column.setName(expression);
-            }
-        }
-    }
-
-    private static String normalizeCharsetLiterals(String expression) {
-        Matcher matcher = MYSQL_ESCAPED_CHARSET_LITERAL_START.matcher(expression);
-        StringBuilder normalized = new StringBuilder(expression.length());
-        int cursor = 0;
-        while (matcher.find(cursor)) {
-            normalized.append(expression, cursor, matcher.start());
-
-            StringBuilder body = new StringBuilder();
-            int metadataCursor = matcher.end();
-            boolean closed = false;
-            while (metadataCursor < expression.length()) {
-                char decoded = expression.charAt(metadataCursor++);
-                if (decoded == '\\' && metadataCursor < expression.length()) {
-                    decoded = expression.charAt(metadataCursor++);
-                }
-                if (decoded == '\'' && !hasOddTrailingBackslashes(body)) {
-                    normalized.append(matcher.group(1)).append('\'').append(body).append('\'');
-                    cursor = metadataCursor;
-                    closed = true;
-                    break;
-                }
-                body.append(decoded);
-            }
-
-            if (!closed) {
-                normalized.append(expression, matcher.start(), expression.length());
-                return normalized.toString();
-            }
-        }
-        normalized.append(expression, cursor, expression.length());
-        return normalized.toString();
-    }
-
-    private static boolean hasOddTrailingBackslashes(StringBuilder value) {
-        int count = 0;
-        for (int i = value.length() - 1; i >= 0 && value.charAt(i) == '\\'; i--) {
-            count++;
-        }
-        return count % 2 != 0;
     }
 }

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbDiffServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbDiffServiceImpl.java
@@ -9,6 +9,7 @@ import ai.chat2db.community.domain.core.converter.ConnectionContextConverter;
 import ai.chat2db.community.tools.exception.BusinessException;
 import ai.chat2db.community.tools.util.ConfigUtils;
 import ai.chat2db.spi.model.datasource.ConnectInfo;
+import ai.chat2db.spi.sql.Chat2DBContext;
 import ai.chat2db.spi.sql.ConnectionPool;
 import ai.chat2db.spi.util.JdbcUtils;
 import ai.chat2db.spi.util.SqlUtils;
@@ -76,7 +77,7 @@ public class DbDiffServiceImpl implements IDbDiffService {
             DiffResult diffResult = generateDiff(sourceDatabase, targetDatabase);
 
             String path = filePath + File.separator + DIFF_FILE;
-            generateChangeLog(diffResult, path);
+            generateChangeLog(diffResult, path, target.getDbType());
 
             if (!FileUtil.exist(path)) {
                 return "-- No differences. ";
@@ -133,13 +134,15 @@ public class DbDiffServiceImpl implements IDbDiffService {
     }
 
 
-    private void generateChangeLog(DiffResult diffResult, String diffFilePath) throws DatabaseException, IOException, ParserConfigurationException {
+    private void generateChangeLog(DiffResult diffResult, String diffFilePath, String targetDbType)
+            throws DatabaseException, IOException, ParserConfigurationException {
         DiffOutputControl diffOutputControl = new DiffOutputControl();
         diffOutputControl.setIncludeCatalog(false);
         diffOutputControl.setIncludeSchema(false);
         diffOutputControl.setIncludeTablespace(false);
 
-        Chat2dbDiffToChangeLog diffToChangeLog = new Chat2dbDiffToChangeLog(diffResult, diffOutputControl);
+        Chat2dbDiffToChangeLog diffToChangeLog = new Chat2dbDiffToChangeLog(
+                diffResult, diffOutputControl, Chat2DBContext.getDiffChangeSetProcessor(targetDbType));
         diffToChangeLog.setChangeSetAuthor("Chat2DB client");
         diffToChangeLog.print(diffFilePath);
     }

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbDiffServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbDiffServiceImpl.java
@@ -27,7 +27,6 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.diff.DiffResult;
 import liquibase.diff.compare.CompareControl;
 import liquibase.diff.output.DiffOutputControl;
-import liquibase.diff.output.changelog.DiffToChangeLog;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.FileSystemResourceAccessor;
@@ -140,7 +139,7 @@ public class DbDiffServiceImpl implements IDbDiffService {
         diffOutputControl.setIncludeSchema(false);
         diffOutputControl.setIncludeTablespace(false);
 
-        DiffToChangeLog diffToChangeLog = new DiffToChangeLog(diffResult, diffOutputControl);
+        Chat2dbDiffToChangeLog diffToChangeLog = new Chat2dbDiffToChangeLog(diffResult, diffOutputControl);
         diffToChangeLog.setChangeSetAuthor("Chat2DB client");
         diffToChangeLog.print(diffFilePath);
     }

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLogTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLogTest.java
@@ -1,165 +1,43 @@
 package ai.chat2db.community.domain.core.impl.db;
 
-import ai.chat2db.spi.util.SqlUtils;
-import com.alibaba.druid.DbType;
-import liquibase.change.AddColumnConfig;
-import liquibase.change.Change;
-import liquibase.change.core.CreateIndexChange;
-import liquibase.change.core.RawSQLChange;
 import liquibase.changelog.ChangeSet;
-import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
 import liquibase.database.core.H2Database;
-import liquibase.database.core.MySQLDatabase;
-import liquibase.serializer.core.xml.XMLChangeLogSerializer;
-import liquibase.sqlgenerator.SqlGeneratorFactory;
+import liquibase.diff.DiffResult;
+import liquibase.diff.compare.CompareControl;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.snapshot.EmptyDatabaseSnapshot;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class Chat2dbDiffToChangeLogTest {
 
     @Test
-    void normalizesScalarAndMultiValuedMysqlIndexExpressions() {
-        CreateIndexChange createIndex = createIndex(
-                computed("cast(json_extract(`payload`,_utf8mb4\\'$.provinceId\\') as unsigned)"),
-                computed("cast(json_extract(`region_ids`,_latin1\\'$[*]\\') as unsigned array)"),
-                computed("lower(`name`)"),
-                computed("(json_extract(`payload`,_utf8mb4'$.alreadyValid'))"));
+    void delegatesGeneratedChangeSetsToTargetPluginProcessor() throws Exception {
+        Database sourceDatabase = new H2Database();
+        Database targetDatabase = new H2Database();
+        DiffResult diffResult = new DiffResult(
+                new EmptyDatabaseSnapshot(sourceDatabase),
+                new EmptyDatabaseSnapshot(targetDatabase),
+                new CompareControl());
+        AtomicReference<List<ChangeSet>> processedChangeSets = new AtomicReference<>();
+        AtomicReference<Database> processedDatabase = new AtomicReference<>();
 
-        List<ChangeSet> changeSets = List.of(changeSet(createIndex));
-        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(changeSets, new MySQLDatabase());
-        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(changeSets, new MySQLDatabase());
+        Chat2dbDiffToChangeLog diffToChangeLog = new Chat2dbDiffToChangeLog(
+                diffResult,
+                new DiffOutputControl(),
+                (changeSets, database) -> {
+                    processedChangeSets.set(changeSets);
+                    processedDatabase.set(database);
+                });
 
-        assertEquals("(cast(json_extract(`payload`,_utf8mb4'$.provinceId') as unsigned))",
-                createIndex.getColumns().get(0).getName());
-        assertEquals("(cast(json_extract(`region_ids`,_latin1'$[*]') as unsigned array))",
-                createIndex.getColumns().get(1).getName());
-        assertEquals("(lower(`name`))", createIndex.getColumns().get(2).getName());
-        assertEquals("(json_extract(`payload`,_utf8mb4'$.alreadyValid'))",
-                createIndex.getColumns().get(3).getName());
-    }
+        List<ChangeSet> generatedChangeSets = diffToChangeLog.generateChangeSets();
 
-    @Test
-    void preservesEscapesInsideCharsetIntroducedLiterals() {
-        String apostrophePath = "cast(json_extract(`payload`,_latin1\\'$.\"a"
-                + "\\".repeat(3) + "'b\"\\') as unsigned)";
-        String backslashPath = "cast(json_extract(`payload`,_latin1\\'$.\"a"
-                + "\\".repeat(8) + "b\"\\') as unsigned)";
-        String trailingBackslashLiteral = "concat(_latin1\\'value"
-                + "\\".repeat(5) + "')";
-        CreateIndexChange createIndex = createIndex(
-                computed(apostrophePath),
-                computed(backslashPath),
-                computed(trailingBackslashLiteral));
-
-        List<ChangeSet> changeSets = List.of(changeSet(createIndex));
-        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(changeSets, new MySQLDatabase());
-        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(changeSets, new MySQLDatabase());
-
-        assertEquals("(cast(json_extract(`payload`,_latin1'$.\"a\\'b\"') as unsigned))",
-                createIndex.getColumns().get(0).getName());
-        assertEquals("(cast(json_extract(`payload`,_latin1'$.\"a"
-                        + "\\".repeat(4) + "b\"') as unsigned))",
-                createIndex.getColumns().get(1).getName());
-        assertEquals("(concat(_latin1'value" + "\\".repeat(2) + "'))",
-                createIndex.getColumns().get(2).getName());
-
-        MySQLDatabase database = new MySQLDatabase();
-        String apostropheSql = SqlGeneratorFactory.getInstance()
-                .generateSql(createIndex, database)[0].toSql();
-        assertTrue(apostropheSql.contains("_latin1'$.\"a\\'b\"'"));
-        assertTrue(apostropheSql.contains("_latin1'$.\"a" + "\\".repeat(4) + "b\"'"));
-        assertTrue(apostropheSql.contains("_latin1'value" + "\\".repeat(2) + "'"));
-        assertDoesNotThrow(() -> SqlUtils.parse(apostropheSql, DbType.mysql, true));
-    }
-
-    @Test
-    void leavesOrdinaryColumnsRawSqlAndNonMysqlChangesUntouched() {
-        AddColumnConfig ordinaryColumn = column("_utf8mb4\\'notAnExpression\\'", false);
-        CreateIndexChange mysqlIndex = createIndex(ordinaryColumn);
-        RawSQLChange rawSql = new RawSQLChange("select _utf8mb4\\'ordinarySql\\'");
-
-        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(
-                List.of(changeSet(mysqlIndex, rawSql)), new MySQLDatabase());
-
-        assertEquals("_utf8mb4\\'notAnExpression\\'", ordinaryColumn.getName());
-        assertEquals("select _utf8mb4\\'ordinarySql\\'", rawSql.getSql());
-
-        AddColumnConfig h2ComputedColumn = computed("_utf8mb4\\'$.regionId\\'");
-        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(
-                List.of(changeSet(createIndex(h2ComputedColumn))), new H2Database());
-
-        assertEquals("_utf8mb4\\'$.regionId\\'", h2ComputedColumn.getName());
-    }
-
-    @Test
-    void serializesValidXmlAndProducesSqlThatDruidCanParse() throws Exception {
-        AddColumnConfig column = computed(
-                "cast(json_extract(`payload`,_utf8mb4\\'$.provinceId\\') as unsigned)");
-        ChangeSet changeSet = changeSet(createIndex(column));
-
-        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(
-                List.of(changeSet), new MySQLDatabase());
-
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        new XMLChangeLogSerializer().write(List.of(changeSet), new PrintStream(output, true, StandardCharsets.UTF_8));
-        String xml = output.toString(StandardCharsets.UTF_8);
-
-        assertTrue(xml.contains("(cast(json_extract(`payload`,_utf8mb4'$.provinceId') as unsigned))"));
-        assertFalse(xml.contains("_utf8mb4\\'$.provinceId\\'"));
-
-        MySQLDatabase database = new MySQLDatabase();
-        String sql = SqlGeneratorFactory.getInstance()
-                .generateSql(changeSet.getChanges().get(0), database)[0].toSql();
-        assertTrue(sql.contains("((cast(json_extract(`payload`,_utf8mb4'$.provinceId') as unsigned)))"));
-        assertDoesNotThrow(() -> SqlUtils.parse(sql, DbType.mysql, true));
-
-        CreateIndexChange multiValuedIndex = createIndex(
-                computed("cast(json_extract(`region_ids`,_latin1\\'$[*]\\') as unsigned array)"));
-        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(
-                List.of(changeSet(multiValuedIndex)), database);
-        String multiValuedSql = SqlGeneratorFactory.getInstance()
-                .generateSql(multiValuedIndex, database)[0].toSql();
-        assertTrue(multiValuedSql.contains(
-                "((cast(json_extract(`region_ids`,_latin1'$[*]') as unsigned array)))"));
-        assertDoesNotThrow(() -> SqlUtils.parse(multiValuedSql, DbType.mysql, true));
-    }
-
-    private static AddColumnConfig computed(String expression) {
-        return column(expression, true);
-    }
-
-    private static AddColumnConfig column(String name, boolean computed) {
-        AddColumnConfig column = new AddColumnConfig();
-        column.setName(name);
-        column.setComputed(computed);
-        return column;
-    }
-
-    private static CreateIndexChange createIndex(AddColumnConfig... columns) {
-        CreateIndexChange createIndex = new CreateIndexChange();
-        createIndex.setIndexName("idx_payload_region");
-        createIndex.setTableName("sample_config");
-        for (AddColumnConfig column : columns) {
-            createIndex.addColumn(column);
-        }
-        return createIndex;
-    }
-
-    private static ChangeSet changeSet(Change... changes) {
-        ChangeSet changeSet = new ChangeSet("1", "test", false, false,
-                "test.xml", null, null, new DatabaseChangeLog());
-        for (Change change : changes) {
-            changeSet.addChange(change);
-        }
-        return changeSet;
+        assertSame(generatedChangeSets, processedChangeSets.get());
+        assertSame(targetDatabase, processedDatabase.get());
     }
 }

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLogTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLogTest.java
@@ -1,0 +1,131 @@
+package ai.chat2db.community.domain.core.impl.db;
+
+import ai.chat2db.spi.util.SqlUtils;
+import com.alibaba.druid.DbType;
+import liquibase.change.AddColumnConfig;
+import liquibase.change.Change;
+import liquibase.change.core.CreateIndexChange;
+import liquibase.change.core.RawSQLChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.core.H2Database;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.serializer.core.xml.XMLChangeLogSerializer;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Chat2dbDiffToChangeLogTest {
+
+    @Test
+    void normalizesScalarAndMultiValuedMysqlIndexExpressions() {
+        CreateIndexChange createIndex = createIndex(
+                computed("cast(json_extract(`payload`,_utf8mb4\\'$.provinceId\\') as unsigned)"),
+                computed("cast(json_extract(`region_ids`,_latin1\\'$[*]\\') as unsigned array)"),
+                computed("lower(`name`)"),
+                computed("(json_extract(`payload`,_utf8mb4'$.alreadyValid'))"));
+
+        List<ChangeSet> changeSets = List.of(changeSet(createIndex));
+        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(changeSets, new MySQLDatabase());
+        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(changeSets, new MySQLDatabase());
+
+        assertEquals("(cast(json_extract(`payload`,_utf8mb4'$.provinceId') as unsigned))",
+                createIndex.getColumns().get(0).getName());
+        assertEquals("(cast(json_extract(`region_ids`,_latin1'$[*]') as unsigned array))",
+                createIndex.getColumns().get(1).getName());
+        assertEquals("(lower(`name`))", createIndex.getColumns().get(2).getName());
+        assertEquals("(json_extract(`payload`,_utf8mb4'$.alreadyValid'))",
+                createIndex.getColumns().get(3).getName());
+    }
+
+    @Test
+    void leavesOrdinaryColumnsRawSqlAndNonMysqlChangesUntouched() {
+        AddColumnConfig ordinaryColumn = column("_utf8mb4\\'notAnExpression\\'", false);
+        CreateIndexChange mysqlIndex = createIndex(ordinaryColumn);
+        RawSQLChange rawSql = new RawSQLChange("select _utf8mb4\\'ordinarySql\\'");
+
+        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(
+                List.of(changeSet(mysqlIndex, rawSql)), new MySQLDatabase());
+
+        assertEquals("_utf8mb4\\'notAnExpression\\'", ordinaryColumn.getName());
+        assertEquals("select _utf8mb4\\'ordinarySql\\'", rawSql.getSql());
+
+        AddColumnConfig h2ComputedColumn = computed("_utf8mb4\\'$.regionId\\'");
+        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(
+                List.of(changeSet(createIndex(h2ComputedColumn))), new H2Database());
+
+        assertEquals("_utf8mb4\\'$.regionId\\'", h2ComputedColumn.getName());
+    }
+
+    @Test
+    void serializesValidXmlAndProducesSqlThatDruidCanParse() throws Exception {
+        AddColumnConfig column = computed(
+                "cast(json_extract(`payload`,_utf8mb4\\'$.provinceId\\') as unsigned)");
+        ChangeSet changeSet = changeSet(createIndex(column));
+
+        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(
+                List.of(changeSet), new MySQLDatabase());
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new XMLChangeLogSerializer().write(List.of(changeSet), new PrintStream(output, true, StandardCharsets.UTF_8));
+        String xml = output.toString(StandardCharsets.UTF_8);
+
+        assertTrue(xml.contains("(cast(json_extract(`payload`,_utf8mb4'$.provinceId') as unsigned))"));
+        assertFalse(xml.contains("_utf8mb4\\'$.provinceId\\'"));
+
+        MySQLDatabase database = new MySQLDatabase();
+        String sql = SqlGeneratorFactory.getInstance()
+                .generateSql(changeSet.getChanges().get(0), database)[0].toSql();
+        assertTrue(sql.contains("((cast(json_extract(`payload`,_utf8mb4'$.provinceId') as unsigned)))"));
+        assertDoesNotThrow(() -> SqlUtils.parse(sql, DbType.mysql, true));
+
+        CreateIndexChange multiValuedIndex = createIndex(
+                computed("cast(json_extract(`region_ids`,_latin1\\'$[*]\\') as unsigned array)"));
+        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(
+                List.of(changeSet(multiValuedIndex)), database);
+        String multiValuedSql = SqlGeneratorFactory.getInstance()
+                .generateSql(multiValuedIndex, database)[0].toSql();
+        assertTrue(multiValuedSql.contains(
+                "((cast(json_extract(`region_ids`,_latin1'$[*]') as unsigned array)))"));
+        assertDoesNotThrow(() -> SqlUtils.parse(multiValuedSql, DbType.mysql, true));
+    }
+
+    private static AddColumnConfig computed(String expression) {
+        return column(expression, true);
+    }
+
+    private static AddColumnConfig column(String name, boolean computed) {
+        AddColumnConfig column = new AddColumnConfig();
+        column.setName(name);
+        column.setComputed(computed);
+        return column;
+    }
+
+    private static CreateIndexChange createIndex(AddColumnConfig... columns) {
+        CreateIndexChange createIndex = new CreateIndexChange();
+        createIndex.setIndexName("idx_payload_region");
+        createIndex.setTableName("sample_config");
+        for (AddColumnConfig column : columns) {
+            createIndex.addColumn(column);
+        }
+        return createIndex;
+    }
+
+    private static ChangeSet changeSet(Change... changes) {
+        ChangeSet changeSet = new ChangeSet("1", "test", false, false,
+                "test.xml", null, null, new DatabaseChangeLog());
+        for (Change change : changes) {
+            changeSet.addChange(change);
+        }
+        return changeSet;
+    }
+}

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLogTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/Chat2dbDiffToChangeLogTest.java
@@ -48,6 +48,40 @@ class Chat2dbDiffToChangeLogTest {
     }
 
     @Test
+    void preservesEscapesInsideCharsetIntroducedLiterals() {
+        String apostrophePath = "cast(json_extract(`payload`,_latin1\\'$.\"a"
+                + "\\".repeat(3) + "'b\"\\') as unsigned)";
+        String backslashPath = "cast(json_extract(`payload`,_latin1\\'$.\"a"
+                + "\\".repeat(8) + "b\"\\') as unsigned)";
+        String trailingBackslashLiteral = "concat(_latin1\\'value"
+                + "\\".repeat(5) + "')";
+        CreateIndexChange createIndex = createIndex(
+                computed(apostrophePath),
+                computed(backslashPath),
+                computed(trailingBackslashLiteral));
+
+        List<ChangeSet> changeSets = List.of(changeSet(createIndex));
+        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(changeSets, new MySQLDatabase());
+        Chat2dbDiffToChangeLog.repairMySqlComputedIndexExpressions(changeSets, new MySQLDatabase());
+
+        assertEquals("(cast(json_extract(`payload`,_latin1'$.\"a\\'b\"') as unsigned))",
+                createIndex.getColumns().get(0).getName());
+        assertEquals("(cast(json_extract(`payload`,_latin1'$.\"a"
+                        + "\\".repeat(4) + "b\"') as unsigned))",
+                createIndex.getColumns().get(1).getName());
+        assertEquals("(concat(_latin1'value" + "\\".repeat(2) + "'))",
+                createIndex.getColumns().get(2).getName());
+
+        MySQLDatabase database = new MySQLDatabase();
+        String apostropheSql = SqlGeneratorFactory.getInstance()
+                .generateSql(createIndex, database)[0].toSql();
+        assertTrue(apostropheSql.contains("_latin1'$.\"a\\'b\"'"));
+        assertTrue(apostropheSql.contains("_latin1'$.\"a" + "\\".repeat(4) + "b\"'"));
+        assertTrue(apostropheSql.contains("_latin1'value" + "\\".repeat(2) + "'"));
+        assertDoesNotThrow(() -> SqlUtils.parse(apostropheSql, DbType.mysql, true));
+    }
+
+    @Test
     void leavesOrdinaryColumnsRawSqlAndNonMysqlChangesUntouched() {
         AddColumnConfig ordinaryColumn = column("_utf8mb4\\'notAnExpression\\'", false);
         CreateIndexChange mysqlIndex = createIndex(ordinaryColumn);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/pom.xml
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>chat2db-community-spi</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/MysqlPlugin.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/MysqlPlugin.java
@@ -1,7 +1,9 @@
 package ai.chat2db.plugin.mysql;
 
 import ai.chat2db.plugin.mysql.account.MysqlAccountManager;
+import ai.chat2db.plugin.mysql.diff.MysqlDiffChangeSetProcessor;
 import ai.chat2db.spi.IAccountManager;
+import ai.chat2db.spi.IDbDiffChangeSetProcessor;
 import ai.chat2db.spi.IDbManager;
 import ai.chat2db.spi.IDbMetaData;
 import ai.chat2db.spi.IPlugin;
@@ -10,6 +12,9 @@ import ai.chat2db.community.domain.api.config.DBConfig;
 import ai.chat2db.spi.util.FileUtils;
 
 public class MysqlPlugin extends MysqlSyntaxPlugin implements IPlugin {
+
+    private static final IDbDiffChangeSetProcessor DIFF_CHANGE_SET_PROCESSOR =
+            new MysqlDiffChangeSetProcessor();
 
     private DBConfig dbConfig;
 
@@ -30,6 +35,11 @@ public class MysqlPlugin extends MysqlSyntaxPlugin implements IPlugin {
     @Override
     public IDbManager getDbManager() {
         return new MysqlDBManager();
+    }
+
+    @Override
+    public IDbDiffChangeSetProcessor getDiffChangeSetProcessor() {
+        return DIFF_CHANGE_SET_PROCESSOR;
     }
 
     @Override

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/diff/MysqlDiffChangeSetProcessor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/diff/MysqlDiffChangeSetProcessor.java
@@ -1,0 +1,92 @@
+package ai.chat2db.plugin.mysql.diff;
+
+import ai.chat2db.spi.IDbDiffChangeSetProcessor;
+import liquibase.change.AddColumnConfig;
+import liquibase.change.Change;
+import liquibase.change.core.CreateIndexChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.Database;
+import liquibase.database.core.MySQLDatabase;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Repairs MySQL computed index metadata before Liquibase serializes the changelog.
+ */
+public final class MysqlDiffChangeSetProcessor implements IDbDiffChangeSetProcessor {
+
+    private static final Pattern MYSQL_ESCAPED_CHARSET_LITERAL_START =
+            Pattern.compile("(?i)(_[a-z0-9]+)\\\\'");
+
+    @Override
+    public void process(List<ChangeSet> changeSets, Database targetDatabase) {
+        if (!(targetDatabase instanceof MySQLDatabase)) {
+            return;
+        }
+        for (ChangeSet changeSet : changeSets) {
+            for (Change change : changeSet.getChanges()) {
+                if (change instanceof CreateIndexChange createIndexChange) {
+                    normalizeComputedColumns(createIndexChange);
+                }
+            }
+        }
+    }
+
+    private static void normalizeComputedColumns(CreateIndexChange createIndexChange) {
+        for (AddColumnConfig column : createIndexChange.getColumns()) {
+            if (Boolean.TRUE.equals(column.getComputed()) && column.getName() != null) {
+                String expression = normalizeCharsetLiterals(column.getName());
+                String trimmedExpression = expression.trim();
+                // Liquibase uses the name verbatim, while MySQL requires an extra pair around expression key parts.
+                if (!trimmedExpression.isEmpty()
+                        && !(trimmedExpression.startsWith("(") && trimmedExpression.endsWith(")"))) {
+                    expression = "(" + trimmedExpression + ")";
+                }
+                column.setName(expression);
+            }
+        }
+    }
+
+    private static String normalizeCharsetLiterals(String expression) {
+        Matcher matcher = MYSQL_ESCAPED_CHARSET_LITERAL_START.matcher(expression);
+        StringBuilder normalized = new StringBuilder(expression.length());
+        int cursor = 0;
+        while (matcher.find(cursor)) {
+            normalized.append(expression, cursor, matcher.start());
+
+            StringBuilder body = new StringBuilder();
+            int metadataCursor = matcher.end();
+            boolean closed = false;
+            while (metadataCursor < expression.length()) {
+                char decoded = expression.charAt(metadataCursor++);
+                if (decoded == '\\' && metadataCursor < expression.length()) {
+                    decoded = expression.charAt(metadataCursor++);
+                }
+                if (decoded == '\'' && !hasOddTrailingBackslashes(body)) {
+                    normalized.append(matcher.group(1)).append('\'').append(body).append('\'');
+                    cursor = metadataCursor;
+                    closed = true;
+                    break;
+                }
+                body.append(decoded);
+            }
+
+            if (!closed) {
+                normalized.append(expression, matcher.start(), expression.length());
+                return normalized.toString();
+            }
+        }
+        normalized.append(expression, cursor, expression.length());
+        return normalized.toString();
+    }
+
+    private static boolean hasOddTrailingBackslashes(StringBuilder value) {
+        int count = 0;
+        for (int i = value.length() - 1; i >= 0 && value.charAt(i) == '\\'; i--) {
+            count++;
+        }
+        return count % 2 != 0;
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/diff/MysqlDiffChangeSetProcessorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/diff/MysqlDiffChangeSetProcessorTest.java
@@ -1,0 +1,171 @@
+package ai.chat2db.plugin.mysql.diff;
+
+import ai.chat2db.spi.sql.Chat2DBContext;
+import ai.chat2db.spi.util.SqlUtils;
+import com.alibaba.druid.DbType;
+import liquibase.change.AddColumnConfig;
+import liquibase.change.Change;
+import liquibase.change.core.CreateIndexChange;
+import liquibase.change.core.RawSQLChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.core.H2Database;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.serializer.core.xml.XMLChangeLogSerializer;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MysqlDiffChangeSetProcessorTest {
+
+    private static final MysqlDiffChangeSetProcessor PROCESSOR = new MysqlDiffChangeSetProcessor();
+
+    @Test
+    void mysqlPluginRegistersDiffProcessor() {
+        assertInstanceOf(MysqlDiffChangeSetProcessor.class,
+                Chat2DBContext.getDiffChangeSetProcessor("MYSQL"));
+    }
+
+    @Test
+    void normalizesScalarAndMultiValuedMysqlIndexExpressions() {
+        CreateIndexChange createIndex = createIndex(
+                computed("cast(json_extract(`payload`,_utf8mb4\\'$.provinceId\\') as unsigned)"),
+                computed("cast(json_extract(`region_ids`,_latin1\\'$[*]\\') as unsigned array)"),
+                computed("lower(`name`)"),
+                computed("(json_extract(`payload`,_utf8mb4'$.alreadyValid'))"));
+
+        List<ChangeSet> changeSets = List.of(changeSet(createIndex));
+        PROCESSOR.process(changeSets, new MySQLDatabase());
+        PROCESSOR.process(changeSets, new MySQLDatabase());
+
+        assertEquals("(cast(json_extract(`payload`,_utf8mb4'$.provinceId') as unsigned))",
+                createIndex.getColumns().get(0).getName());
+        assertEquals("(cast(json_extract(`region_ids`,_latin1'$[*]') as unsigned array))",
+                createIndex.getColumns().get(1).getName());
+        assertEquals("(lower(`name`))", createIndex.getColumns().get(2).getName());
+        assertEquals("(json_extract(`payload`,_utf8mb4'$.alreadyValid'))",
+                createIndex.getColumns().get(3).getName());
+    }
+
+    @Test
+    void preservesEscapesInsideCharsetIntroducedLiterals() {
+        String apostrophePath = "cast(json_extract(`payload`,_latin1\\'$.\"a"
+                + "\\".repeat(3) + "'b\"\\') as unsigned)";
+        String backslashPath = "cast(json_extract(`payload`,_latin1\\'$.\"a"
+                + "\\".repeat(8) + "b\"\\') as unsigned)";
+        String trailingBackslashLiteral = "concat(_latin1\\'value"
+                + "\\".repeat(5) + "')";
+        CreateIndexChange createIndex = createIndex(
+                computed(apostrophePath),
+                computed(backslashPath),
+                computed(trailingBackslashLiteral));
+
+        List<ChangeSet> changeSets = List.of(changeSet(createIndex));
+        PROCESSOR.process(changeSets, new MySQLDatabase());
+        PROCESSOR.process(changeSets, new MySQLDatabase());
+
+        assertEquals("(cast(json_extract(`payload`,_latin1'$.\"a\\'b\"') as unsigned))",
+                createIndex.getColumns().get(0).getName());
+        assertEquals("(cast(json_extract(`payload`,_latin1'$.\"a"
+                        + "\\".repeat(4) + "b\"') as unsigned))",
+                createIndex.getColumns().get(1).getName());
+        assertEquals("(concat(_latin1'value" + "\\".repeat(2) + "'))",
+                createIndex.getColumns().get(2).getName());
+
+        MySQLDatabase database = new MySQLDatabase();
+        String apostropheSql = SqlGeneratorFactory.getInstance()
+                .generateSql(createIndex, database)[0].toSql();
+        assertTrue(apostropheSql.contains("_latin1'$.\"a\\'b\"'"));
+        assertTrue(apostropheSql.contains("_latin1'$.\"a" + "\\".repeat(4) + "b\"'"));
+        assertTrue(apostropheSql.contains("_latin1'value" + "\\".repeat(2) + "'"));
+        assertDoesNotThrow(() -> SqlUtils.parse(apostropheSql, DbType.mysql, true));
+    }
+
+    @Test
+    void leavesOrdinaryColumnsRawSqlAndNonMysqlChangesUntouched() {
+        AddColumnConfig ordinaryColumn = column("_utf8mb4\\'notAnExpression\\'", false);
+        CreateIndexChange mysqlIndex = createIndex(ordinaryColumn);
+        RawSQLChange rawSql = new RawSQLChange("select _utf8mb4\\'ordinarySql\\'");
+
+        PROCESSOR.process(List.of(changeSet(mysqlIndex, rawSql)), new MySQLDatabase());
+
+        assertEquals("_utf8mb4\\'notAnExpression\\'", ordinaryColumn.getName());
+        assertEquals("select _utf8mb4\\'ordinarySql\\'", rawSql.getSql());
+
+        AddColumnConfig h2ComputedColumn = computed("_utf8mb4\\'$.regionId\\'");
+        PROCESSOR.process(List.of(changeSet(createIndex(h2ComputedColumn))), new H2Database());
+
+        assertEquals("_utf8mb4\\'$.regionId\\'", h2ComputedColumn.getName());
+    }
+
+    @Test
+    void serializesValidXmlAndProducesSqlThatDruidCanParse() throws Exception {
+        AddColumnConfig column = computed(
+                "cast(json_extract(`payload`,_utf8mb4\\'$.provinceId\\') as unsigned)");
+        ChangeSet changeSet = changeSet(createIndex(column));
+
+        PROCESSOR.process(List.of(changeSet), new MySQLDatabase());
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new XMLChangeLogSerializer().write(List.of(changeSet), new PrintStream(output, true, StandardCharsets.UTF_8));
+        String xml = output.toString(StandardCharsets.UTF_8);
+
+        assertTrue(xml.contains("(cast(json_extract(`payload`,_utf8mb4'$.provinceId') as unsigned))"));
+        assertFalse(xml.contains("_utf8mb4\\'$.provinceId\\'"));
+
+        MySQLDatabase database = new MySQLDatabase();
+        String sql = SqlGeneratorFactory.getInstance()
+                .generateSql(changeSet.getChanges().get(0), database)[0].toSql();
+        assertTrue(sql.contains("((cast(json_extract(`payload`,_utf8mb4'$.provinceId') as unsigned)))"));
+        assertDoesNotThrow(() -> SqlUtils.parse(sql, DbType.mysql, true));
+
+        CreateIndexChange multiValuedIndex = createIndex(
+                computed("cast(json_extract(`region_ids`,_latin1\\'$[*]\\') as unsigned array)"));
+        PROCESSOR.process(List.of(changeSet(multiValuedIndex)), database);
+        String multiValuedSql = SqlGeneratorFactory.getInstance()
+                .generateSql(multiValuedIndex, database)[0].toSql();
+        assertTrue(multiValuedSql.contains(
+                "((cast(json_extract(`region_ids`,_latin1'$[*]') as unsigned array)))"));
+        assertDoesNotThrow(() -> SqlUtils.parse(multiValuedSql, DbType.mysql, true));
+    }
+
+    private static AddColumnConfig computed(String expression) {
+        return column(expression, true);
+    }
+
+    private static AddColumnConfig column(String name, boolean computed) {
+        AddColumnConfig column = new AddColumnConfig();
+        column.setName(name);
+        column.setComputed(computed);
+        return column;
+    }
+
+    private static CreateIndexChange createIndex(AddColumnConfig... columns) {
+        CreateIndexChange createIndex = new CreateIndexChange();
+        createIndex.setIndexName("idx_payload_region");
+        createIndex.setTableName("sample_config");
+        for (AddColumnConfig column : columns) {
+            createIndex.addColumn(column);
+        }
+        return createIndex;
+    }
+
+    private static ChangeSet changeSet(Change... changes) {
+        ChangeSet changeSet = new ChangeSet("1", "test", false, false,
+                "test.xml", null, null, new DatabaseChangeLog());
+        for (Change change : changes) {
+            changeSet.addChange(change);
+        }
+        return changeSet;
+    }
+}

--- a/chat2db-community-server/chat2db-community-spi/pom.xml
+++ b/chat2db-community-server/chat2db-community-spi/pom.xml
@@ -41,6 +41,11 @@
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Supported connected databases -->
         <dependency>

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/IDbDiffChangeSetProcessor.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/IDbDiffChangeSetProcessor.java
@@ -1,0 +1,24 @@
+package ai.chat2db.spi;
+
+import liquibase.changelog.ChangeSet;
+import liquibase.database.Database;
+
+import java.util.List;
+
+/**
+ * Database plugin hook for normalizing Liquibase change sets before serialization.
+ */
+@FunctionalInterface
+public interface IDbDiffChangeSetProcessor {
+
+    IDbDiffChangeSetProcessor NO_OP = (changeSets, targetDatabase) -> {
+    };
+
+    /**
+     * Applies database-specific corrections to generated change sets.
+     *
+     * @param changeSets generated Liquibase change sets
+     * @param targetDatabase target Liquibase database
+     */
+    void process(List<ChangeSet> changeSets, Database targetDatabase);
+}

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/IPlugin.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/IPlugin.java
@@ -70,6 +70,15 @@ public interface IPlugin {
     }
 
     /**
+     * Returns the optional Liquibase change-set processor for this plugin.
+     *
+     * @return database-specific diff processor, or a no-op processor by default.
+     */
+    default IDbDiffChangeSetProcessor getDiffChangeSetProcessor() {
+        return IDbDiffChangeSetProcessor.NO_OP;
+    }
+
+    /**
      * Returns key operations for this plugin.
      *
      * @return key operations implementation.

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/Chat2DBContext.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/Chat2DBContext.java
@@ -1,6 +1,7 @@
 package ai.chat2db.spi.sql;
 
 import ai.chat2db.spi.IAccountManager;
+import ai.chat2db.spi.IDbDiffChangeSetProcessor;
 import ai.chat2db.spi.IDbManager;
 import ai.chat2db.spi.IDbMetaData;
 import ai.chat2db.spi.IPlugin;
@@ -101,6 +102,10 @@ public class Chat2DBContext {
 
     public static IDbManager getDbManager(String dbType) {
         return getPlugin(dbType).getDbManager();
+    }
+
+    public static IDbDiffChangeSetProcessor getDiffChangeSetProcessor(String dbType) {
+        return getPlugin(dbType).getDiffChangeSetProcessor();
     }
 
     public static IAccountManager getAccountManager() {


### PR DESCRIPTION
## Related issue

Closes #2250

## Summary

Add a database-plugin hook for normalizing Liquibase change sets before the generated changelog is serialized, then implement the MySQL functional-index compatibility repair in the MySQL plugin.

`DbDiffServiceImpl` resolves `IDbDiffChangeSetProcessor` explicitly from the target database type. `Chat2dbDiffToChangeLog` remains a generic Liquibase wrapper and delegates generated change sets to that processor. Plugins that do not need normalization inherit a no-op processor from `IPlugin`.

The MySQL processor applies two compatibility repairs to `CreateIndexChange` columns marked `computed=true`:

- restore charset-introduced literals such as `_utf8mb4\'$.regionId\'` to executable SQL literals while decoding exactly one metadata-escaping layer and preserving semantic escapes inside the literal;
- preserve MySQL functional-key syntax by wrapping an unwrapped expression, so Liquibase generates `ON table((expression))` instead of `ON table(expression)`.

The repair is idempotent and limited to the MySQL plugin. Ordinary index columns, raw SQL, non-MySQL databases, and already-parenthesized expressions remain unchanged. It covers scalar JSON functional indexes, MySQL multi-valued `CAST(... AS UNSIGNED ARRAY)` indexes, and JSON paths containing escaped apostrophes or backslashes.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `mvn -pl chat2db-community-domain/chat2db-community-domain-core,chat2db-community-plugins/chat2db-community-mysql -am -Dmaven.test.skip=false -DskipTests=false -Dtest=Chat2dbDiffToChangeLogTest,MysqlDiffChangeSetProcessorTest -Dsurefire.failIfNoSpecifiedTests=false test` - passed; 6 focused tests, 0 failures, 0 errors. This includes the real `Chat2DBContext`/`ServiceLoader` MySQL plugin lookup.
  - `mvn -pl chat2db-community-domain/chat2db-community-domain-core,chat2db-community-plugins/chat2db-community-mysql -am -Dmaven.test.skip=false -DskipTests=false test` - passed; 613 owning-reactor tests, 0 failures, 0 errors.
  - `mvn -pl chat2db-community-start -am -Dmaven.test.skip=true package` - passed; all 48 backend reactor modules, including every database plugin, compiled and packaged successfully.
  - `git diff --check` - passed.
- Manual verification:
  - Reproduced with task-scoped MySQL 8.0.36, Liquibase 4.30.0, and Connector/J 8.4.0. The unmodified generated changelog failed with MySQL error 1064.
  - Removing only the escaped quote delimiters still failed because Liquibase generated a single-parenthesized functional key part.
  - Applying the repaired changelog succeeded with 2 changesets. `INFORMATION_SCHEMA.STATISTICS` confirmed both the scalar JSON functional index and the multi-valued `UNSIGNED ARRAY` index on the target schema.
  - After review, reproduced functional indexes whose JSON member names contain an apostrophe or backslash. The normalized SQL executed successfully, and the source and target `INFORMATION_SCHEMA.STATISTICS.EXPRESSION` values were byte-identical by `HEX(EXPRESSION)`.
  - The task-scoped MySQL containers, Docker networks, schemas, and temporary changelogs/fixtures were removed after verification.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: The internal database plugin SPI gains a backward-compatible default method returning a no-op processor. HTTP contracts and Chat2DB stored data are unchanged.
- Database or driver compatibility: The concrete repair is registered only by `MysqlPlugin` and still verifies Liquibase `MySQLDatabase`. Other plugins retain the no-op behavior.
- Network, privacy, or security: N/A - no network behavior, credentials, or user data changes.
- Community / Local / Pro boundary: This change is implemented only in the Community structure-diff and plugin modules in this repository.
- Backward compatibility: Existing plugins compile unchanged. Existing valid parenthesized expressions are not wrapped again. Existing expressions without charset-introduced literals receive only the MySQL-required key-part parentheses. Escapes inside affected literals are decoded by one metadata layer rather than removed.

## Reviewer map

- Start here: `IDbDiffChangeSetProcessor`, `IPlugin.getDiffChangeSetProcessor()`, `Chat2DBContext.getDiffChangeSetProcessor(String)`, and `Chat2dbDiffToChangeLog.generateChangeSets()` define the generic path. `MysqlPlugin.getDiffChangeSetProcessor()` and `MysqlDiffChangeSetProcessor` contain the MySQL-specific implementation.
- Failure condition: The core module contains MySQL-specific normalization again; the target plugin is not selected explicitly; a MySQL computed index retains metadata-level escaped quote delimiters, loses semantic escapes inside a literal, lacks the extra functional-key parentheses, is wrapped repeatedly; or the repair changes ordinary indexes/raw SQL/non-MySQL changelogs.
- Rollback or disable path: Revert commits `32f87ba7`, `67638d5d`, and `1d5e223c` to restore direct use of Liquibase `DiffToChangeLog`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used to trace the Community Liquibase diff and plugin pipelines, minimize and reproduce the MySQL metadata round trip, implement the database-plugin extension point and MySQL compatibility processor, preserve escaped-path semantics, run Maven and MySQL verification, and prepare the Issue and PR. The final diff and runtime evidence were reviewed locally.
