### PR TITLE
fix(sql-editor): sync action state on content changes

### DIFF
--- a/chat2db-community-client/src/components/SQLEditor/editor/MonacoEditor/index.tsx
+++ b/chat2db-community-client/src/components/SQLEditor/editor/MonacoEditor/index.tsx
@@ -81,6 +81,8 @@ export type MonacoSQLEditorProps = {
     changePosition?: monaco.Position | null,
     changeRange?: monaco.IRange | null,
   ) => void;
+  /** Immediate editor value change callback for lightweight UI state. */
+  onContentChange?: (value: string) => void;
   /** Cursor change callback. */
   onCursorChange?: (editor: monaco.editor.IStandaloneCodeEditor) => void;
   /** Mouse click callback. */
@@ -111,6 +113,7 @@ const MonacoSQLEditor = forwardRef<MonacoEditorRef, MonacoSQLEditorProps>(
       id,
       defaultValue,
       onChange,
+      onContentChange,
       onCursorChange,
       onMouseClick,
       onMount,
@@ -716,6 +719,8 @@ const MonacoSQLEditor = forwardRef<MonacoEditorRef, MonacoSQLEditorProps>(
 
       // Handle content changes.
       const didChangeModelContentDisposer = editor.onDidChangeModelContent((event) => {
+        onContentChange?.(editor.getValue());
+
         const lastChange = event.changes[event.changes.length - 1];
         if (
           event.changes.length === 1 &&
@@ -788,6 +793,7 @@ const MonacoSQLEditor = forwardRef<MonacoEditorRef, MonacoSQLEditorProps>(
       handleContextMenu,
       handleCursorChange,
       handleValueChange,
+      onContentChange,
       updateContentDiffGutterMarkers,
       scheduleContentDiffHintsRefresh,
     ]);

--- a/chat2db-community-client/src/components/SQLEditor/editor/SQLEditor/index.tsx
+++ b/chat2db-community-client/src/components/SQLEditor/editor/SQLEditor/index.tsx
@@ -75,6 +75,8 @@ export interface SQLEditorProps {
   onContextMenu?: (e: monaco.editor.IEditorMouseEvent) => void;
   /** Editor value change callback. */
   onChange?: (value: string) => void;
+  /** Immediate editor value change callback for lightweight UI state. */
+  onContentChange?: (value: string) => void;
 
   dbInfo: IBoundInfo;
   active?: boolean;
@@ -132,6 +134,7 @@ const SQLEditor = forwardRef<SQLEditorRef, SQLEditorProps>(
       dbInfo,
       active,
       onChange,
+      onContentChange,
       onContextMenu,
       className,
       readOnly,
@@ -989,6 +992,7 @@ const SQLEditor = forwardRef<SQLEditorRef, SQLEditorProps>(
             defaultValue={defaultValue}
             onMount={handleEditorMount}
             onChange={handleValueChange}
+            onContentChange={onContentChange}
             onCursorChange={handleCursorChange}
             onMouseClick={handleMouseClick}
             onContextMenu={handleContextMenu}

--- a/chat2db-community-client/src/components/SQLEditor/editor/SQLEditorWithOperation/index.tsx
+++ b/chat2db-community-client/src/components/SQLEditor/editor/SQLEditorWithOperation/index.tsx
@@ -123,6 +123,9 @@ const SQLEditorWithOperation = forwardRef<ISQLEditorWithOperationRef, ISQLEditor
   const [contextTableIdentifier, setContextTableIdentifier] = useState<EditorTableIdentifier | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [hasEditorContent, setHasEditorContent] = useState<boolean>(!!defaultSQL?.trim());
+  const handleEditorContentChange = useCallback((value: string) => {
+    setHasEditorContent(!!value.trim());
+  }, []);
   const [routineExecutionModal, setRoutineExecutionModal] = useState({
     open: false,
     title: '',
@@ -941,9 +944,7 @@ const SQLEditorWithOperation = forwardRef<ISQLEditorWithOperationRef, ISQLEditor
           readOnly={isReadOnly}
           action={handleAction}
           enableContentDiffHints={enableContentDiffHints}
-          onChange={(value) => {
-            setHasEditorContent(!!value?.trim());
-          }}
+          onContentChange={handleEditorContentChange}
           contextMenuInfo={contextMenuInfo}
           onTableIdentifierContextChange={setContextTableIdentifier}
           onContextMenu={isReadOnly ? undefined : handleContextMenu}


### PR DESCRIPTION
## Related issue

Closes #2259

## Summary

Synchronize SQL editor toolbar availability directly from Monaco model changes instead of waiting for the existing 300 ms debounced value callback.

The new `onContentChange` path is intentionally limited to lightweight UI state. SQL parsing, completion, parameter hints, and the existing external `onChange` behavior remain on the debounced path, preserving the editor's performance boundary while covering paste, deletion, undo, redo, and programmatic model updates.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn eslint src/components/SQLEditor/editor/MonacoEditor/index.tsx src/components/SQLEditor/editor/SQLEditor/index.tsx src/components/SQLEditor/editor/SQLEditorWithOperation/index.tsx --max-warnings=0` - passed
  - `yarn lint` - passed
  - `yarn test:i18n` - passed
  - `yarn build:web:community --app_version=5.3.0` - passed, including all Community prebuild tests
  - `git diff --check` - passed
- Manual verification: The branch-specific Community frontend started on port `8890`; `/workspace` and the frontend-proxied `/api/system` both returned HTTP 200. Interactive paste automation was unavailable in the current browser environment.
- UI evidence: N/A - no controllable browser instance was available; source timing, production build, and runtime smoke checks were verified.

## Risk and compatibility

- Public API or stored data: N/A - no API or persistence changes.
- Database or driver compatibility: N/A - the behavior is database-independent.
- Network, privacy, or security: N/A - no network, clipboard access, or data handling changes.
- Community / Local / Pro boundary: Community frontend source only; the shared editor behavior remains compatible with existing surfaces.
- Backward compatibility: The existing debounced `onChange` callback is unchanged. The new optional callback only synchronizes lightweight content-presence state.

## Reviewer map

- Start here: `chat2db-community-client/src/components/SQLEditor/editor/MonacoEditor/index.tsx`, inside `onDidChangeModelContent`.
- Failure condition: Content-dependent actions remain disabled after a non-empty model change, or SQL parsing/completion begins running synchronously on every edit.
- Rollback or disable path: Revert this commit to restore the previous debounced-only toolbar synchronization.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for source tracing, implementation, and verification.
