### PR TITLE
feat(workspace): improve session panel resizing

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExplorer/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExplorer/index.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, memo, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import SplitPane from 'react-split-pane';
 import { IconfontSvg, SearchBar } from '@chat2db/ui';
 
 import i18n from '@/i18n';
@@ -16,6 +17,7 @@ import LocalSQLFileTree, { type LocalSQLFileTreeRef } from '../LocalSQLFileTree'
 import { useStyles } from './style';
 
 const SESSION_PANEL_MIN_HEIGHT = 72;
+const SESSION_PANEL_DEFAULT_HEIGHT = 220;
 const SESSION_PANEL_MAX_HEIGHT = 420;
 type SearchBarHandle = { focus: () => void; blur: () => void };
 
@@ -28,254 +30,227 @@ export interface WorkspaceExplorerRef {
 }
 
 const WorkspaceExplorer = memo(
-  forwardRef<WorkspaceExplorerRef, WorkspaceExplorerProps>((
-    { active = true },
-    ref,
-  ) => {
-  const { styles } = useStyles();
-  const explorerRef = useRef<HTMLDivElement>(null);
-  const searchBarRef = useRef<SearchBarHandle>(null);
-  const sessionSectionRef = useRef<HTMLElement>(null);
-  const activeSessionRowRef = useRef<HTMLButtonElement | null>(null);
-  const localFileTreeRef = useRef<LocalSQLFileTreeRef>(null);
-  const [searchKeyword, setSearchKeyword] = useState('');
-  const [sessionPanelHeight, setSessionPanelHeight] = useState<number | null>(null);
-  const { activeConsoleId, workspaceTabList, editorList, setActiveConsoleId } = useWorkspaceStore((state) => ({
-    activeConsoleId: state.activeConsoleId,
-    workspaceTabList: state.workspaceTabList,
-    editorList: state.editorList,
-    setActiveConsoleId: state.setActiveConsoleId,
-  }));
-  const shortcutOverrides = useGlobalStore((state) => state.shortcutOverrides);
-  const shortcutConfig = useMemo(
-    () => getEffectiveShortcutConfigMap(shortcutOverrides as ShortcutOverrides),
-    [shortcutOverrides],
-  );
+  forwardRef<WorkspaceExplorerRef, WorkspaceExplorerProps>(({ active = true }, ref) => {
+    const { styles } = useStyles();
+    const explorerRef = useRef<HTMLDivElement>(null);
+    const searchBarRef = useRef<SearchBarHandle>(null);
+    const activeSessionRowRef = useRef<HTMLButtonElement | null>(null);
+    const localFileTreeRef = useRef<LocalSQLFileTreeRef>(null);
+    const [searchKeyword, setSearchKeyword] = useState('');
+    const [sessionPanelHeight, setSessionPanelHeight] = useState(SESSION_PANEL_DEFAULT_HEIGHT);
+    const { activeConsoleId, workspaceTabList, editorList, setActiveConsoleId } = useWorkspaceStore((state) => ({
+      activeConsoleId: state.activeConsoleId,
+      workspaceTabList: state.workspaceTabList,
+      editorList: state.editorList,
+      setActiveConsoleId: state.setActiveConsoleId,
+    }));
+    const shortcutOverrides = useGlobalStore((state) => state.shortcutOverrides);
+    const shortcutConfig = useMemo(
+      () => getEffectiveShortcutConfigMap(shortcutOverrides as ShortcutOverrides),
+      [shortcutOverrides],
+    );
 
-  const openSessions = useMemo(() => {
-    return (workspaceTabList || []).filter((item) => {
-      return item.type === WorkspaceTabType.CONSOLE;
-    });
-  }, [workspaceTabList]);
+    const openSessions = useMemo(() => {
+      return (workspaceTabList || []).filter((item) => {
+        return item.type === WorkspaceTabType.CONSOLE;
+      });
+    }, [workspaceTabList]);
 
-  const trimmedSearchKeyword = searchKeyword.trim();
-  const filteredOpenSessions = useMemo(() => {
-    const keyword = trimmedSearchKeyword.toLowerCase();
-    if (!keyword) {
-      return openSessions;
+    const trimmedSearchKeyword = searchKeyword.trim();
+    const filteredOpenSessions = useMemo(() => {
+      const keyword = trimmedSearchKeyword.toLowerCase();
+      if (!keyword) {
+        return openSessions;
+      }
+
+      return openSessions.filter((session) => {
+        const context = [
+          session.uniqueData?.databaseName || session.uniqueData?.schemaName,
+          session.uniqueData?.dataSourceName,
+        ]
+          .filter(Boolean)
+          .join(' @ ');
+
+        return [session.title, context]
+          .filter(Boolean)
+          .some((text) =>
+            String(text)
+              .toLowerCase()
+              .includes(keyword),
+          );
+      });
+    }, [openSessions, trimmedSearchKeyword]);
+
+    useEffect(() => {
+      if (!active) {
+        return;
+      }
+      const activeRow = activeSessionRowRef.current;
+      if (!activeRow) {
+        const activeSessionIsFiltered =
+          !!trimmedSearchKeyword && openSessions.some((session) => session.id === activeConsoleId);
+        if (activeSessionIsFiltered) {
+          setSearchKeyword('');
+        }
+        return;
+      }
+
+      window.requestAnimationFrame(() => {
+        try {
+          activeRow.scrollIntoView({ block: 'nearest' });
+        } catch {
+          activeRow.scrollIntoView(false);
+        }
+      });
+    }, [active, activeConsoleId, filteredOpenSessions.length, openSessions, sessionPanelHeight, trimmedSearchKeyword]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        locateLocalFile: (filePath: string) => !!localFileTreeRef.current?.locateFile(filePath),
+      }),
+      [],
+    );
+
+    useEffect(() => {
+      if (!active) {
+        return;
+      }
+
+      const searchArea = document.getElementById('tree-search-area');
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (isShortcutEventMatch(event, shortcutConfig[ShortcutAction.WorkspaceTreeSearch].binding)) {
+          event.preventDefault();
+          searchBarRef.current?.focus?.();
+        }
+      };
+
+      searchArea?.addEventListener('keydown', handleKeyDown);
+      return () => {
+        searchArea?.removeEventListener('keydown', handleKeyDown);
+      };
+    }, [active, shortcutConfig]);
+
+    function getSessionTitle(session: IWorkspaceTab) {
+      return session.title || i18n('workspace.openSessions.untitled');
     }
 
-    return openSessions.filter((session) => {
-      const context = [
-        session.uniqueData?.databaseName || session.uniqueData?.schemaName,
-        session.uniqueData?.dataSourceName,
-      ]
+    function getSessionContext(session: IWorkspaceTab) {
+      return [session.uniqueData?.databaseName || session.uniqueData?.schemaName, session.uniqueData?.dataSourceName]
         .filter(Boolean)
         .join(' @ ');
-
-      return [session.title, context]
-        .filter(Boolean)
-        .some((text) =>
-          String(text)
-            .toLowerCase()
-            .includes(keyword),
-        );
-    });
-  }, [openSessions, trimmedSearchKeyword]);
-
-  useEffect(() => {
-    if (!active) {
-      return;
     }
-    const activeRow = activeSessionRowRef.current;
-    if (!activeRow) {
-      const activeSessionIsFiltered =
-        !!trimmedSearchKeyword && openSessions.some((session) => session.id === activeConsoleId);
-      if (activeSessionIsFiltered) {
-        setSearchKeyword('');
+
+    function getSessionFileName(session: IWorkspaceTab) {
+      const title =
+        getSessionTitle(session)
+          .split(/[\\/]/)
+          .pop() || i18n('workspace.openSessions.untitled');
+      return title.toLowerCase().endsWith('.sql') ? title.slice(0, -4) : title;
+    }
+
+    function getSessionContent(session: IWorkspaceTab) {
+      const editor = editorList?.[session.id as number];
+      if (editor?.getValue) {
+        return editor.getValue();
       }
-      return;
+      return session.uniqueData?.ddl || '';
     }
 
-    window.requestAnimationFrame(() => {
-      try {
-        activeRow.scrollIntoView({ block: 'nearest' });
-      } catch {
-        activeRow.scrollIntoView(false);
-      }
-    });
-  }, [active, activeConsoleId, filteredOpenSessions.length, openSessions, sessionPanelHeight, trimmedSearchKeyword]);
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      locateLocalFile: (filePath: string) => !!localFileTreeRef.current?.locateFile(filePath),
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!active) {
-      return;
+    function handleSessionDragStart(event: React.DragEvent<HTMLButtonElement>, session: IWorkspaceTab) {
+      setActiveConsoleId(session.id);
+      const payload = {
+        id: session.id,
+        title: getSessionFileName(session),
+        content: getSessionContent(session),
+      };
+      event.dataTransfer.effectAllowed = 'copy';
+      event.dataTransfer.setData(LOCAL_SQL_SESSION_DRAG_TYPE, JSON.stringify(payload));
+      event.dataTransfer.setData('text/plain', payload.title);
     }
 
-    const searchArea = document.getElementById('tree-search-area');
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (isShortcutEventMatch(event, shortcutConfig[ShortcutAction.WorkspaceTreeSearch].binding)) {
-        event.preventDefault();
-        searchBarRef.current?.focus?.();
-      }
-    };
-
-    searchArea?.addEventListener('keydown', handleKeyDown);
-    return () => {
-      searchArea?.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [active, shortcutConfig]);
-
-  function getSessionTitle(session: IWorkspaceTab) {
-    return session.title || i18n('workspace.openSessions.untitled');
-  }
-
-  function getSessionContext(session: IWorkspaceTab) {
-    return [session.uniqueData?.databaseName || session.uniqueData?.schemaName, session.uniqueData?.dataSourceName]
-      .filter(Boolean)
-      .join(' @ ');
-  }
-
-  function getSessionFileName(session: IWorkspaceTab) {
-    const title =
-      getSessionTitle(session)
-        .split(/[\\/]/)
-        .pop() || i18n('workspace.openSessions.untitled');
-    return title.toLowerCase().endsWith('.sql') ? title.slice(0, -4) : title;
-  }
-
-  function getSessionContent(session: IWorkspaceTab) {
-    const editor = editorList?.[session.id as number];
-    if (editor?.getValue) {
-      return editor.getValue();
+    function clampSessionPanelHeight(height: number) {
+      const explorerHeight = explorerRef.current?.clientHeight || SESSION_PANEL_MAX_HEIGHT;
+      const maxHeight = Math.max(SESSION_PANEL_MIN_HEIGHT, Math.min(SESSION_PANEL_MAX_HEIGHT, explorerHeight - 120));
+      return Math.max(SESSION_PANEL_MIN_HEIGHT, Math.min(maxHeight, height));
     }
-    return session.uniqueData?.ddl || '';
-  }
 
-  function handleSessionDragStart(event: React.DragEvent<HTMLButtonElement>, session: IWorkspaceTab) {
-    setActiveConsoleId(session.id);
-    const payload = {
-      id: session.id,
-      title: getSessionFileName(session),
-      content: getSessionContent(session),
-    };
-    event.dataTransfer.effectAllowed = 'copy';
-    event.dataTransfer.setData(LOCAL_SQL_SESSION_DRAG_TYPE, JSON.stringify(payload));
-    event.dataTransfer.setData('text/plain', payload.title);
-  }
-
-  function clampSessionPanelHeight(height: number) {
-    const explorerHeight = explorerRef.current?.clientHeight || SESSION_PANEL_MAX_HEIGHT;
-    const maxHeight = Math.max(SESSION_PANEL_MIN_HEIGHT, Math.min(SESSION_PANEL_MAX_HEIGHT, explorerHeight - 120));
-    return Math.max(SESSION_PANEL_MIN_HEIGHT, Math.min(maxHeight, height));
-  }
-
-  function handleSessionResizeStart(event: React.MouseEvent<HTMLDivElement>) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    const startY = event.clientY;
-    const startHeight = sessionSectionRef.current?.getBoundingClientRect().height || SESSION_PANEL_MIN_HEIGHT;
-    const originalCursor = document.body.style.cursor;
-    const originalUserSelect = document.body.style.userSelect;
-
-    document.body.style.cursor = 'row-resize';
-    document.body.style.userSelect = 'none';
-
-    const handleMouseMove = (moveEvent: MouseEvent) => {
-      setSessionPanelHeight(clampSessionPanelHeight(startHeight + startY - moveEvent.clientY));
-    };
-    const handleMouseUp = () => {
-      document.body.style.cursor = originalCursor;
-      document.body.style.userSelect = originalUserSelect;
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseup', handleMouseUp);
-    };
-
-    window.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('mouseup', handleMouseUp);
-  }
-
-  return (
-    <div ref={explorerRef} className={styles.explorer}>
-      <div className={styles.searchWrap}>
-        <SearchBar
-          ref={searchBarRef}
-          className={styles.searchBar}
-          value={searchKeyword}
-          placeholder={i18n('common.text.search')}
-          onChange={(event) => setSearchKeyword(event.target.value)}
-        />
-      </div>
-      <section className={styles.fileSection}>
-        <LocalSQLFileTree
-          ref={localFileTreeRef}
-          active={active}
-        />
-      </section>
-      <section
-        ref={sessionSectionRef}
-        className={[styles.sessionSection, sessionPanelHeight ? styles.sessionSectionResized : '']
-          .filter(Boolean)
-          .join(' ')}
-        style={sessionPanelHeight ? { height: sessionPanelHeight } : undefined}
-      >
-        <div className={styles.sessionResizeHandle} onMouseDown={handleSessionResizeStart} />
-        <div className={styles.sectionHeader}>
-          <span>{i18n('workspace.openSessions.title')}</span>
-          <span className={styles.sectionCount}>
-            {trimmedSearchKeyword ? `${filteredOpenSessions.length}/${openSessions.length}` : openSessions.length}
-          </span>
+    return (
+      <div ref={explorerRef} className={styles.explorer}>
+        <div className={styles.searchWrap}>
+          <SearchBar
+            ref={searchBarRef}
+            className={styles.searchBar}
+            value={searchKeyword}
+            placeholder={i18n('common.text.search')}
+            onChange={(event) => setSearchKeyword(event.target.value)}
+          />
         </div>
-        <div className={[styles.sessionList, 'workspace-session-list'].join(' ')}>
-          {!openSessions.length && <div className={styles.emptyText}>{i18n('workspace.openSessions.empty')}</div>}
-          {openSessions.length > 0 && !filteredOpenSessions.length && (
-            <div className={styles.emptyText}>{i18n('workspace.tips.noSearchResult')}</div>
-          )}
-          {filteredOpenSessions.map((session) => {
-            const isActive = activeConsoleId === session.id;
-            const context = getSessionContext(session);
-
-            return (
-              <button
-                key={session.id}
-                ref={(node) => {
-                  if (isActive) {
-                    activeSessionRowRef.current = node;
-                  }
-                }}
-                type="button"
-                draggable
-                className={[styles.sessionRow, isActive ? styles.sessionRowActive : ''].filter(Boolean).join(' ')}
-                onDragStart={(event) => handleSessionDragStart(event, session)}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  setActiveConsoleId(session.id);
-                }}
-              >
-                <IconfontSvg
-                  code={workspaceTabConfig[session.type]?.icon || 'icon-run-sql'}
-                  size={14}
-                  className={styles.sessionIcon}
-                />
-                <span className={styles.sessionMain}>
-                  <span className={styles.sessionTitle}>{getSessionTitle(session)}</span>
-                  {context && <span className={styles.sessionContext}>{context}</span>}
+        <div className={styles.splitPaneContainer}>
+          <SplitPane
+            split="horizontal"
+            primary="second"
+            size={sessionPanelHeight}
+            minSize={SESSION_PANEL_MIN_HEIGHT}
+            maxSize={SESSION_PANEL_MAX_HEIGHT}
+            pane1Style={{ minHeight: 0, overflow: 'hidden' }}
+            pane2Style={{ minHeight: 0, overflow: 'hidden' }}
+            onChange={(height) => setSessionPanelHeight(clampSessionPanelHeight(height))}
+          >
+            <section className={styles.fileSection}>
+              <LocalSQLFileTree ref={localFileTreeRef} active={active} />
+            </section>
+            <section className={styles.sessionSection}>
+              <div className={styles.sectionHeader}>
+                <span>{i18n('workspace.openSessions.title')}</span>
+                <span className={styles.sectionCount}>
+                  {trimmedSearchKeyword ? `${filteredOpenSessions.length}/${openSessions.length}` : openSessions.length}
                 </span>
-              </button>
-            );
-          })}
+              </div>
+              <div className={styles.sessionList}>
+                {!openSessions.length && <div className={styles.emptyText}>{i18n('workspace.openSessions.empty')}</div>}
+                {openSessions.length > 0 && !filteredOpenSessions.length && (
+                  <div className={styles.emptyText}>{i18n('workspace.tips.noSearchResult')}</div>
+                )}
+                {filteredOpenSessions.map((session) => {
+                  const isActive = activeConsoleId === session.id;
+                  const context = getSessionContext(session);
+
+                  return (
+                    <button
+                      key={session.id}
+                      ref={(node) => {
+                        if (isActive) {
+                          activeSessionRowRef.current = node;
+                        }
+                      }}
+                      type="button"
+                      draggable
+                      className={[styles.sessionRow, isActive ? styles.sessionRowActive : ''].filter(Boolean).join(' ')}
+                      onDragStart={(event) => handleSessionDragStart(event, session)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setActiveConsoleId(session.id);
+                      }}
+                    >
+                      <IconfontSvg
+                        code={workspaceTabConfig[session.type]?.icon || 'icon-run-sql'}
+                        size={14}
+                        className={styles.sessionIcon}
+                      />
+                      <span className={styles.sessionMain}>
+                        <span className={styles.sessionTitle}>{getSessionTitle(session)}</span>
+                        {context && <span className={styles.sessionContext}>{context}</span>}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          </SplitPane>
         </div>
-      </section>
-    </div>
-  );
+      </div>
+    );
   }),
 );
 

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExplorer/style.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExplorer/style.ts
@@ -24,42 +24,25 @@ export const useStyles = createStyles(({ css, token }) => {
       background-color: ${token.colorFillTertiary};
       height: 25px;
     `,
-    fileSection: css`
+    splitPaneContainer: css`
+      position: relative;
       flex: 1;
       min-height: 0;
       overflow: hidden;
     `,
-    sessionSection: css`
-      position: relative;
-      display: flex;
-      flex-direction: column;
-      flex-shrink: 0;
-      max-height: 220px;
-      padding: 8px 8px 10px;
-      border-top: 1px solid ${token.colorBorderLayout};
+    fileSection: css`
+      height: 100%;
+      min-height: 0;
       overflow: hidden;
     `,
-    sessionResizeHandle: css`
-      position: absolute;
-      top: -3px;
-      left: 0;
-      right: 0;
-      height: 6px;
-      cursor: row-resize;
-
-      &:hover::after {
-        background: ${token.colorPrimary};
-      }
-
-      &::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 2px;
-        height: 1px;
-        background: transparent;
-      }
+    sessionSection: css`
+      display: flex;
+      height: 100%;
+      min-height: 0;
+      flex-direction: column;
+      padding: 8px 8px 10px;
+      box-sizing: border-box;
+      overflow: hidden;
     `,
     sectionHeader: css`
       display: flex;
@@ -83,16 +66,8 @@ export const useStyles = createStyles(({ css, token }) => {
       gap: 2px;
       flex: 1;
       min-height: 0;
-      max-height: 180px;
       overflow-y: auto;
       overflow-x: hidden;
-    `,
-    sessionSectionResized: css`
-      max-height: none;
-
-      .workspace-session-list {
-        max-height: none;
-      }
     `,
     sessionRow: css`
       display: flex;


### PR DESCRIPTION
## Related issue

Closes #2260

## Summary

Replaces the custom Open Sessions resize handlers with the existing `react-split-pane` component already used elsewhere in Chat2DB. The sessions panel keeps a 220 px default height and remains bounded between 72 px and 420 px, while the standard divider provides a discoverable resize cursor and interaction.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `yarn eslint src/pages/main/workspace/components/WorkspaceExplorer/index.tsx src/pages/main/workspace/components/WorkspaceExplorer/style.ts` passed; `git diff origin/main...HEAD --check` passed.
- Manual verification: Verified in the Community desktop client against the local Web runtime. The requester tested the divider and confirmed the interaction works as expected.
- UI evidence: Manual JCEF verification completed; no separate image artifact attached.

## Risk and compatibility

- Public API or stored data: N/A; no API or storage changes.
- Database or driver compatibility: N/A; no database or driver changes.
- Network, privacy, or security: N/A; no network or trust-boundary changes.
- Community / Local / Pro boundary: Community frontend only.
- Backward compatibility: Preserves the existing default panel height and resize bounds while replacing the interaction implementation.

## Reviewer map

- Start here: `WorkspaceExplorer/index.tsx`, specifically the horizontal `SplitPane` around the local file tree and Open Sessions panel.
- Failure condition: The divider does not show the row-resize cursor, cannot resize smoothly, or allows the sessions panel outside the 72-420 px bounds.
- Rollback or disable path: Revert this commit to restore the previous custom pointer handlers and styles.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with implementation review, focused verification, and PR preparation.