### PR TITLE
feat(sql-editor): add output history retention option

### DIFF
--- a/chat2db-community-client/scripts/i18n-source-hashes.json
+++ b/chat2db-community-client/scripts/i18n-source-hashes.json
@@ -5,7 +5,7 @@
     "es-ES": {
       "ai.ts": "391a6e14c58d8401bf3bc245eca5bdd4b66efd8225a877bfbbcae01a1c1c019a",
       "chat.ts": "0cbe009eacbaa95a9a29bbc69588cb547e90b563667c53edec3e54ee64f5667b",
-      "common.ts": "9ae18f30c9bec0784fc6dca322c63dd440d4d3281e223dbddfd811685f63a7cd",
+      "common.ts": "1f70d1ba81aecbbd985a9dd9d1ae8b18ddfb3d209982a2ca17fbe3e4bf883a1f",
       "connection.ts": "41d07fd10c9550ae51995620cc998de5e99add35edb31c2bb592864c76c13688",
       "dashboard.ts": "b217bbe260c7674d4efad1dd1b61136653858884f5b9b2134cfdf7d1de5a44ee",
       "editTable.ts": "0f7a808f50053cd52b183d156bb4fd46bb125b8058f8774deb61c7f02894a350",
@@ -32,7 +32,7 @@
     "ko-KR": {
       "ai.ts": "391a6e14c58d8401bf3bc245eca5bdd4b66efd8225a877bfbbcae01a1c1c019a",
       "chat.ts": "0cbe009eacbaa95a9a29bbc69588cb547e90b563667c53edec3e54ee64f5667b",
-      "common.ts": "9ae18f30c9bec0784fc6dca322c63dd440d4d3281e223dbddfd811685f63a7cd",
+      "common.ts": "1f70d1ba81aecbbd985a9dd9d1ae8b18ddfb3d209982a2ca17fbe3e4bf883a1f",
       "connection.ts": "41d07fd10c9550ae51995620cc998de5e99add35edb31c2bb592864c76c13688",
       "dashboard.ts": "b217bbe260c7674d4efad1dd1b61136653858884f5b9b2134cfdf7d1de5a44ee",
       "editTable.ts": "0f7a808f50053cd52b183d156bb4fd46bb125b8058f8774deb61c7f02894a350",

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.test.ts
@@ -1,11 +1,15 @@
 import assert from 'node:assert/strict';
 import type { SqlExecutionLogRecord } from '@/service/sqlExecutionLog';
 import {
+  createExecutionConsoleKeepHistoryStorageKey,
   createExecutionConsoleOrderStorageKey,
   getLatestExecutionEdgeScrollTop,
   orderExecutionLogRecords,
+  persistExecutionConsoleKeepHistory,
   persistExecutionConsoleOrder,
+  readExecutionConsoleKeepHistory,
   readExecutionConsoleOrder,
+  subscribeExecutionConsoleKeepHistory,
 } from './executionConsolePreferences';
 
 function record(id: string, executionId: string, statementSequence: number): SqlExecutionLogRecord {
@@ -23,6 +27,7 @@ function record(id: string, executionId: string, statementSequence: number): Sql
 }
 
 const storageKey = createExecutionConsoleOrderStorageKey('community', 'community');
+const keepHistoryStorageKey = createExecutionConsoleKeepHistoryStorageKey('community', 'community');
 const values = new Map<string, string>();
 const storage = {
   getItem: (key: string) => values.get(key) ?? null,
@@ -32,6 +37,7 @@ const storage = {
 };
 
 assert.equal(storageKey, 'chat2db.community.community.execution-console.order.v1');
+assert.equal(keepHistoryStorageKey, 'chat2db.community.community.execution-console.keep-history.v1');
 assert.notEqual(
   storageKey,
   createExecutionConsoleOrderStorageKey('community', 'desktop'),
@@ -47,6 +53,35 @@ assert.equal(readExecutionConsoleOrder(storage, storageKey), 'newest-first');
 persistExecutionConsoleOrder(storage, storageKey, 'oldest-first');
 assert.equal(values.get(storageKey), 'oldest-first');
 
+assert.equal(readExecutionConsoleKeepHistory(undefined, keepHistoryStorageKey), true);
+assert.equal(readExecutionConsoleKeepHistory(storage, keepHistoryStorageKey), true);
+values.set(keepHistoryStorageKey, 'invalid');
+assert.equal(readExecutionConsoleKeepHistory(storage, keepHistoryStorageKey), true);
+values.set(keepHistoryStorageKey, 'false');
+assert.equal(readExecutionConsoleKeepHistory(storage, keepHistoryStorageKey), false);
+persistExecutionConsoleKeepHistory(storage, keepHistoryStorageKey, true);
+assert.equal(values.get(keepHistoryStorageKey), 'true');
+
+const keepHistoryUpdates: Array<[string, boolean]> = [];
+const secondKeepHistoryUpdates: Array<[string, boolean]> = [];
+const unsubscribeKeepHistory = subscribeExecutionConsoleKeepHistory((key, keepHistory) => {
+  keepHistoryUpdates.push([key, keepHistory]);
+});
+const unsubscribeSecondKeepHistory = subscribeExecutionConsoleKeepHistory((key, keepHistory) => {
+  secondKeepHistoryUpdates.push([key, keepHistory]);
+});
+persistExecutionConsoleKeepHistory(storage, keepHistoryStorageKey, false);
+assert.deepEqual(keepHistoryUpdates, [[keepHistoryStorageKey, false]]);
+assert.deepEqual(secondKeepHistoryUpdates, [[keepHistoryStorageKey, false]]);
+unsubscribeKeepHistory();
+persistExecutionConsoleKeepHistory(storage, keepHistoryStorageKey, true);
+assert.deepEqual(keepHistoryUpdates, [[keepHistoryStorageKey, false]], 'unsubscribed editors stop receiving updates');
+assert.deepEqual(secondKeepHistoryUpdates, [
+  [keepHistoryStorageKey, false],
+  [keepHistoryStorageKey, true],
+]);
+unsubscribeSecondKeepHistory();
+
 const unavailableStorage = {
   getItem: () => {
     throw new Error('unavailable');
@@ -57,6 +92,8 @@ const unavailableStorage = {
 };
 assert.equal(readExecutionConsoleOrder(unavailableStorage, storageKey), 'oldest-first');
 assert.doesNotThrow(() => persistExecutionConsoleOrder(unavailableStorage, storageKey, 'newest-first'));
+assert.equal(readExecutionConsoleKeepHistory(unavailableStorage, keepHistoryStorageKey), true);
+assert.doesNotThrow(() => persistExecutionConsoleKeepHistory(unavailableStorage, keepHistoryStorageKey, false));
 
 const records = [
   record('execution-1-statement-1', 'execution-1', 1),

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences.ts
@@ -7,10 +7,19 @@ interface ExecutionConsolePreferenceStorage {
   setItem(key: string, value: string): void;
 }
 
+type ExecutionConsoleKeepHistoryListener = (storageKey: string, keepHistory: boolean) => void;
+
 export const DEFAULT_EXECUTION_CONSOLE_ORDER: ExecutionConsoleOrder = 'oldest-first';
+export const DEFAULT_EXECUTION_CONSOLE_KEEP_HISTORY = true;
+
+const keepHistoryListeners = new Set<ExecutionConsoleKeepHistoryListener>();
 
 export function createExecutionConsoleOrderStorageKey(clientEdition: string, runtimeEnv: string) {
   return `chat2db.${clientEdition}.${runtimeEnv}.execution-console.order.v1`;
+}
+
+export function createExecutionConsoleKeepHistoryStorageKey(clientEdition: string, runtimeEnv: string) {
+  return `chat2db.${clientEdition}.${runtimeEnv}.execution-console.keep-history.v1`;
 }
 
 export function getExecutionConsolePreferenceStorage(): ExecutionConsolePreferenceStorage | undefined {
@@ -45,6 +54,38 @@ export function persistExecutionConsoleOrder(
   } catch {
     // Storage can be unavailable in restricted browser contexts.
   }
+}
+
+export function readExecutionConsoleKeepHistory(
+  storage: ExecutionConsolePreferenceStorage | undefined,
+  storageKey: string,
+) {
+  try {
+    const storedValue = storage?.getItem(storageKey);
+    return storedValue === 'false' ? false : DEFAULT_EXECUTION_CONSOLE_KEEP_HISTORY;
+  } catch {
+    return DEFAULT_EXECUTION_CONSOLE_KEEP_HISTORY;
+  }
+}
+
+export function persistExecutionConsoleKeepHistory(
+  storage: ExecutionConsolePreferenceStorage | undefined,
+  storageKey: string,
+  keepHistory: boolean,
+) {
+  try {
+    storage?.setItem(storageKey, String(keepHistory));
+  } catch {
+    // Storage can be unavailable in restricted browser contexts.
+  }
+  keepHistoryListeners.forEach((listener) => listener(storageKey, keepHistory));
+}
+
+export function subscribeExecutionConsoleKeepHistory(listener: ExecutionConsoleKeepHistoryListener) {
+  keepHistoryListeners.add(listener);
+  return () => {
+    keepHistoryListeners.delete(listener);
+  };
 }
 
 export function orderExecutionLogRecords(

--- a/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ExecutionConsole/index.tsx
@@ -31,12 +31,21 @@ const ORDER_STORAGE_KEY = createExecutionConsoleOrderStorageKey('community', __R
 
 interface IProps {
   records: SqlExecutionLogRecord[];
+  keepHistory: boolean;
   onClear: () => void;
+  onKeepHistoryChange: (keepHistory: boolean) => void;
   onOpenResult: (resultKey: string) => void;
   isResultAvailable: (resultKey: string) => boolean;
 }
 
-export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable }) => {
+export default memo<IProps>(({
+  records,
+  keepHistory,
+  onClear,
+  onKeepHistoryChange,
+  onOpenResult,
+  isResultAvailable,
+}) => {
   const {
     styles,
     theme: { appearance },
@@ -111,6 +120,8 @@ export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable
       onClear();
     } else if (key === 'follow') {
       handleToggleFollowLatest();
+    } else if (key === 'keep-history') {
+      onKeepHistoryChange(!keepHistory);
     } else if (key === 'toggle-order') {
       handleOrderChange(order === 'oldest-first' ? 'newest-first' : 'oldest-first');
     }
@@ -157,6 +168,11 @@ export default memo<IProps>(({ records, onClear, onOpenResult, isResultAvailable
                 <ArrowDownToLine size={14} />
               ),
               label: i18n('common.button.followConsole'),
+            },
+            {
+              key: 'keep-history',
+              icon: <Check opacity={keepHistory ? 1 : 0} size={14} />,
+              label: i18n('common.button.keepHistoryOutput'),
             },
             { type: 'divider' },
             { key: 'clear', icon: <Trash2 size={14} />, label: i18n('common.button.clearConsole'), danger: true },

--- a/chat2db-community-client/src/blocks/SearchResult/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/index.tsx
@@ -41,8 +41,10 @@ interface IProps {
   executionLogRecords?: SqlExecutionLogRecord[];
   resultBatchKey?: number;
   forceOutputTab?: boolean;
+  keepExecutionLogHistory?: boolean;
   viewTable?: boolean;
   onClearExecutionLog?: () => void;
+  onKeepExecutionLogHistoryChange?: (keepHistory: boolean) => void;
   onResultDataListChange?: (params: {
     resultDataList: IManageResultData[];
     historyResultDataList: IManageResultData[];
@@ -315,7 +317,9 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
       children: (
         <ExecutionConsole
           records={props.executionLogRecords || []}
+          keepHistory={props.keepExecutionLogHistory ?? true}
           onClear={props.onClearExecutionLog || (() => {})}
+          onKeepHistoryChange={props.onKeepExecutionLogHistoryChange || (() => {})}
           onOpenResult={handleOpenResult}
           isResultAvailable={isResultAvailable}
         />
@@ -325,7 +329,9 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
   }, [
     consoleMode,
     props.executionLogRecords,
+    props.keepExecutionLogHistory,
     props.onClearExecutionLog,
+    props.onKeepExecutionLogHistoryChange,
     handleOpenResult,
     isResultAvailable,
     styles.abstractIcon,

--- a/chat2db-community-client/src/hooks/useSqlExecutor.ts
+++ b/chat2db-community-client/src/hooks/useSqlExecutor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { IManageResultData, IExecuteSqlParams } from '@/typings';
 import executeSqlServer from '@/service/executeSql';
 import useAbortRequest from './useAbortRequest';
@@ -16,14 +16,16 @@ import { settingSelectors } from '@/store/global/selectors';
 interface IUseSqlExecutorProps {
   // Whether to return only one piece of data
   onlyOne?: boolean;
-  onExecutionEvent?: (event: SqlExecutionEvent) => void;
+  onExecutionRequestStart?: (requestSequence: number) => void;
+  onExecutionEvent?: (event: SqlExecutionEvent, requestSequence: number) => void;
 }
 
 const useSqlExecutor = (props?: IUseSqlExecutorProps) => {
-  const { onlyOne, onExecutionEvent } = props || {};
+  const { onlyOne, onExecutionRequestStart, onExecutionEvent } = props || {};
   const defaultPageSize = useGlobalStore((state) => settingSelectors.currentBaseSetting(state).defaultPageSize);
   const [executing, setExecuting] = useState(false);
   const [executionId, setExecutionId] = useState<string>();
+  const executionRequestSequenceRef = useRef(0);
   // interrupt request
   const [initSignal, abortRequest] = useAbortRequest();
 
@@ -45,11 +47,14 @@ const useSqlExecutor = (props?: IUseSqlExecutorProps) => {
     };
     if (isDesktop && onExecutionEvent) {
       const requestUuid = uuidv4();
+      const requestSequence = executionRequestSequenceRef.current + 1;
+      executionRequestSequenceRef.current = requestSequence;
+      onExecutionRequestStart?.(requestSequence);
       setExecuting(true);
       return new Promise((resolve, reject) => {
         const subscription: { unsubscribe?: () => void } = {};
         subscription.unsubscribe = onSqlExecutionEvent(requestUuid, (event) => {
-          onExecutionEvent(event);
+          onExecutionEvent(event, requestSequence);
           if (event.eventType === 'finished') {
             subscription.unsubscribe?.();
             setExecuting(false);
@@ -104,7 +109,7 @@ const useSqlExecutor = (props?: IUseSqlExecutorProps) => {
           setExecuting(false);
         });
     });
-  }, [defaultPageSize, onExecutionEvent]);
+  }, [defaultPageSize, onExecutionEvent, onExecutionRequestStart]);
 
   // Stop executing sql
   const stopExecuteSQL = useCallback(() => {

--- a/chat2db-community-client/src/hooks/useSqlExecutor.ts
+++ b/chat2db-community-client/src/hooks/useSqlExecutor.ts
@@ -12,6 +12,14 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { useGlobalStore } from '@/store/global';
 import { settingSelectors } from '@/store/global/selectors';
+import {
+  beginSqlExecutionRequest,
+  createSqlExecutionRequestTracker,
+  finishSqlExecutionRequest,
+  getActiveSqlExecutionId,
+  setSqlExecutionRequestId,
+  SqlExecutionRequestTracker,
+} from '@/service/sqlExecutionRequestTracker';
 
 interface IUseSqlExecutorProps {
   // Whether to return only one piece of data
@@ -24,8 +32,10 @@ const useSqlExecutor = (props?: IUseSqlExecutorProps) => {
   const { onlyOne, onExecutionRequestStart, onExecutionEvent } = props || {};
   const defaultPageSize = useGlobalStore((state) => settingSelectors.currentBaseSetting(state).defaultPageSize);
   const [executing, setExecuting] = useState(false);
-  const [executionId, setExecutionId] = useState<string>();
-  const executionRequestSequenceRef = useRef(0);
+  const executionRequestTrackerRef = useRef<SqlExecutionRequestTracker>();
+  if (!executionRequestTrackerRef.current) {
+    executionRequestTrackerRef.current = createSqlExecutionRequestTracker();
+  }
   // interrupt request
   const [initSignal, abortRequest] = useAbortRequest();
 
@@ -47,8 +57,8 @@ const useSqlExecutor = (props?: IUseSqlExecutorProps) => {
     };
     if (isDesktop && onExecutionEvent) {
       const requestUuid = uuidv4();
-      const requestSequence = executionRequestSequenceRef.current + 1;
-      executionRequestSequenceRef.current = requestSequence;
+      const executionRequestTracker = executionRequestTrackerRef.current;
+      const requestSequence = beginSqlExecutionRequest(executionRequestTracker);
       onExecutionRequestStart?.(requestSequence);
       setExecuting(true);
       return new Promise((resolve, reject) => {
@@ -57,14 +67,16 @@ const useSqlExecutor = (props?: IUseSqlExecutorProps) => {
           onExecutionEvent(event, requestSequence);
           if (event.eventType === 'finished') {
             subscription.unsubscribe?.();
-            setExecuting(false);
-            setExecutionId(undefined);
+            if (finishSqlExecutionRequest(executionRequestTracker, requestSequence)) {
+              setExecuting(false);
+            }
             resolve([]);
           }
           if (event.eventType === 'failed' || event.eventType === 'cancelled') {
             subscription.unsubscribe?.();
-            setExecuting(false);
-            setExecutionId(undefined);
+            if (finishSqlExecutionRequest(executionRequestTracker, requestSequence)) {
+              setExecuting(false);
+            }
             if (event.eventType === 'cancelled') {
               resolve([]);
             } else {
@@ -76,15 +88,19 @@ const useSqlExecutor = (props?: IUseSqlExecutorProps) => {
           .then((res) => {
             if (!res?.executionId) {
               subscription.unsubscribe?.();
-              setExecuting(false);
+              if (finishSqlExecutionRequest(executionRequestTracker, requestSequence)) {
+                setExecuting(false);
+              }
               reject(getStartExecutionError(res));
               return;
             }
-            setExecutionId(res.executionId);
+            setSqlExecutionRequestId(executionRequestTracker, requestSequence, res.executionId);
           })
           .catch((err) => {
             subscription.unsubscribe?.();
-            setExecuting(false);
+            if (finishSqlExecutionRequest(executionRequestTracker, requestSequence)) {
+              setExecuting(false);
+            }
             reject(err);
           });
       });
@@ -113,13 +129,14 @@ const useSqlExecutor = (props?: IUseSqlExecutorProps) => {
 
   // Stop executing sql
   const stopExecuteSQL = useCallback(() => {
-    if (isDesktop && executionId) {
-      cancelSqlExecution(executionId);
+    const activeExecutionId = getActiveSqlExecutionId(executionRequestTrackerRef.current!);
+    if (isDesktop && activeExecutionId) {
+      cancelSqlExecution(activeExecutionId);
       return;
     }
     abortRequest();
     setExecuting(false);
-  }, [abortRequest, executionId]);
+  }, [abortRequest]);
 
   return {
     executing,

--- a/chat2db-community-client/src/i18n/en-US/common.ts
+++ b/chat2db-community-client/src/i18n/en-US/common.ts
@@ -227,6 +227,7 @@ export default {
   'common.button.copyConsole': 'Copy output',
   'common.button.clearConsole': 'Clear output',
   'common.button.followConsole': 'Follow latest entry',
+  'common.button.keepHistoryOutput': 'Keep history output',
   'common.text.order': 'Order',
   'common.text.oldestFirst': 'Oldest first',
   'common.text.newestFirst': 'Newest first',

--- a/chat2db-community-client/src/i18n/es-ES/common.ts
+++ b/chat2db-community-client/src/i18n/es-ES/common.ts
@@ -264,6 +264,7 @@ export default {
   'common.button.copyConsole': 'Copiar salida',
   'common.button.clearConsole': 'Limpiar salida',
   'common.button.followConsole': 'Seguir la última entrada',
+  'common.button.keepHistoryOutput': 'Conservar el historial de salida',
   'common.text.order': 'Orden',
   'common.text.oldestFirst': 'Antiguos primero',
   'common.text.newestFirst': 'Nuevos primero',

--- a/chat2db-community-client/src/i18n/ja-JP/common.ts
+++ b/chat2db-community-client/src/i18n/ja-JP/common.ts
@@ -227,6 +227,7 @@ export default {
   'common.button.copyConsole': '出力をコピー',
   'common.button.clearConsole': '出力をクリア',
   'common.button.followConsole': '最新のログを追従',
+  'common.button.keepHistoryOutput': '出力履歴を保持',
   'common.text.order': '並び順',
   'common.text.oldestFirst': '古い順',
   'common.text.newestFirst': '新しい順',

--- a/chat2db-community-client/src/i18n/ko-KR/common.ts
+++ b/chat2db-community-client/src/i18n/ko-KR/common.ts
@@ -264,6 +264,7 @@ export default {
   'common.button.copyConsole': '출력 복사',
   'common.button.clearConsole': '출력 지우기',
   'common.button.followConsole': '최신 로그 따라가기',
+  'common.button.keepHistoryOutput': '출력 기록 유지',
   'common.text.order': '정렬',
   'common.text.oldestFirst': '오래된 순',
   'common.text.newestFirst': '최신 순',

--- a/chat2db-community-client/src/i18n/zh-CN/common.ts
+++ b/chat2db-community-client/src/i18n/zh-CN/common.ts
@@ -225,6 +225,7 @@ export default {
   'common.button.copyConsole': '复制输出',
   'common.button.clearConsole': '清空输出',
   'common.button.followConsole': '跟随最新日志',
+  'common.button.keepHistoryOutput': '保留历史输出',
   'common.text.order': '排序规则',
   'common.text.oldestFirst': '最早优先',
   'common.text.newestFirst': '最新优先',

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
@@ -10,6 +10,13 @@ import {
   useImperativeHandle,
 } from 'react';
 import SearchResult from '@/blocks/SearchResult';
+import {
+  createExecutionConsoleKeepHistoryStorageKey,
+  getExecutionConsolePreferenceStorage,
+  persistExecutionConsoleKeepHistory,
+  readExecutionConsoleKeepHistory,
+  subscribeExecutionConsoleKeepHistory,
+} from '@/blocks/SearchResult/components/ExecutionConsole/executionConsolePreferences';
 import { useWorkspaceStore } from '@/store/workspace';
 import { IConsoleReturnExecuteSql, IBoundInfo, IDatabaseBaseInfo, IManageResultData } from '@/typings';
 import { Spin } from 'antd';
@@ -41,7 +48,9 @@ import {
   completeWebSqlExecution,
   createSqlExecutionLogState,
   failWebSqlExecution,
-  reduceDesktopSqlExecutionEvent,
+  prepareDesktopSqlExecutionLogForRequest,
+  prepareSqlExecutionLogForExecution,
+  reduceDesktopSqlExecutionEventWithHistoryPreference,
   rethrowNonCancellationSqlExecutionError,
   SqlExecutionLogContext,
 } from '@/service/sqlExecutionLog';
@@ -50,6 +59,10 @@ import { v4 as uuidv4 } from 'uuid';
 
 const SplitPaneAny = SplitPane as any;
 const HISTORY_RESULT_LIMIT = 30;
+const KEEP_EXECUTION_LOG_HISTORY_STORAGE_KEY = createExecutionConsoleKeepHistoryStorageKey(
+  'community',
+  __RUNTIME_ENV__,
+);
 
 interface IProps {
   boundInfo: IBoundInfo;
@@ -190,6 +203,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
   const editorId = boundInfo.workspaceTabId ?? boundInfo.consoleId;
   const [boxRightConsoleHeight, setBoxRightConsoleHeight] = useState<number | string>(0);
   const executionSequenceRef = useRef(0);
+  const desktopReplacementRequestSequenceRef = useRef(0);
   const executionSequenceByIdRef = useRef<Record<string, number>>({});
   const statementSequenceRef = useRef(0);
   const statementSqlCountsRef = useRef<Record<string, number>>({});
@@ -210,7 +224,30 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
   const [historyResultDataList, setHistoryResultDataList] = useState<IManageResultData[]>([]);
   const historyResultDataListRef = useRef<IManageResultData[]>([]);
   const [sqlExecutionLogState, setSqlExecutionLogState] = useState(createSqlExecutionLogState);
+  const [keepExecutionLogHistory, setKeepExecutionLogHistory] = useState(() =>
+    readExecutionConsoleKeepHistory(
+      getExecutionConsolePreferenceStorage(),
+      KEEP_EXECUTION_LOG_HISTORY_STORAGE_KEY,
+    ),
+  );
   const handleClearExecutionLog = useCallback(() => setSqlExecutionLogState(clearSqlExecutionLog), []);
+  const handleKeepExecutionLogHistoryChange = useCallback((keepHistory: boolean) => {
+    setKeepExecutionLogHistory(keepHistory);
+    persistExecutionConsoleKeepHistory(
+      getExecutionConsolePreferenceStorage(),
+      KEEP_EXECUTION_LOG_HISTORY_STORAGE_KEY,
+      keepHistory,
+    );
+  }, []);
+  useEffect(
+    () =>
+      subscribeExecutionConsoleKeepHistory((storageKey, keepHistory) => {
+        if (storageKey === KEEP_EXECUTION_LOG_HISTORY_STORAGE_KEY) {
+          setKeepExecutionLogHistory(keepHistory);
+        }
+      }),
+    [],
+  );
   const archivedForExecutionRef = useRef(false);
   const executionSnapshotRef = useRef<{
     resultDataList: IManageResultData[];
@@ -271,10 +308,30 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
     archiveCurrentResultDataList();
     resetCurrentExecutionState(false);
   }, [archiveCurrentResultDataList, resetCurrentExecutionState]);
-  const handleSqlExecutionEvent = useCallback(
-    (event: SqlExecutionEvent) => {
+  const handleSqlExecutionRequestStart = useCallback(
+    (requestSequence: number) => {
+      if (!keepExecutionLogHistory) {
+        desktopReplacementRequestSequenceRef.current = requestSequence;
+      }
       setSqlExecutionLogState((state) =>
-        reduceDesktopSqlExecutionEvent(state, event, getExecutionLogContext(boundInfoRef.current)),
+        prepareDesktopSqlExecutionLogForRequest(state, requestSequence, keepExecutionLogHistory),
+      );
+    },
+    [keepExecutionLogHistory],
+  );
+  const handleSqlExecutionEvent = useCallback(
+    (event: SqlExecutionEvent, requestSequence: number) => {
+      if (requestSequence < desktopReplacementRequestSequenceRef.current) {
+        return;
+      }
+      setSqlExecutionLogState((state) =>
+        reduceDesktopSqlExecutionEventWithHistoryPreference(
+          state,
+          event,
+          getExecutionLogContext(boundInfoRef.current),
+          keepExecutionLogHistory,
+          requestSequence,
+        ),
       );
       // Execution always replaces the previous result; use View History to inspect older results.
       const shouldOverwriteResultTabs = true;
@@ -423,9 +480,18 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
         return;
       }
     },
-    [archiveCurrentResultDataList, getExecutionSequence, handleRefreshTreeByExecuteSQL, resetCurrentExecutionState],
+    [
+      archiveCurrentResultDataList,
+      getExecutionSequence,
+      handleRefreshTreeByExecuteSQL,
+      keepExecutionLogHistory,
+      resetCurrentExecutionState,
+    ],
   );
-  const { executing, executeSQL, stopExecuteSQL } = useSqlExecutor({ onExecutionEvent: handleSqlExecutionEvent });
+  const { executing, executeSQL, stopExecuteSQL } = useSqlExecutor({
+    onExecutionRequestStart: handleSqlExecutionRequestStart,
+    onExecutionEvent: handleSqlExecutionEvent,
+  });
 
   // Whether to show the split panel.
   const isSplitPane = useMemo(() => {
@@ -527,11 +593,14 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
     const executionLogContext = getExecutionLogContext(boundInfo);
     if (webExecutionId) {
       setSqlExecutionLogState((state) =>
-        beginWebSqlExecution(state, {
-          executionId: webExecutionId,
-          sql: params.sql,
-          context: executionLogContext,
-        }),
+        beginWebSqlExecution(
+          prepareSqlExecutionLogForExecution(state, webExecutionId, keepExecutionLogHistory),
+          {
+            executionId: webExecutionId,
+            sql: params.sql,
+            context: executionLogContext,
+          },
+        ),
       );
     }
 
@@ -691,9 +760,11 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
                 resultDataList={resultDataList}
                 historyResultDataList={historyResultDataList}
                 executionLogRecords={sqlExecutionLogState.records}
+                keepExecutionLogHistory={keepExecutionLogHistory}
                 resultBatchKey={resultBatchKey}
                 forceOutputTab={forceOutputTab}
                 onClearExecutionLog={handleClearExecutionLog}
+                onKeepExecutionLogHistoryChange={handleKeepExecutionLogHistoryChange}
                 onResultDataListChange={handleResultDataListChange}
               />
             )}

--- a/chat2db-community-client/src/service/sqlExecutionLog.test.ts
+++ b/chat2db-community-client/src/service/sqlExecutionLog.test.ts
@@ -63,6 +63,12 @@ function result(overrides: Partial<IManageResultData> = {}): IManageResultData {
   assert.equal(getActiveSqlExecutionId(tracker), 'desktop-new', 'a late old start response is ignored');
   assert.equal(finishSqlExecutionRequest(tracker, newRequest), true);
   assert.equal(getActiveSqlExecutionId(tracker), undefined);
+  assert.equal(setSqlExecutionRequestId(tracker, newRequest, 'desktop-new-late'), false);
+  assert.equal(
+    getActiveSqlExecutionId(tracker),
+    undefined,
+    'a start response arriving after its terminal event cannot restore the cancel target',
+  );
 }
 
 function rawExecutionContext(value: Record<string, unknown>) {

--- a/chat2db-community-client/src/service/sqlExecutionLog.test.ts
+++ b/chat2db-community-client/src/service/sqlExecutionLog.test.ts
@@ -9,7 +9,10 @@ import {
   createSqlExecutionLogState,
   failWebSqlExecution,
   isSqlExecutionCancellationError,
+  prepareDesktopSqlExecutionLogForRequest,
+  prepareSqlExecutionLogForExecution,
   reduceDesktopSqlExecutionEvent,
+  reduceDesktopSqlExecutionEventWithHistoryPreference,
   rethrowNonCancellationSqlExecutionError,
 } from './sqlExecutionLog';
 
@@ -70,6 +73,89 @@ function webExecution() {
     results: [],
   });
   assert.equal(clearSqlExecutionLog(completed).records.length, 0);
+}
+
+{
+  const completed = completeWebSqlExecution(webExecution(), {
+    executionId: 'web-1',
+    sql: 'select 1',
+    context,
+    occurredAtEpochMs: 110,
+    results: [],
+  });
+  const state = beginWebSqlExecution(completed, {
+    executionId: 'web-2',
+    sql: 'select 2',
+    context,
+    occurredAtEpochMs: 120,
+  });
+  assert.deepEqual(
+    prepareSqlExecutionLogForExecution(state, 'web-3', true).records.map((record) => record.executionId),
+    ['web-1', 'web-2'],
+    'keep-history mode does not remove existing executions',
+  );
+  const replacement = beginWebSqlExecution(prepareSqlExecutionLogForExecution(state, 'web-3', false), {
+    executionId: 'web-3',
+    sql: 'select 3',
+    context,
+    occurredAtEpochMs: 130,
+  });
+  assert.deepEqual(
+    replacement.records.map((record) => record.executionId),
+    ['web-3'],
+    'replace mode keeps only the latest execution, including while older executions are running',
+  );
+  assert.equal(
+    completeWebSqlExecution(replacement, {
+      executionId: 'web-2',
+      sql: 'select 2',
+      context,
+      occurredAtEpochMs: 140,
+      results: [result()],
+    }),
+    replacement,
+    'a superseded execution cannot reappear when it completes later',
+  );
+  const appendMode = prepareSqlExecutionLogForExecution(replacement, 'web-4', true);
+  assert.equal(appendMode.replacementExecutionId, undefined);
+  assert.deepEqual(appendMode.supersededExecutionIds, ['web-2']);
+  assert.deepEqual(appendMode.records.map((record) => record.executionId), ['web-3']);
+  assert.equal(
+    completeWebSqlExecution(appendMode, {
+      executionId: 'web-2',
+      sql: 'select 2',
+      context,
+      occurredAtEpochMs: 150,
+      results: [result()],
+    }),
+    appendMode,
+    'switching back to keep-history mode does not revive an execution replaced while it was running',
+  );
+  const cleared = clearSqlExecutionLog(replacement);
+  assert.equal(
+    completeWebSqlExecution(cleared, {
+      executionId: 'web-2',
+      sql: 'select 2',
+      context,
+      occurredAtEpochMs: 160,
+      results: [result()],
+    }),
+    cleared,
+    'clearing output keeps the superseded-execution guard',
+  );
+
+  const boundedSupersededExecutions = prepareSqlExecutionLogForExecution(
+    {
+      records: [],
+      activeExecutionIds: ['running-old'],
+      supersededExecutionIds: Array.from({ length: 200 }, (_, index) => `superseded-${index}`),
+    },
+    'web-new',
+    false,
+  );
+  assert.equal(boundedSupersededExecutions.supersededExecutionIds?.length, 200);
+  assert.equal(boundedSupersededExecutions.supersededExecutionIds?.includes('superseded-0'), false);
+  assert.equal(boundedSupersededExecutions.supersededExecutionIds?.includes('running-old'), true);
 }
 
 {
@@ -189,6 +275,101 @@ function webExecution() {
   });
   assert.equal(state.records[0].status, 'cancelled');
   assert.equal(state.records[0].outputs.length, 0);
+}
+
+{
+  let state = prepareDesktopSqlExecutionLogForRequest(createSqlExecutionLogState(), 1, false);
+  state = prepareDesktopSqlExecutionLogForRequest(state, 2, false);
+  state = reduceDesktopSqlExecutionEventWithHistoryPreference(
+    state,
+    {
+      executionId: 'desktop-new',
+      eventSequence: 1,
+      occurredAtEpochMs: 175,
+      eventType: 'failed',
+      message: { message: 'new request failed' },
+    },
+    context,
+    false,
+    2,
+  );
+  assert.deepEqual(state.records.map((record) => record.executionId), ['desktop-new']);
+  const afterLateFirstEvent = reduceDesktopSqlExecutionEventWithHistoryPreference(
+    state,
+    {
+      executionId: 'desktop-old-late',
+      eventSequence: 1,
+      occurredAtEpochMs: 180,
+      eventType: 'failed',
+      message: { message: 'old request failed late' },
+    },
+    context,
+    false,
+    1,
+  );
+  assert.equal(
+    afterLateFirstEvent,
+    state,
+    'an older Desktop request cannot replace a newer request when its first event arrives late',
+  );
+}
+
+{
+  let state = reduceDesktopSqlExecutionEventWithHistoryPreference(
+    createSqlExecutionLogState(),
+    {
+      executionId: 'desktop-old',
+      eventSequence: 1,
+      occurredAtEpochMs: 180,
+      eventType: 'started',
+      message: {},
+    },
+    context,
+    false,
+  );
+  state = reduceDesktopSqlExecutionEventWithHistoryPreference(
+    state,
+    {
+      executionId: 'desktop-failed',
+      eventSequence: 1,
+      occurredAtEpochMs: 190,
+      eventType: 'failed',
+      message: { message: 'connection binding failed' },
+    },
+    context,
+    false,
+  );
+  assert.deepEqual(state.records.map((record) => record.executionId), ['desktop-failed']);
+  assert.equal(state.records[0].status, 'failed');
+  assert.deepEqual(state.supersededExecutionIds, ['desktop-old']);
+  const afterLateFailure = reduceDesktopSqlExecutionEventWithHistoryPreference(
+    state,
+    {
+      executionId: 'desktop-old',
+      eventSequence: 2,
+      occurredAtEpochMs: 195,
+      eventType: 'failed',
+      message: { message: 'late failure' },
+    },
+    context,
+    true,
+  );
+  assert.equal(afterLateFailure, state, 'a superseded Desktop execution cannot reclaim replace mode');
+
+  const cancelled = reduceDesktopSqlExecutionEventWithHistoryPreference(
+    state,
+    {
+      executionId: 'desktop-cancelled',
+      eventSequence: 1,
+      occurredAtEpochMs: 200,
+      eventType: 'cancelled',
+      message: {},
+    },
+    context,
+    false,
+  );
+  assert.deepEqual(cancelled.records.map((record) => record.executionId), ['desktop-cancelled']);
+  assert.equal(cancelled.records[0].status, 'cancelled');
 }
 
 {

--- a/chat2db-community-client/src/service/sqlExecutionLog.test.ts
+++ b/chat2db-community-client/src/service/sqlExecutionLog.test.ts
@@ -3,6 +3,13 @@ import { TableDataType } from '@/constants/table';
 import type { IManageResultData } from '@/typings';
 import { SqlTypeEnum } from '@/typings/sqlParser';
 import {
+  beginSqlExecutionRequest,
+  createSqlExecutionRequestTracker,
+  finishSqlExecutionRequest,
+  getActiveSqlExecutionId,
+  setSqlExecutionRequestId,
+} from './sqlExecutionRequestTracker';
+import {
   beginWebSqlExecution,
   clearSqlExecutionLog,
   completeWebSqlExecution,
@@ -39,6 +46,23 @@ function result(overrides: Partial<IManageResultData> = {}): IManageResultData {
     hasNextPage: false,
     ...overrides,
   };
+}
+
+{
+  const tracker = createSqlExecutionRequestTracker();
+  const oldRequest = beginSqlExecutionRequest(tracker);
+  assert.equal(setSqlExecutionRequestId(tracker, oldRequest, 'desktop-old'), true);
+  assert.equal(getActiveSqlExecutionId(tracker), 'desktop-old');
+
+  const newRequest = beginSqlExecutionRequest(tracker);
+  assert.equal(getActiveSqlExecutionId(tracker), undefined, 'a new request cannot cancel the previous execution');
+  assert.equal(setSqlExecutionRequestId(tracker, newRequest, 'desktop-new'), true);
+  assert.equal(finishSqlExecutionRequest(tracker, oldRequest), false);
+  assert.equal(getActiveSqlExecutionId(tracker), 'desktop-new', 'a late old terminal event keeps the new cancel target');
+  assert.equal(setSqlExecutionRequestId(tracker, oldRequest, 'desktop-old-late'), false);
+  assert.equal(getActiveSqlExecutionId(tracker), 'desktop-new', 'a late old start response is ignored');
+  assert.equal(finishSqlExecutionRequest(tracker, newRequest), true);
+  assert.equal(getActiveSqlExecutionId(tracker), undefined);
 }
 
 function rawExecutionContext(value: Record<string, unknown>) {
@@ -311,6 +335,42 @@ function webExecution() {
     afterLateFirstEvent,
     state,
     'an older Desktop request cannot replace a newer request when its first event arrives late',
+  );
+}
+
+{
+  let state = prepareDesktopSqlExecutionLogForRequest(createSqlExecutionLogState(), 1, false);
+  state = prepareDesktopSqlExecutionLogForRequest(state, 2, true);
+  state = reduceDesktopSqlExecutionEventWithHistoryPreference(
+    state,
+    {
+      executionId: 'desktop-new-kept',
+      eventSequence: 1,
+      occurredAtEpochMs: 181,
+      eventType: 'failed',
+      message: { message: 'new request failed' },
+    },
+    context,
+    true,
+    2,
+  );
+  state = reduceDesktopSqlExecutionEventWithHistoryPreference(
+    state,
+    {
+      executionId: 'desktop-old-kept',
+      eventSequence: 1,
+      occurredAtEpochMs: 182,
+      eventType: 'failed',
+      message: { message: 'old request completed late' },
+    },
+    context,
+    false,
+    1,
+  );
+  assert.deepEqual(
+    state.records.map((record) => record.executionId),
+    ['desktop-new-kept', 'desktop-old-kept'],
+    'switching to keep-history mode prevents an older request from clearing the newer output',
   );
 }
 

--- a/chat2db-community-client/src/service/sqlExecutionLog.ts
+++ b/chat2db-community-client/src/service/sqlExecutionLog.ts
@@ -56,6 +56,10 @@ export interface SqlExecutionLogRecord {
 
 export interface SqlExecutionLogState {
   records: SqlExecutionLogRecord[];
+  activeExecutionIds?: string[];
+  replacementExecutionId?: string;
+  replacementRequestSequence?: number;
+  supersededExecutionIds?: string[];
 }
 
 export interface BeginWebSqlExecutionParams {
@@ -74,6 +78,7 @@ export interface FailWebSqlExecutionParams extends BeginWebSqlExecutionParams {
 }
 
 const MAX_RECORDS = 200;
+const MAX_SUPERSEDED_EXECUTIONS = MAX_RECORDS;
 const MAX_OUTPUTS_PER_RECORD = 200;
 const MAX_MESSAGE_LENGTH = 8_192;
 const MESSAGE_TRUNCATION_MARKER = '\n...[truncated]...\n';
@@ -84,9 +89,78 @@ export function createSqlExecutionLogState(): SqlExecutionLogState {
 
 export function clearSqlExecutionLog(state: SqlExecutionLogState): SqlExecutionLogState {
   return {
+    ...state,
     records: state.records
       .filter((record) => record.status === 'running')
       .map((record) => ({ ...record, outputs: [] })),
+  };
+}
+
+export function prepareSqlExecutionLogForExecution(
+  state: SqlExecutionLogState,
+  executionId: string,
+  keepHistory: boolean,
+): SqlExecutionLogState {
+  if (state.supersededExecutionIds?.includes(executionId)) {
+    return state;
+  }
+  const activeExecutionIds = addExecutionId(state.activeExecutionIds, executionId);
+  if (keepHistory) {
+    if (activeExecutionIds === state.activeExecutionIds && !state.replacementExecutionId) {
+      return state;
+    }
+    return {
+      ...state,
+      activeExecutionIds,
+      replacementExecutionId: undefined,
+    };
+  }
+  if (state.replacementExecutionId === executionId) {
+    return activeExecutionIds === state.activeExecutionIds ? state : { ...state, activeExecutionIds };
+  }
+  const supersededExecutionIds = Array.from(
+    new Set([
+      ...(state.supersededExecutionIds || []),
+      ...(state.activeExecutionIds || []).filter((activeExecutionId) => activeExecutionId !== executionId),
+      ...state.records
+        .filter((record) => record.status === 'running' && record.executionId !== executionId)
+        .map((record) => record.executionId),
+    ]),
+  ).slice(-MAX_SUPERSEDED_EXECUTIONS);
+  return {
+    ...state,
+    records: state.records.filter((record) => record.executionId === executionId),
+    activeExecutionIds: [executionId],
+    replacementExecutionId: executionId,
+    supersededExecutionIds,
+  };
+}
+
+export function prepareDesktopSqlExecutionLogForRequest(
+  state: SqlExecutionLogState,
+  requestSequence: number,
+  keepHistory: boolean,
+): SqlExecutionLogState {
+  if (keepHistory) {
+    return state.replacementExecutionId ? { ...state, replacementExecutionId: undefined } : state;
+  }
+  if ((state.replacementRequestSequence ?? 0) >= requestSequence) {
+    return state;
+  }
+  const supersededExecutionIds = Array.from(
+    new Set([
+      ...(state.supersededExecutionIds || []),
+      ...(state.activeExecutionIds || []),
+      ...state.records.filter((record) => record.status === 'running').map((record) => record.executionId),
+    ]),
+  ).slice(-MAX_SUPERSEDED_EXECUTIONS);
+  return {
+    ...state,
+    records: [],
+    activeExecutionIds: undefined,
+    replacementExecutionId: undefined,
+    replacementRequestSequence: requestSequence,
+    supersededExecutionIds,
   };
 }
 
@@ -94,10 +168,12 @@ export function beginWebSqlExecution(
   state: SqlExecutionLogState,
   params: BeginWebSqlExecutionParams,
 ): SqlExecutionLogState {
-  if (state.records.some((record) => record.executionId === params.executionId)) return state;
+  if (isSupersededExecution(state, params.executionId)) return state;
+  const trackedState = trackActiveExecution(state, params.executionId);
+  if (trackedState.records.some((record) => record.executionId === params.executionId)) return trackedState;
   const startedAtEpochMs = params.occurredAtEpochMs ?? Date.now();
-  return setRecords(state, [
-    ...state.records,
+  return setRecords(trackedState, [
+    ...trackedState.records,
     createRecord({ ...params, statementSequence: 1, startedAtEpochMs, temporary: true }),
   ]);
 }
@@ -106,16 +182,20 @@ export function completeWebSqlExecution(
   state: SqlExecutionLogState,
   params: CompleteWebSqlExecutionParams,
 ): SqlExecutionLogState {
+  if (isSupersededExecution(state, params.executionId)) return state;
   const completedAt = params.occurredAtEpochMs ?? Date.now();
   const temporary = state.records.find((record) => record.executionId === params.executionId && record.temporary);
   if (!params.results.length) {
-    return updateRecord(state, temporary?.id, (record) => ({
-      ...record,
-      temporary: false,
-      status: 'success',
-      finishedAtEpochMs: completedAt,
-      durationMs: Math.max(0, completedAt - record.startedAtEpochMs),
-    }));
+    return finishActiveExecution(
+      updateRecord(state, temporary?.id, (record) => ({
+        ...record,
+        temporary: false,
+        status: 'success',
+        finishedAtEpochMs: completedAt,
+        durationMs: Math.max(0, completedAt - record.startedAtEpochMs),
+      })),
+      params.executionId,
+    );
   }
 
   const groups = new Map<number, IManageResultData[]>();
@@ -160,16 +240,20 @@ export function completeWebSqlExecution(
     };
   });
 
-  return setRecords(state, [
-    ...state.records.filter((record) => record.id !== temporary?.id),
-    ...replacement,
-  ]);
+  return finishActiveExecution(
+    setRecords(state, [
+      ...state.records.filter((record) => record.id !== temporary?.id),
+      ...replacement,
+    ]),
+    params.executionId,
+  );
 }
 
 export function failWebSqlExecution(
   state: SqlExecutionLogState,
   params: FailWebSqlExecutionParams,
 ): SqlExecutionLogState {
+  if (isSupersededExecution(state, params.executionId)) return state;
   const finishedAtEpochMs = params.occurredAtEpochMs ?? Date.now();
   const cancelled = isSqlExecutionCancellationError(params.error);
   const existing = latestRecord(state.records, params.executionId);
@@ -185,21 +269,48 @@ export function failWebSqlExecution(
       finishedAtEpochMs,
       durationMs: 0,
     };
-    return setRecords(state, [
-      ...state.records,
-      cancelled ? finishedRecord : addError(finishedRecord, params.error, finishedAtEpochMs),
-    ]);
+    return finishActiveExecution(
+      setRecords(state, [
+        ...state.records,
+        cancelled ? finishedRecord : addError(finishedRecord, params.error, finishedAtEpochMs),
+      ]),
+      params.executionId,
+    );
   }
-  return updateRecord(state, existing.id, (record) => {
-    const finishedRecord = {
-      ...record,
-      temporary: false,
-      status: cancelled ? ('cancelled' as const) : ('failed' as const),
-      finishedAtEpochMs,
-      durationMs: Math.max(0, finishedAtEpochMs - record.startedAtEpochMs),
-    };
-    return cancelled ? finishedRecord : addError(finishedRecord, params.error, finishedAtEpochMs);
-  });
+  return finishActiveExecution(
+    updateRecord(state, existing.id, (record) => {
+      const finishedRecord = {
+        ...record,
+        temporary: false,
+        status: cancelled ? ('cancelled' as const) : ('failed' as const),
+        finishedAtEpochMs,
+        durationMs: Math.max(0, finishedAtEpochMs - record.startedAtEpochMs),
+      };
+      return cancelled ? finishedRecord : addError(finishedRecord, params.error, finishedAtEpochMs);
+    }),
+    params.executionId,
+  );
+}
+
+export function reduceDesktopSqlExecutionEventWithHistoryPreference(
+  state: SqlExecutionLogState,
+  event: SqlExecutionEvent,
+  context: SqlExecutionLogContext,
+  keepHistory: boolean,
+  requestSequence?: number,
+): SqlExecutionLogState {
+  if (
+    requestSequence !== undefined &&
+    state.replacementRequestSequence !== undefined &&
+    requestSequence < state.replacementRequestSequence
+  ) {
+    return state;
+  }
+  const preparedState =
+    event.eventType === 'started' || !isSqlExecutionTracked(state, event.executionId)
+      ? prepareSqlExecutionLogForExecution(state, event.executionId, keepHistory)
+      : state;
+  return reduceDesktopSqlExecutionEvent(preparedState, event, context);
 }
 
 export function reduceDesktopSqlExecutionEvent(
@@ -207,15 +318,17 @@ export function reduceDesktopSqlExecutionEvent(
   event: SqlExecutionEvent,
   context: SqlExecutionLogContext,
 ): SqlExecutionLogState {
+  if (isSupersededExecution(state, event.executionId)) return state;
+  const trackedState = trackActiveExecution(state, event.executionId);
   const occurredAt = event.occurredAtEpochMs ?? Date.now();
   const statementSequence = event.statementSequence ?? 1;
   const recordId = idFor(event.executionId, statementSequence);
 
-  if (event.eventType === 'started') return state;
+  if (event.eventType === 'started') return trackedState;
   if (event.eventType === 'statementStarted') {
-    if (state.records.some((record) => record.id === recordId)) return state;
-    return setRecords(state, [
-      ...state.records,
+    if (trackedState.records.some((record) => record.id === recordId)) return trackedState;
+    return setRecords(trackedState, [
+      ...trackedState.records,
       createRecord({
         executionId: event.executionId,
         statementSequence,
@@ -229,8 +342,9 @@ export function reduceDesktopSqlExecutionEvent(
 
   const target =
     (event.statementSequence === undefined
-      ? latestRecord(state.records, event.executionId)
-      : state.records.find((record) => record.id === recordId)) || latestRecord(state.records, event.executionId);
+      ? latestRecord(trackedState.records, event.executionId)
+      : trackedState.records.find((record) => record.id === recordId)) ||
+    latestRecord(trackedState.records, event.executionId);
   if (!target && (event.eventType === 'failed' || event.eventType === 'cancelled')) {
     const record = createRecord({
       executionId: event.executionId,
@@ -239,11 +353,16 @@ export function reduceDesktopSqlExecutionEvent(
       context,
       startedAtEpochMs: occurredAt,
     });
-    return setRecords(state, [...state.records, finishTerminal(record, event, occurredAt)]);
+    return finishActiveExecution(
+      setRecords(trackedState, [...trackedState.records, finishTerminal(record, event, occurredAt)]),
+      event.executionId,
+    );
   }
-  if (!target) return state;
+  if (!target) {
+    return event.eventType === 'finished' ? finishActiveExecution(trackedState, event.executionId) : trackedState;
+  }
 
-  return updateRecord(state, target.id, (record) => {
+  const nextState = updateRecord(trackedState, target.id, (record) => {
     switch (event.eventType) {
       case 'resultStarted':
         return {
@@ -312,6 +431,9 @@ export function reduceDesktopSqlExecutionEvent(
         return record;
     }
   });
+  return event.eventType === 'finished' || event.eventType === 'failed' || event.eventType === 'cancelled'
+    ? finishActiveExecution(nextState, event.executionId)
+    : nextState;
 }
 
 function mergeExecutionContext(
@@ -549,7 +671,7 @@ function updateRecord(
 }
 
 function setRecords(state: SqlExecutionLogState, records: SqlExecutionLogRecord[]): SqlExecutionLogState {
-  if (records.length <= MAX_RECORDS) return { records };
+  if (records.length <= MAX_RECORDS) return { ...state, records };
   let overflow = records.length - MAX_RECORDS;
   const next = records.filter((record) => {
     if (overflow > 0 && record.status !== 'running') {
@@ -558,7 +680,41 @@ function setRecords(state: SqlExecutionLogState, records: SqlExecutionLogRecord[
     }
     return true;
   });
-  return { records: next };
+  return { ...state, records: next };
+}
+
+function isSupersededExecution(state: SqlExecutionLogState, executionId: string) {
+  return (
+    !!state.supersededExecutionIds?.includes(executionId) ||
+    (!!state.replacementExecutionId && state.replacementExecutionId !== executionId)
+  );
+}
+
+function isSqlExecutionTracked(state: SqlExecutionLogState, executionId: string) {
+  return (
+    state.replacementExecutionId === executionId ||
+    !!state.activeExecutionIds?.includes(executionId) ||
+    !!state.supersededExecutionIds?.includes(executionId) ||
+    state.records.some((record) => record.executionId === executionId)
+  );
+}
+
+function trackActiveExecution(state: SqlExecutionLogState, executionId: string): SqlExecutionLogState {
+  const activeExecutionIds = addExecutionId(state.activeExecutionIds, executionId);
+  return activeExecutionIds === state.activeExecutionIds ? state : { ...state, activeExecutionIds };
+}
+
+function finishActiveExecution(state: SqlExecutionLogState, executionId: string): SqlExecutionLogState {
+  if (!state.activeExecutionIds?.includes(executionId)) return state;
+  const activeExecutionIds = state.activeExecutionIds.filter((activeExecutionId) => activeExecutionId !== executionId);
+  return {
+    ...state,
+    activeExecutionIds: activeExecutionIds.length ? activeExecutionIds : undefined,
+  };
+}
+
+function addExecutionId(executionIds: string[] | undefined, executionId: string) {
+  return executionIds?.includes(executionId) ? executionIds : [...(executionIds || []), executionId];
 }
 
 function latestRecord(records: SqlExecutionLogRecord[], executionId: string) {

--- a/chat2db-community-client/src/service/sqlExecutionLog.ts
+++ b/chat2db-community-client/src/service/sqlExecutionLog.ts
@@ -306,6 +306,9 @@ export function reduceDesktopSqlExecutionEventWithHistoryPreference(
   ) {
     return state;
   }
+  if (requestSequence !== undefined) {
+    return reduceDesktopSqlExecutionEvent(state, event, context);
+  }
   const preparedState =
     event.eventType === 'started' || !isSqlExecutionTracked(state, event.executionId)
       ? prepareSqlExecutionLogForExecution(state, event.executionId, keepHistory)

--- a/chat2db-community-client/src/service/sqlExecutionRequestTracker.ts
+++ b/chat2db-community-client/src/service/sqlExecutionRequestTracker.ts
@@ -1,0 +1,39 @@
+import { beginLatestRequest, isLatestRequest, RequestGenerationRef } from '@/utils/latestRequest';
+
+export interface SqlExecutionRequestTracker {
+  generationRef: RequestGenerationRef;
+  executionId?: string;
+}
+
+export function createSqlExecutionRequestTracker(): SqlExecutionRequestTracker {
+  return { generationRef: { current: 0 } };
+}
+
+export function beginSqlExecutionRequest(tracker: SqlExecutionRequestTracker) {
+  tracker.executionId = undefined;
+  return beginLatestRequest(tracker.generationRef);
+}
+
+export function setSqlExecutionRequestId(
+  tracker: SqlExecutionRequestTracker,
+  requestSequence: number,
+  executionId: string,
+) {
+  if (!isLatestRequest(tracker.generationRef, requestSequence)) {
+    return false;
+  }
+  tracker.executionId = executionId;
+  return true;
+}
+
+export function finishSqlExecutionRequest(tracker: SqlExecutionRequestTracker, requestSequence: number) {
+  if (!isLatestRequest(tracker.generationRef, requestSequence)) {
+    return false;
+  }
+  tracker.executionId = undefined;
+  return true;
+}
+
+export function getActiveSqlExecutionId(tracker: SqlExecutionRequestTracker) {
+  return tracker.executionId;
+}

--- a/chat2db-community-client/src/service/sqlExecutionRequestTracker.ts
+++ b/chat2db-community-client/src/service/sqlExecutionRequestTracker.ts
@@ -2,6 +2,7 @@ import { beginLatestRequest, isLatestRequest, RequestGenerationRef } from '@/uti
 
 export interface SqlExecutionRequestTracker {
   generationRef: RequestGenerationRef;
+  activeRequestSequence?: number;
   executionId?: string;
 }
 
@@ -11,7 +12,9 @@ export function createSqlExecutionRequestTracker(): SqlExecutionRequestTracker {
 
 export function beginSqlExecutionRequest(tracker: SqlExecutionRequestTracker) {
   tracker.executionId = undefined;
-  return beginLatestRequest(tracker.generationRef);
+  const requestSequence = beginLatestRequest(tracker.generationRef);
+  tracker.activeRequestSequence = requestSequence;
+  return requestSequence;
 }
 
 export function setSqlExecutionRequestId(
@@ -19,7 +22,10 @@ export function setSqlExecutionRequestId(
   requestSequence: number,
   executionId: string,
 ) {
-  if (!isLatestRequest(tracker.generationRef, requestSequence)) {
+  if (
+    !isLatestRequest(tracker.generationRef, requestSequence) ||
+    tracker.activeRequestSequence !== requestSequence
+  ) {
     return false;
   }
   tracker.executionId = executionId;
@@ -27,9 +33,13 @@ export function setSqlExecutionRequestId(
 }
 
 export function finishSqlExecutionRequest(tracker: SqlExecutionRequestTracker, requestSequence: number) {
-  if (!isLatestRequest(tracker.generationRef, requestSequence)) {
+  if (
+    !isLatestRequest(tracker.generationRef, requestSequence) ||
+    tracker.activeRequestSequence !== requestSequence
+  ) {
     return false;
   }
+  tracker.activeRequestSequence = undefined;
   tracker.executionId = undefined;
   return true;
 }


### PR DESCRIPTION
## Related issue

Closes #2269

## Summary

- Add a `Keep history output` option to the execution console menu, enabled by default and persisted per edition/runtime.
- When disabled, retain only the newest SQL execution output across Web and Desktop runtimes.
- Prevent late events from superseded executions from restoring older output, including Desktop requests whose first event arrives out of order.
- Synchronize the preference across mounted editors and bound superseded-execution tracking to 200 entries.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:execution-console` - passed
  - `yarn test:sql-execution-log` - passed
  - `yarn test:i18n` - passed
  - `yarn lint` - passed
  - `yarn build:web:community --app_version=5.3.0` - passed
  - `git diff --check` - passed
- Manual verification: N/A - no local runtime was started.
- UI evidence: N/A - no local runtime was started.

## Risk and compatibility

- Public API or stored data: Adds one client-side localStorage preference key; no public API or server-side data changes.
- Database or driver compatibility: N/A - execution and driver behavior are unchanged.
- Network, privacy, or security: N/A - no network, privacy, or security behavior changes.
- Community / Local / Pro boundary: Community frontend only; the preference key remains scoped by edition and runtime.
- Backward compatibility: Existing behavior is preserved by default because history retention defaults to enabled.

## Reviewer map

- Start here: `chat2db-community-client/src/service/sqlExecutionLog.ts`, then `src/pages/main/workspace/components/SQLExecute/index.tsx`.
- Failure condition: Enabled mode loses prior output, disabled mode retains more than the newest execution, or a late superseded event restores older output.
- Rollback or disable path: Revert this PR; users can also leave the new option enabled to preserve the prior behavior.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for implementation, tests, edge-case analysis, and review. The final diff and verification results were reviewed before submission.
