### PR TITLE
fix(ui): align chart icon and page-size chevron

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetToolbar/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetToolbar/index.tsx
@@ -11,6 +11,7 @@ import sqlService from '@/service/sql';
 import _ from 'lodash';
 import EditorChartModal, { EditChartModalRef } from '@/blocks/BI/ChartCardBox/EditorChartModal';
 import DingChartModal, { DingChartModalRef } from '@/blocks/BI/ChartCardBox/DingChartModal';
+import ChartNoAxesCombined from '@/components/LucideIcons/ChartNoAxesCombined';
 import { useZoerStore } from '@/store/zoer';
 import { useGlobalStore } from '@/store/global';
 
@@ -214,7 +215,7 @@ const ResultSetToolbar = forwardRef((props: IProps, ref: ForwardedRef<ResultSetT
             }}
             size="sm"
             className={styles.createChartIcon}
-            code="icon-combo-chart"
+            icon={ChartNoAxesCombined}
           />
           <EditorChartModal
             submitEditorChartCallback={(data) => {

--- a/chat2db-community-client/src/components/LucideIcons/ChartNoAxesCombined.ts
+++ b/chat2db-community-client/src/components/LucideIcons/ChartNoAxesCombined.ts
@@ -1,0 +1,13 @@
+import { createLucideIcon } from 'lucide-react';
+
+// Backport the official Lucide icon; the direct 0.356 dependency predates this export.
+const ChartNoAxesCombined = createLucideIcon('ChartNoAxesCombined', [
+  ['path', { d: 'M12 16v5', key: 'zza2cw' }],
+  ['path', { d: 'M16 14v7', key: '1g90b9' }],
+  ['path', { d: 'M20 10v11', key: '1iqoj0' }],
+  ['path', { d: 'm22 3-8.646 8.646a.5.5 0 0 1-.708 0L9.354 8.354a.5.5 0 0 0-.707 0L2 15', key: '1fw8x9' }],
+  ['path', { d: 'M4 18v3', key: '1yp0dc' }],
+  ['path', { d: 'M8 14v7', key: 'n3cwzv' }],
+]);
+
+export default ChartNoAxesCombined;

--- a/chat2db-community-client/src/components/Pagination/style.ts
+++ b/chat2db-community-client/src/components/Pagination/style.ts
@@ -66,6 +66,7 @@ export const useStyles = createStyles(({ css, token }, { inputNumberWidth }: { i
       cursor: pointer;
       margin-left: 10px;
       display: flex;
+      align-items: center;
       gap: 4px;
       &:hover {
         color: ${token.colorPrimaryText};

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -1,8 +1,9 @@
 import { Confetti, IconButton, IconfontSvg } from '@chat2db/ui';
 import { Tooltip, type InputRef } from 'antd';
-import { createLucideIcon, Layers, MessagesSquare } from 'lucide-react';
+import { Layers, MessagesSquare } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import ChartNoAxesCombined from '@/components/LucideIcons/ChartNoAxesCombined';
 import i18n from '@/i18n';
 import { INavItem } from '@/typings/main';
 import feedback from '@/utils/feedback';
@@ -33,16 +34,6 @@ import { useChatStore } from '@/store/chat';
 import { useWorkspaceStore } from '@/store/workspace';
 import { isDesktop, isHashHistoryEnv } from '@/utils/env';
 import { checkIsSharePage } from '@/utils/url';
-
-// Backport the official Lucide icon; the direct 0.356 dependency predates this export.
-const ChartNoAxesCombined = createLucideIcon('ChartNoAxesCombined', [
-  ['path', { d: 'M12 16v5', key: 'zza2cw' }],
-  ['path', { d: 'M16 14v7', key: '1g90b9' }],
-  ['path', { d: 'M20 10v11', key: '1iqoj0' }],
-  ['path', { d: 'm22 3-8.646 8.646a.5.5 0 0 1-.708 0L9.354 8.354a.5.5 0 0 0-.707 0L2 15', key: '1fw8x9' }],
-  ['path', { d: 'M4 18v3', key: '1yp0dc' }],
-  ['path', { d: 'M8 14v7', key: 'n3cwzv' }],
-]);
 
 function CommunityMainPage() {
   const [navConfig, setNavConfig] = useState<INavItem[]>([]);


### PR DESCRIPTION
## Related issue

Closes #2282

## Summary

- Extract the Dashboard's Lucide `ChartNoAxesCombined` backport into a shared frontend component.
- Use the same icon for the result toolbar's create-chart action.
- Vertically center the page-size value and its Lucide dropdown chevron.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn eslint src/components/LucideIcons/ChartNoAxesCombined.ts src/pages/main/CommunityMainPage.tsx src/blocks/SearchResult/components/ResultSetToolbar/index.tsx src/components/Pagination/style.ts --max-warnings=0` - passed.
  - `yarn prettier --check src/components/LucideIcons/ChartNoAxesCombined.ts src/pages/main/CommunityMainPage.tsx src/blocks/SearchResult/components/ResultSetToolbar/index.tsx src/components/Pagination/style.ts` - passed.
  - `yarn run build:web:community --app_version=5.3.0` - passed, including the three configured prebuild tests.
- Manual verification: Reproduced and reviewed in the local Community Web runtime at `http://localhost:8889`; the requested final behavior was confirmed before filing this PR.
- UI evidence: The source screenshots were provided during local review and are not attached to GitHub.

## Risk and compatibility

- Public API or stored data: N/A - visual frontend changes only.
- Database or driver compatibility: N/A - no database or driver behavior changes.
- Network, privacy, or security: N/A - no network, privacy, or security behavior changes.
- Community / Local / Pro boundary: Community frontend files only.
- Backward compatibility: No persisted state or interaction contract changes; the create-chart action keeps the same behavior.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/SearchResult/components/ResultSetToolbar/index.tsx` and `chat2db-community-client/src/components/Pagination/style.ts`.
- Failure condition: The toolbar chart action does not match Dashboard, or the page-size chevron remains vertically offset.
- Rollback or disable path: Revert commit `7f158a0f`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Implemented and verified with substantial OpenAI Codex assistance.
