### PR TITLE
feat(sql-editor): use table icon for result tabs

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/index.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react';
 import classnames from 'classnames';
 import CustomTabs, { ITabItem } from '@/components/Tabs';
-import Iconfont from '@/components/Iconfont';
 import { IManageResultData } from '@/typings';
 import SearchResultItem from './components/SearchResultItem';
 import Abstract from '@/components/Abstract';
@@ -176,13 +175,7 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
     const tabsListRes =
       newResultDataList?.map((queryResultData, index) => {
         return {
-          prefixIcon: (
-            <Iconfont
-              key={index}
-              className={classnames(styles[queryResultData.success ? 'successIcon' : 'failIcon'], styles.statusIcon)}
-              code={queryResultData.success ? '\ue605' : '\ue87c'}
-            />
-          ),
+          prefixIcon: <IconfontSvg key={index} className={styles.resultTabIcon} size="sm" code="icon-table" />,
           popover: (
             <SQLPreview
               source="search-result-tab-popover"

--- a/chat2db-community-client/src/blocks/SearchResult/style.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/style.ts
@@ -38,15 +38,9 @@ export const useStyles = createStyles(({ css, token }) => {
       font-size: 16px;
       margin-right: 4px;
     `,
-    statusIcon: css`
-      margin-right: 6px;
-      font-size: 12px;
-    `,
-    successIcon: css`
-      color: ${token.colorPrimary};
-    `,
-    failIcon: css`
-      color: ${token.colorError};
+    resultTabIcon: css`
+      margin-right: 4px;
+      color: inherit;
     `,
     tableIndex: css`
       width: 50px;


### PR DESCRIPTION
## Related issue

Closes #2283

## Summary

Replace the colored execution-status icon on SQL result tabs with the existing neutral table icon. SQL console result tabs only expose tabular results, while failed executions remain in Output, so the icon now communicates the result type instead of redundant status.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `git diff --check` - passed.
  - Targeted ESLint for `src/blocks/SearchResult/index.tsx` and `src/blocks/SearchResult/style.ts` with `--max-warnings=0` - passed using the existing workspace dependencies.
- Manual verification: Local Community desktop session hot-reloaded the change; result tabs use the neutral table icon and failed execution output remains in the Output tab.
- UI evidence: N/A - verified in the local desktop session; no screenshot artifact was committed.

## Risk and compatibility

- Public API or stored data: N/A - presentation-only frontend change.
- Database or driver compatibility: N/A - SQL execution and result data are unchanged.
- Network, privacy, or security: N/A - no network or data-handling changes.
- Community / Local / Pro boundary: Community frontend only.
- Backward compatibility: Existing result tabs keep the same labels, keys, content, and selection behavior.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/SearchResult/index.tsx` result-tab `prefixIcon`.
- Failure condition: A result tab has no table icon, retains success/failure coloring, or changes result-tab selection behavior.
- Rollback or disable path: Revert commit `27e05422`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with the scoped implementation and verification; the maintainer directed the behavior and reviewed the local UI.
