### PR TITLE
fix(gaussdb): expose public schema and enable INSERT editor hints

### DIFF
--- a/chat2db-community-client/src/components/SQLEditor/core/sqlCompletionModelMode.test.ts
+++ b/chat2db-community-client/src/components/SQLEditor/core/sqlCompletionModelMode.test.ts
@@ -15,12 +15,22 @@ assert.equal(
   false,
   'non-configured databases keep legacy completion mode',
 );
+assert.equal(
+  isBackendCompletionDatabaseType(DatabaseTypeCode.GAUSSDB),
+  false,
+  'GaussDB keeps legacy completion mode while using backend editor hints',
+);
 assert.equal(isBackendCompletionDatabaseType(undefined), false, 'missing database type keeps legacy completion mode');
 assert.equal(isBackendEditorHintsDatabaseType(DatabaseTypeCode.MYSQL), true, 'MySQL supports backend editor hints');
 assert.equal(
   isBackendEditorHintsDatabaseType(DatabaseTypeCode.POSTGRESQL),
   true,
   'PostgreSQL supports backend editor hints without switching completion mode',
+);
+assert.equal(
+  isBackendEditorHintsDatabaseType(DatabaseTypeCode.GAUSSDB),
+  true,
+  'GaussDB supports PostgreSQL-compatible backend editor hints',
 );
 assert.equal(
   isBackendEditorHintsDatabaseType(DatabaseTypeCode.SQLSERVER),

--- a/chat2db-community-client/src/constants/databaseCapabilities.ts
+++ b/chat2db-community-client/src/constants/databaseCapabilities.ts
@@ -38,7 +38,11 @@ export const databaseCapabilities = {
     DatabaseTypeCode.ORACLE,
   ],
   backendCompletionSupported: [DatabaseTypeCode.MYSQL],
-  backendEditorHintsSupported: [DatabaseTypeCode.MYSQL, DatabaseTypeCode.POSTGRESQL],
+  backendEditorHintsSupported: [
+    DatabaseTypeCode.MYSQL,
+    DatabaseTypeCode.POSTGRESQL,
+    DatabaseTypeCode.GAUSSDB,
+  ],
   tableEditorMysqlBaseInfoSupported: [DatabaseTypeCode.MYSQL],
   tableEditorMysqlIndexMethodSupported: [DatabaseTypeCode.MYSQL],
   tableEditorOracleIndexColumnHidden: [DatabaseTypeCode.ORACLE],

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBMetaData.java
@@ -2,13 +2,10 @@ package ai.chat2db.plugin.gaussdb;
 
 import ai.chat2db.plugin.postgresql.PostgreSQLMetaData;
 import ai.chat2db.spi.IDbMetaData;
-import ai.chat2db.community.domain.api.model.metadata.TableIndex;
 import ai.chat2db.spi.DefaultSQLExecutor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
-import java.util.List;
 
 import static ai.chat2db.plugin.gaussdb.constant.GaussDBMetaDataConstants.SEARCH_PATH_STATEMENT_PREFIX;
 import static ai.chat2db.plugin.gaussdb.constant.GaussDBMetaDataConstants.TABLE_DDL_SQL;
@@ -58,11 +55,4 @@ public class GaussDBMetaData extends PostgreSQLMetaData implements IDbMetaData {
         }
         return ddl;
     }
-
-    @Override
-    public List<TableIndex> indexes(Connection connection, String databaseName, String schemaName, String tableName) {
-        return DefaultSQLExecutor.getInstance().indexes(connection, StringUtils.isEmpty(databaseName) ? null : databaseName, StringUtils.isEmpty(schemaName) ? null : schemaName, tableName);
-    }
-
-
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBMetaData.java
@@ -2,10 +2,13 @@ package ai.chat2db.plugin.gaussdb;
 
 import ai.chat2db.plugin.postgresql.PostgreSQLMetaData;
 import ai.chat2db.spi.IDbMetaData;
+import ai.chat2db.community.domain.api.model.metadata.TableIndex;
 import ai.chat2db.spi.DefaultSQLExecutor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
+import java.util.List;
 
 import static ai.chat2db.plugin.gaussdb.constant.GaussDBMetaDataConstants.SEARCH_PATH_STATEMENT_PREFIX;
 import static ai.chat2db.plugin.gaussdb.constant.GaussDBMetaDataConstants.TABLE_DDL_SQL;
@@ -55,4 +58,11 @@ public class GaussDBMetaData extends PostgreSQLMetaData implements IDbMetaData {
         }
         return ddl;
     }
+
+    @Override
+    public List<TableIndex> indexes(Connection connection, String databaseName, String schemaName, String tableName) {
+        return DefaultSQLExecutor.getInstance().indexes(connection, StringUtils.isEmpty(databaseName) ? null : databaseName, StringUtils.isEmpty(schemaName) ? null : schemaName, tableName);
+    }
+
+
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBSyntaxPlugin.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBSyntaxPlugin.java
@@ -1,13 +1,12 @@
 package ai.chat2db.plugin.gaussdb;
 
-import ai.chat2db.spi.ISqlSyntaxPlugin;
 import ai.chat2db.community.domain.api.enums.parser.DatabaseTypeEnum;
 import ai.chat2db.community.domain.api.model.completion.SqlCompletionEditorHint;
 import ai.chat2db.community.domain.api.model.completion.request.DbSqlCompletionRequest;
-import ai.chat2db.spi.ISQLParser;
 import ai.chat2db.plugin.gaussdb.parser.GaussDBSqlParser;
 import ai.chat2db.plugin.postgresql.completion.PostgreSqlInsertEditorHintProvider;
-
+import ai.chat2db.spi.ISQLParser;
+import ai.chat2db.spi.ISqlSyntaxPlugin;
 import java.util.List;
 
 public class GaussDBSyntaxPlugin implements ISqlSyntaxPlugin {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBSyntaxPlugin.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/java/ai/chat2db/plugin/gaussdb/GaussDBSyntaxPlugin.java
@@ -2,8 +2,13 @@ package ai.chat2db.plugin.gaussdb;
 
 import ai.chat2db.spi.ISqlSyntaxPlugin;
 import ai.chat2db.community.domain.api.enums.parser.DatabaseTypeEnum;
+import ai.chat2db.community.domain.api.model.completion.SqlCompletionEditorHint;
+import ai.chat2db.community.domain.api.model.completion.request.DbSqlCompletionRequest;
 import ai.chat2db.spi.ISQLParser;
 import ai.chat2db.plugin.gaussdb.parser.GaussDBSqlParser;
+import ai.chat2db.plugin.postgresql.completion.PostgreSqlInsertEditorHintProvider;
+
+import java.util.List;
 
 public class GaussDBSyntaxPlugin implements ISqlSyntaxPlugin {
     @Override
@@ -14,5 +19,10 @@ public class GaussDBSyntaxPlugin implements ISqlSyntaxPlugin {
     @Override
     public ISQLParser getSQLParser() {
         return new GaussDBSqlParser();
+    }
+
+    @Override
+    public List<SqlCompletionEditorHint> getSqlEditorHints(DbSqlCompletionRequest request) {
+        return new PostgreSqlInsertEditorHintProvider().build(request);
     }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/resources/ai/chat2db/plugin/gaussdb/gaussdb.json
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/main/resources/ai/chat2db/plugin/gaussdb/gaussdb.json
@@ -14,6 +14,6 @@
       "jdbcDriverClass": "org.postgresql.Driver"
     }
   ],
-  "systemSchemas": ["blockchain", "cstore", "db4ai", "dbe_application_info", "dbe_compression", "dbe_file", "dbe_heat_map", "dbe_ilm", "dbe_ilm_admin", "dbe_lob", "dbe_match", "dbe_output", "dbe_perf", "dbe_pldebugger", "dbe_pldeveloper", "dbe_profiler", "dbe_random", "dbe_raw", "dbe_scheduler", "dbe_session", "dbe_sql", "dbe_sql_util", "dbe_stats", "dbe_task", "dbe_utility", "dbe_xml", "dbe_xmldom", "dbe_xmlparser", "information_schema", "pg_catalog", "pkg_service", "pkg_util", "prvt_ilm", "public", "snapshot", "sqladvisor", "sys"],
+  "systemSchemas": ["blockchain", "cstore", "db4ai", "dbe_application_info", "dbe_compression", "dbe_file", "dbe_heat_map", "dbe_ilm", "dbe_ilm_admin", "dbe_lob", "dbe_match", "dbe_output", "dbe_perf", "dbe_pldebugger", "dbe_pldeveloper", "dbe_profiler", "dbe_random", "dbe_raw", "dbe_scheduler", "dbe_session", "dbe_sql", "dbe_sql_util", "dbe_stats", "dbe_task", "dbe_utility", "dbe_xml", "dbe_xmldom", "dbe_xmlparser", "information_schema", "pg_catalog", "pkg_service", "pkg_util", "prvt_ilm", "snapshot", "sqladvisor", "sys"],
   "name": "GaussDB"
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/test/java/ai/chat2db/plugin/gaussdb/GaussDBMetaDataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/test/java/ai/chat2db/plugin/gaussdb/GaussDBMetaDataTest.java
@@ -1,12 +1,9 @@
 package ai.chat2db.plugin.gaussdb;
 
-import ai.chat2db.plugin.postgresql.PostgreSQLMetaData;
+import ai.chat2db.community.domain.api.config.DBConfig;
 import org.junit.jupiter.api.Test;
 
-import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -21,23 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class GaussDBMetaDataTest {
 
     @Test
-    void indexesInheritsPostgreSqlImplementationWithTypesAndForeignKeys() throws Exception {
-        Method indexes = GaussDBMetaData.class.getMethod(
-                "indexes", Connection.class, String.class, String.class, String.class);
+    void gaussdbJsonDoesNotMarkPublicSchemaAsSystem() {
+        DBConfig dbConfig = new GaussPlugin().getDBConfig();
 
-        assertEquals(PostgreSQLMetaData.class, indexes.getDeclaringClass());
-    }
-
-    @Test
-    void gaussdbJsonDoesNotMarkPublicSchemaAsSystem() throws Exception {
-        String json;
-        try (InputStream in = GaussDBMetaDataTest.class.getResourceAsStream(
-                "/ai/chat2db/plugin/gaussdb/gaussdb.json")) {
-            assertNotNull(in, "gaussdb.json must be on the test classpath");
-            json = new String(in.readAllBytes(), StandardCharsets.UTF_8);
-        }
-
-        assertFalse(json.contains("\"public\""),
+        assertNotNull(dbConfig, "gaussdb.json must deserialize into DBConfig");
+        assertNotNull(dbConfig.getSystemSchemas(), "gaussdb.json must define systemSchemas");
+        assertFalse(dbConfig.getSystemSchemas().contains("public"),
                 "the default user schema 'public' must not be listed in systemSchemas");
     }
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/test/java/ai/chat2db/plugin/gaussdb/GaussDBMetaDataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/test/java/ai/chat2db/plugin/gaussdb/GaussDBMetaDataTest.java
@@ -1,8 +1,12 @@
 package ai.chat2db.plugin.gaussdb;
 
+import ai.chat2db.plugin.postgresql.PostgreSQLMetaData;
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -11,8 +15,31 @@ import java.util.List;
 
 import static ai.chat2db.plugin.gaussdb.constant.GaussDBMetaDataConstants.TABLE_DDL_SQL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class GaussDBMetaDataTest {
+
+    @Test
+    void indexesInheritsPostgreSqlImplementationWithTypesAndForeignKeys() throws Exception {
+        Method indexes = GaussDBMetaData.class.getMethod(
+                "indexes", Connection.class, String.class, String.class, String.class);
+
+        assertEquals(PostgreSQLMetaData.class, indexes.getDeclaringClass());
+    }
+
+    @Test
+    void gaussdbJsonDoesNotMarkPublicSchemaAsSystem() throws Exception {
+        String json;
+        try (InputStream in = GaussDBMetaDataTest.class.getResourceAsStream(
+                "/ai/chat2db/plugin/gaussdb/gaussdb.json")) {
+            assertNotNull(in, "gaussdb.json must be on the test classpath");
+            json = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        assertFalse(json.contains("\"public\""),
+                "the default user schema 'public' must not be listed in systemSchemas");
+    }
 
     @Test
     void tableDdlUsesTableOidAndRemovesSearchPath() {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/test/java/ai/chat2db/plugin/gaussdb/GaussDBSyntaxPluginTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gaussdb/src/test/java/ai/chat2db/plugin/gaussdb/GaussDBSyntaxPluginTest.java
@@ -1,0 +1,44 @@
+package ai.chat2db.plugin.gaussdb;
+
+import ai.chat2db.community.domain.api.enums.completion.SqlCompletionCandidateTypeEnum;
+import ai.chat2db.community.domain.api.enums.completion.SqlCompletionEditorHintTypeEnum;
+import ai.chat2db.community.domain.api.model.completion.SqlCompletionCandidate;
+import ai.chat2db.community.domain.api.model.completion.SqlCompletionEditorHint;
+import ai.chat2db.community.domain.api.model.completion.request.DbSqlCompletionRequest;
+import ai.chat2db.community.domain.api.model.completion.result.SqlCompletionMetadataResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GaussDBSyntaxPluginTest {
+
+    @Test
+    void providesInsertEditorHintsLikePostgreSqlSibling() {
+        String sql = "INSERT INTO app.demo (id, enabled, created_at) VALUES (";
+        List<SqlCompletionCandidate> columns = List.of(
+                column("id", "integer", 1),
+                column("enabled", "boolean", 2),
+                column("created_at", "timestamp", 3));
+        DbSqlCompletionRequest request = DbSqlCompletionRequest.of(
+                sql, sql.length(), "GAUSSDB", 0,
+                metadataRequest -> SqlCompletionMetadataResponse.of(columns));
+
+        List<SqlCompletionEditorHint> hints = new GaussDBSyntaxPlugin().getSqlEditorHints(request);
+
+        assertEquals(1, hints.size());
+        assertEquals(SqlCompletionEditorHintTypeEnum.INSERT_VALUE, hints.get(0).getType());
+        assertEquals(List.of("0", "FALSE", "CURRENT_TIMESTAMP"),
+                hints.get(0).getItems().stream()
+                        .map(SqlCompletionEditorHint.Item::getDefaultValue).toList());
+    }
+
+    private SqlCompletionCandidate column(String name, String type, int rank) {
+        SqlCompletionCandidate candidate = SqlCompletionCandidate.of(SqlCompletionCandidateTypeEnum.COLUMN, name);
+        candidate.setColumnName(name);
+        candidate.setDataType(type);
+        candidate.setSortRank(rank);
+        return candidate;
+    }
+}


### PR DESCRIPTION
## Problem

Two GaussDB integration gaps remained:

1. gaussdb.json listed public in systemSchemas, so user tables in the default public schema were treated as system objects and hidden from the schema tree.
2. GaussDBSyntaxPlugin could produce PostgreSQL-compatible INSERT value hints, but the frontend capability gate did not request them for GaussDB.

The existing GaussDB JDBC indexes implementation is intentionally preserved because PostgreSQLMetaData uses PostgreSQL-specific metadata queries.

## Fix

- Remove public from GaussDB systemSchemas.
- Delegate GaussDB INSERT editor hints to PostgreSqlInsertEditorHintProvider.
- Enable backend editor hints for GaussDB while keeping the existing legacy completion mode.
- Add backend and frontend regression coverage for both contracts.

Tracked in #2281.

## Verification

- GaussDBMetaDataTest and GaussDBSyntaxPluginTest: 5 tests passed with 0 failures/errors/skips.
- sqlCompletionModelMode focused frontend test passed.
- Frontend lint passed.
- Community frontend build and its prebuild tests passed.
- GaussDB module plus 8 dependency modules packaged successfully.
- The separate package command used -Dmaven.test.skip=true; test success comes from the focused test command.
- git diff --check passed.