### PR TITLE
fix(mysql): emit NULL instead of ST_GeomFromText('null') for null geometry

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/value/sub/MysqlGeometryProcessor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/value/sub/MysqlGeometryProcessor.java
@@ -72,7 +72,11 @@ public class MysqlGeometryProcessor extends DefaultValueProcessor {
 
     @Override
     public String convertJDBCValueStrByType(JDBCDataValue dataValue) {
-        return MysqlDmlValueTemplate.wrapGeometry(convertJDBCValueByType(dataValue));
+        String value = convertJDBCValueByType(dataValue);
+        if (value == null) {
+            return "NULL";
+        }
+        return MysqlDmlValueTemplate.wrapGeometry(value);
     }
 
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/value/sub/MysqlGeometryProcessorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/value/sub/MysqlGeometryProcessorTest.java
@@ -1,0 +1,42 @@
+package ai.chat2db.plugin.mysql.value.sub;
+
+import ai.chat2db.spi.model.value.JDBCDataValue;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.io.WKBWriter;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MysqlGeometryProcessorTest {
+
+    private final MysqlGeometryProcessor processor = new MysqlGeometryProcessor();
+
+    @Test
+    void nullBinaryStreamYieldsSqlNullInsteadOfWrappedNullLiteral() {
+        JDBCDataValue dataValue = new JDBCDataValue(null, null, 1, false) {
+            @Override
+            public InputStream getBinaryStream() {
+                return null;
+            }
+        };
+        assertEquals("NULL", processor.convertJDBCValueStrByType(dataValue));
+    }
+
+    @Test
+    void validGeometryIsWrappedInGeomFromText() {
+        byte[] wkb = new WKBWriter().write(new GeometryFactory().createPoint(new Coordinate(1, 2)));
+        byte[] blob = new byte[4 + wkb.length];
+        System.arraycopy(wkb, 0, blob, 4, wkb.length);
+        JDBCDataValue dataValue = new JDBCDataValue(null, null, 1, false) {
+            @Override
+            public InputStream getBinaryStream() {
+                return new ByteArrayInputStream(blob);
+            }
+        };
+        assertEquals("ST_GeomFromText('POINT (1 2)')", processor.convertJDBCValueStrByType(dataValue));
+    }
+}


### PR DESCRIPTION
## Problem

`MysqlGeometryProcessor.convertJDBCValueStrByType` unconditionally wrapped the converted value with `MysqlDmlValueTemplate.wrapGeometry(...)` (`ST_GeomFromText(...)`). For a NULL geometry column, `convertJDBCValueByType` returns `null`, so the generated statement contained `ST_GeomFromText('null')` instead of SQL `NULL` — failing at execution time or inserting garbage.

## Fix

Return the literal `NULL` when the converted value is null; only wrap non-null values in `ST_GeomFromText`.

## Tests

`MysqlGeometryProcessorTest` covers the null path and normal wrapping. `mvn test` on chat2db-community-mysql: 610/610 pass.



---
Verified on fork HandSonic/Chat2DB#16 (meaningful CI checks green; dependency-review/project-sync jobs are fork-permission noise). Regression tests pass; adversarial review cleared.
