### PR TITLE
security: fix unauthenticated RCE via JDBC driver upload + unsafe Cla…

### DIFF
--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/JdbcDriverManager.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/sql/JdbcDriverManager.java
@@ -16,7 +16,13 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static ai.chat2db.community.tools.util.JdbcJarUtils.getFullPath;
@@ -28,6 +34,112 @@ public class JdbcDriverManager {
     private static final Map<String, ClassLoader> CLASS_LOADER_MAP = new ConcurrentHashMap();
     private static final Map<String, DriverEntry> DRIVER_ENTRY_MAP = new ConcurrentHashMap();
     private static final String SQL_STATE_CODE = "08001";
+
+    /**
+     * Whitelist of allowed JDBC driver class package prefixes.
+     *
+     * <p>The class name supplied via {@code DriverConfig.jdbcDriverClass} is fully
+     * attacker-controllable through the custom-driver save API. Without a
+     * whitelist, an attacker who can drop a jar into {@code jdbc-lib/} (see
+     * {@code /api/jdbc/driver/upload}) can name any class inside that jar and
+     * have it instantiated here — including a class whose {@code <clinit>} runs
+     * {@code Runtime.getRuntime().exec(...)}. This is the root of the two-stage
+     * unauthenticated RCE affecting v0.3.0 → v5.3.1.</p>
+     *
+     * <p>The default list below is derived from every
+     * {@code chat2db-community-plugins/*.json} so all built-in drivers keep
+     * working. Operators can extend (never shrink) it via the system property
+     * {@code chat2db.jdbc.allowed-class-prefixes} — comma-separated.</p>
+     */
+    private static final List<String> DEFAULT_ALLOWED_PREFIXES = Collections.unmodifiableList(Arrays.asList(
+            "com.mysql.",
+            "org.postgresql.",
+            "oracle.jdbc.",
+            "com.microsoft.sqlserver.",
+            "org.sqlite.",
+            "com.ibm.db2.",
+            "org.h2.",
+            "org.mariadb.",
+            "com.clickhouse.",
+            "ru.yandex.clickhouse.",
+            "org.apache.hive.",
+            "org.apache.druid.",
+            "org.apache.kylin.",
+            "org.opengauss.",
+            "org.duckdb.",
+            "org.elasticsearch.xpack.sql.",
+            "com.aliyun.odps.",
+            "com.databricks.",
+            "org.mongodb.",
+            "com.dbschema.",
+            "com.datastax.",
+            "org.neo4j.",
+            "com.amazon.redshift.",
+            "com.snowflake.",
+            "net.snowflake.",
+            "com.sap.db.",
+            "com.oceanbase.",
+            "com.kingbase8.",
+            "com.gbasedbt.",
+            "com.oscar.",
+            "com.informix.",
+            "com.simba.googlebigquery.",
+            "com.taosdata.",
+            "com.xugu.",
+            "com.facebook.presto.",
+            "csii.sundb.",
+            "dm.jdbc.",
+            "jdbc.RedisDriver"
+    ));
+
+    private static volatile List<String> allowedClassPrefixes;
+
+    private static List<String> getAllowedClassPrefixes() {
+        if (allowedClassPrefixes == null) {
+            synchronized (JdbcDriverManager.class) {
+                if (allowedClassPrefixes == null) {
+                    List<String> prefixes = new ArrayList<>(DEFAULT_ALLOWED_PREFIXES);
+                    String extra = System.getProperty("chat2db.jdbc.allowed-class-prefixes", "");
+                    if (StringUtils.isNotBlank(extra)) {
+                        for (String p : extra.split(",")) {
+                            String trimmed = p.trim();
+                            if (!trimmed.isEmpty() && !prefixes.contains(trimmed)) {
+                                prefixes.add(trimmed);
+                            }
+                        }
+                    }
+                    allowedClassPrefixes = Collections.unmodifiableList(prefixes);
+                }
+            }
+        }
+        return allowedClassPrefixes;
+    }
+
+    /**
+     * Throws {@link ConnectionException} if {@code className} is not under any
+     * whitelisted prefix. This must run BEFORE any {@code loadClass(...)} call
+     * so the malicious class is never resolved and its {@code <clinit>} never
+     * fires.
+     *
+     * <p>ConnectionException extends BusinessException extends RuntimeException,
+     * so this method does not need a {@code throws} clause — it can be called
+     * from any context, including ones that only declare checked exceptions
+     * like {@code IOException}.</p>
+     */
+    static void assertDriverClassAllowed(String className) {
+        if (StringUtils.isBlank(className)) {
+            throw new ConnectionException("driver.class.missing", null, null);
+        }
+        for (String prefix : getAllowedClassPrefixes()) {
+            if (className.startsWith(prefix)) {
+                return;
+            }
+        }
+        log.warn("SECURITY: rejected loadClass for non-whitelisted JDBC driver " +
+                "class '{}' — possible tainted upload attempt", className);
+        throw new ConnectionException("driver.class.not.allowed",
+                new Object[]{className}, null);
+    }
 
     public static Connection getConnection(String url, DriverConfig driver) throws SQLException {
         Properties info = new Properties();
@@ -130,6 +242,11 @@ public class JdbcDriverManager {
 
     private static DriverEntry getJDBCDriver(DriverConfig driver)
             throws SQLException {
+        // Layer-2 defence: reject non-whitelisted driver class names BEFORE any
+        // classloading occurs. Without this guard, an attacker-controlled
+        // jdbcDriverClass would be resolved via URLClassLoader.loadClass below,
+        // triggering its <clinit> and yielding RCE.
+        assertDriverClassAllowed(driver.getJdbcDriverClass());
         synchronized (driver) {
             try {
                 if (DRIVER_ENTRY_MAP.containsKey(driver.getJdbcDriver())) {
@@ -140,6 +257,9 @@ public class JdbcDriverManager {
                 DriverEntry driverEntry = DriverEntry.builder().driverConfig(driver).driver(d).build();
                 DRIVER_ENTRY_MAP.put(driver.getJdbcDriver(), driverEntry);
                 return driverEntry;
+            } catch (ConnectionException e) {
+                // Whitelist rejection from getClassLoader/getURLClassLoader — propagate as-is.
+                throw e;
             } catch (Exception e) {
                 throw new ConnectionException("connection.driver.load.error", null, e);
             }
@@ -148,6 +268,9 @@ public class JdbcDriverManager {
     }
 
     public static ClassLoader getClassLoader(DriverConfig driverConfig) throws IOException, ClassNotFoundException {
+        // Belt-and-braces: also enforce the whitelist here so future call sites
+        // that skip getJDBCDriver cannot accidentally load arbitrary classes.
+        assertDriverClassAllowed(driverConfig.getJdbcDriverClass());
         String jarPath = driverConfig.getJdbcDriver();
         if (CLASS_LOADER_MAP.containsKey(jarPath)) {
             return CLASS_LOADER_MAP.get(jarPath);
@@ -159,6 +282,9 @@ public class JdbcDriverManager {
                 URLClassLoader cl;
                 try {
                     cl = getURLClassLoader(jarPath, driverConfig.getJdbcDriverClass(), false);
+                } catch (ConnectionException e) {
+                    // Whitelist rejection — do NOT retry with clean=true, just propagate.
+                    throw e;
                 } catch (Exception e) {
                     cl = getURLClassLoader(jarPath, driverConfig.getJdbcDriverClass(), true);
                 }
@@ -216,6 +342,9 @@ public class JdbcDriverManager {
     }
 
     private static URLClassLoader getURLClassLoader(String jarPath, String clazz, boolean clean) throws IOException, ClassNotFoundException {
+        // Final enforcement point: this method actually invokes loadClass below,
+        // which is the instruction that fires a malicious class's <clinit>.
+        assertDriverClassAllowed(clazz);
         String[] jarPaths = jarPath.split(",");
         List<URL> jarUrls;
         if (jarPath.endsWith(".zip")) {

--- a/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/JdbcJarUtils.java
+++ b/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/JdbcJarUtils.java
@@ -122,8 +122,22 @@ public class JdbcJarUtils {
         if(jarPath.endsWith(".zip")){
             return getFullPathZip(jarPath);
         }
+        // Layer-4 defence: reject path traversal in the driver jar filename.
+        // The jar name is attacker-controlled via the custom-driver save API;
+        // without canonicalization an attacker could supply "../evil.jar" or
+        // absolute paths and have the classloader read from anywhere on disk.
+        assertSimpleJarName(jarPath);
         String path = JdbcDriverConstants.DRIVER_LIB_PATH + jarPath;
         File file = new File(path);
+        try {
+            String canonicalBase = new File(JdbcDriverConstants.DRIVER_LIB_PATH).getCanonicalPath();
+            String canonicalTarget = file.getCanonicalPath();
+            if (!canonicalTarget.startsWith(canonicalBase + File.separator)) {
+                throw new SecurityException("jarPath escapes DRIVER_LIB_PATH: " + jarPath);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to canonicalize jar path: " + jarPath, e);
+        }
         if (!file.exists()) {
             String url = getDownloadUrl(jarPath);
             try {
@@ -139,7 +153,25 @@ public class JdbcJarUtils {
         return path;
     }
 
+    /**
+     * Rejects any jar name that contains path separators, parent references,
+     * absolute paths, or Windows drive letters. Driver jars must be simple
+     * filenames directly under {@code DRIVER_LIB_PATH}.
+     */
+    private static void assertSimpleJarName(String jarPath) {
+        if (jarPath == null || jarPath.isEmpty()) {
+            throw new IllegalArgumentException("jarPath is empty");
+        }
+        if (jarPath.contains("..") || jarPath.contains("/") || jarPath.contains("\\")) {
+            throw new SecurityException("jarPath must be a simple filename, got: " + jarPath);
+        }
+        if (jarPath.length() >= 2 && jarPath.charAt(1) == ':') {
+            throw new SecurityException("absolute paths not allowed: " + jarPath);
+        }
+    }
+
     private static String getFullPathZip(String jarPath) {
+        assertSimpleJarName(jarPath);
         String path = JdbcDriverConstants.DRIVER_LIB_PATH + jarPath;
         File file = new File(path);
         File destDir = FileUtil.file(file.getParentFile(), FileUtil.mainName(file));

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/db/MultipartJdbcDriverUploadAdapter.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/db/MultipartJdbcDriverUploadAdapter.java
@@ -2,27 +2,129 @@ package ai.chat2db.community.web.api.adapter.db;
 
 import ai.chat2db.community.domain.api.service.db.IDbJdbcDriverUploadService;
 import ai.chat2db.community.tools.constant.JdbcDriverConstants;
+import ai.chat2db.community.tools.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
 
+/**
+ * Multipart upload endpoint for JDBC driver jars.
+ *
+ * <p><b>Security context:</b> prior to this fix, this adapter accepted any
+ * {@link MultipartFile} and dropped it into {@code jdbc-lib/} with no
+ * validation. Combined with the absence of a class-name whitelist in
+ * {@code JdbcDriverManager}, this yielded a two-stage unauthenticated RCE
+ * (Stage 1 here, Stage 2 in {@code JdbcDriverManager.getJDBCDriver}). The
+ * checks below are defence-in-depth: even if the Layer-2 class whitelist is
+ * ever bypassed, an attacker should not be able to drop arbitrary content
+ * into the driver directory.</p>
+ */
+@Slf4j
 @Component
 public class MultipartJdbcDriverUploadAdapter implements IDbJdbcDriverUploadService<MultipartFile[]> {
+
+    /** Max size of a single uploaded driver jar. 50 MB is generous — MySQL/PG/Oracle drivers are 1–10 MB. */
+    private static final long MAX_DRIVER_JAR_BYTES = 50L * 1024 * 1024;
+
+    /** Only simple filenames: alphanumerics, dash, underscore, dot; must end in .jar */
+    private static final String SAFE_FILENAME_REGEX = "[a-zA-Z0-9_\\-]+\\.jar";
+
+    /** ZIP local-file-header magic. All JARs are ZIPs. */
+    private static final byte[] ZIP_MAGIC = new byte[]{0x50, 0x4B, 0x03, 0x04};
 
     @Override
     public List<String> upload(MultipartFile[] files) throws IOException {
         List<String> uploadedFiles = new ArrayList<>();
+        if (files == null || files.length == 0) {
+            return uploadedFiles;
+        }
         for (MultipartFile file : files) {
-            String originalFilename = FilenameUtils.getName(file.getOriginalFilename());
-            String location = JdbcDriverConstants.DRIVER_LIB_PATH + originalFilename;
-            file.transferTo(new File(location));
-            uploadedFiles.add(originalFilename);
+            if (file == null || file.isEmpty()) {
+                continue;
+            }
+            String safeName = validate(file);
+            File target = new File(JdbcDriverConstants.DRIVER_LIB_PATH, safeName);
+            // Final containment check — canonical path must stay inside DRIVER_LIB_PATH.
+            String canonicalBase = new File(JdbcDriverConstants.DRIVER_LIB_PATH).getCanonicalPath();
+            String canonicalTarget = target.getCanonicalPath();
+            if (!canonicalTarget.startsWith(canonicalBase + File.separator)) {
+                log.warn("SECURITY: driver upload path traversal attempt, name={}", safeName);
+                throw new BusinessException("jdbc.driver.invalidPath", new Object[]{safeName});
+            }
+            file.transferTo(target);
+            uploadedFiles.add(safeName);
+            log.info("JDBC driver uploaded: name={}, size={} bytes", safeName, file.getSize());
         }
         return uploadedFiles;
+    }
+
+    /**
+     * Runs all upload validation and returns the sanitized filename. Throws
+     * {@link BusinessException} on any rule failure. Nothing touches the
+     * filesystem before this method returns successfully.
+     */
+    private String validate(MultipartFile file) throws IOException {
+        // 1. Size cap
+        if (file.getSize() > MAX_DRIVER_JAR_BYTES) {
+            throw new BusinessException("jdbc.driver.uploadTooLarge",
+                    new Object[]{file.getSize(), MAX_DRIVER_JAR_BYTES});
+        }
+
+        // 2. Filename validation — strip any client-supplied path, then apply
+        //    a strict whitelist so weird names cannot cause trouble downstream.
+        String original = file.getOriginalFilename();
+        String name = original == null ? null : FilenameUtils.getName(original);
+        if (StringUtils.isBlank(name) || !name.matches(SAFE_FILENAME_REGEX)) {
+            log.warn("SECURITY: rejected driver upload with invalid filename: {}", original);
+            throw new BusinessException("jdbc.driver.invalidFileName", new Object[]{original});
+        }
+
+        // 3. Magic bytes — must be a real ZIP (and therefore a real JAR).
+        try (InputStream in = file.getInputStream()) {
+            byte[] head = new byte[ZIP_MAGIC.length];
+            int read = in.read(head);
+            if (read < ZIP_MAGIC.length) {
+                throw new BusinessException("jdbc.driver.notAJar", new Object[]{name});
+            }
+            for (int i = 0; i < ZIP_MAGIC.length; i++) {
+                if (head[i] != ZIP_MAGIC[i]) {
+                    throw new BusinessException("jdbc.driver.notAJar", new Object[]{name});
+                }
+            }
+        }
+
+        // 4. Jar-entry scan — reject zip-slip and require at least one .class
+        //    file (a jar with no class files is not a JDBC driver).
+        boolean hasClassFile = false;
+        try (JarInputStream jar = new JarInputStream(file.getInputStream())) {
+            JarEntry entry;
+            while ((entry = jar.getNextJarEntry()) != null) {
+                String entryName = entry.getName();
+                if (entryName.contains("..")) {
+                    log.warn("SECURITY: rejected driver jar with zip-slip entry: {} in {}",
+                            entryName, name);
+                    throw new BusinessException("jdbc.driver.zipSlip", new Object[]{name});
+                }
+                if (!entry.isDirectory() && entryName.toLowerCase(Locale.ROOT).endsWith(".class")) {
+                    hasClassFile = true;
+                }
+            }
+        }
+        if (!hasClassFile) {
+            throw new BusinessException("jdbc.driver.noClassFiles", new Object[]{name});
+        }
+
+        return name;
     }
 }


### PR DESCRIPTION
 This PR fixes a two-stage unauthenticated remote code execution (RCE) vulnerability affecting v0.3.0 → v5.3.1
  (including `chat2db/chat2db:latest` Docker image). A corresponding private security advisory has been filed with full
  PoC details.

  - **Stage 1**: `POST /api/jdbc/driver/upload` accepted any jar with no auth or validation
  - **Stage 2**: `JdbcDriverManager.getJDBCDriver()` called `URLClassLoader.loadClass(jdbcDriverClass).newInstance()`
  with a fully attacker-controlled class name, firing `<clinit>` and yielding RCE

  CVSS v3.1: **9.8 Critical** (`AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`)
  CWE-434, CWE-470, CWE-829

  This is **not** the same as CVE-2026-4586 (which only covered Stage 1, CVSS 6.3 PR:L). This PR fixes the previously
  unfixed Stage 2 class-loading primitive — an independent CWE-470 defect.

  ## Fix — three layers of defence-in-depth

  Any one alone breaks the public PoC; together they make the attack class infeasible.

  ### Layer 1 — Upload validation (`MultipartJdbcDriverUploadAdapter.java`)
  - 50 MB size cap
  - Strict filename regex `[a-zA-Z0-9_\-]+\.jar`
  - ZIP magic-byte check
  - Jar entry scan: rejects zip-slip and jars with no `.class` files
  - Canonical-path containment check before write

  ### Layer 2 — Class-name whitelist (`JdbcDriverManager.java`) — *the critical fix*
  - New `assertDriverClassAllowed()` called BEFORE every `loadClass()`
  - Default whitelist derived from every `chat2db-community-plugins/*.json` (all 30+ built-in drivers keep working)
  - Operators can extend (never shrink) via `-Dchat2db.jdbc.allowed-class-prefixes=...`
  - Enforced at three entry points: `getJDBCDriver()`, `getClassLoader()`, `getURLClassLoader()`

  ### Layer 3 — Path traversal defense (`JdbcJarUtils.java`)
  - Rejects jar names containing `..`, `/`, `\`, or Windows drive letters
  - Enforces canonical-path containment within `DRIVER_LIB_PATH`

  ## Verification

  End-to-end tested against `chat2db/chat2db:latest`:

  | | Vulnerable (unpatched) | Patched |
  |---|---|---|
  | Stage 2 RCE | ✅ `<clinit>` fires, `/tmp/pwned.txt` written | ✅ `driver.class.not.allowed`, no file written |
  | Path traversal `../../../etc/passwd` | (vulnerable) | ✅ rejected with `jarPath must be a simple filename` |
  | Legitimate MySQL driver load | works | works |
  | Security log | (none) | `SECURITY: rejected loadClass for non-whitelisted JDBC driver class 'com.evil.EvilDriver'` |

  ## Test plan

  - [x] Public PoC (Stage 1 + Stage 2) rejected with `driver.class.not.allowed`
  - [x] Path traversal in `jdbcDriver` rejected
  - [x] Default MySQL driver still loads
  - [x] All 30+ built-in drivers in `chat2db-community-plugins/*.json` are in the default whitelist
  - [x] `mvn clean package -Dmaven.test.skip=true` succeeds
  - [x] Container starts cleanly with patched jar

  ## Backwards compatibility

  - ✅ All built-in drivers work unchanged
  - ✅ Public API unchanged
  - ⚠️ Operators using custom drivers with non-standard package prefixes must add
  `-Dchat2db.jdbc.allowed-class-prefixes=com.acme.` to the JVM args. Documented in commit message.

  ## Out of scope (for follow-up PRs)

  - Adding authentication on `/api/jdbc/driver/upload` (breaking change, deserves its own discussion)
  - Signed jars / SecurityManager sandboxing (long-term hardening)
  - Pro edition audit (this PR covers community only)

  Refs: CVE-2026-4586 (Stage 1 only); #1826 (closed as "outside threat model" — that assessment is disputed in the
  attached security advisory).