### PR TITLE
feat(workspace): open history in editable console

### DIFF
--- a/chat2db-community-client/scripts/i18n-source-hashes.json
+++ b/chat2db-community-client/scripts/i18n-source-hashes.json
@@ -5,7 +5,7 @@
     "es-ES": {
       "ai.ts": "391a6e14c58d8401bf3bc245eca5bdd4b66efd8225a877bfbbcae01a1c1c019a",
       "chat.ts": "0cbe009eacbaa95a9a29bbc69588cb547e90b563667c53edec3e54ee64f5667b",
-      "common.ts": "1f70d1ba81aecbbd985a9dd9d1ae8b18ddfb3d209982a2ca17fbe3e4bf883a1f",
+      "common.ts": "8796e1084e494aac89a887dbd2546ec08e3ecbf0bbf22dbe0b342280d6702182",
       "connection.ts": "41d07fd10c9550ae51995620cc998de5e99add35edb31c2bb592864c76c13688",
       "dashboard.ts": "b217bbe260c7674d4efad1dd1b61136653858884f5b9b2134cfdf7d1de5a44ee",
       "editTable.ts": "0f7a808f50053cd52b183d156bb4fd46bb125b8058f8774deb61c7f02894a350",
@@ -32,7 +32,7 @@
     "ko-KR": {
       "ai.ts": "391a6e14c58d8401bf3bc245eca5bdd4b66efd8225a877bfbbcae01a1c1c019a",
       "chat.ts": "0cbe009eacbaa95a9a29bbc69588cb547e90b563667c53edec3e54ee64f5667b",
-      "common.ts": "1f70d1ba81aecbbd985a9dd9d1ae8b18ddfb3d209982a2ca17fbe3e4bf883a1f",
+      "common.ts": "8796e1084e494aac89a887dbd2546ec08e3ecbf0bbf22dbe0b342280d6702182",
       "connection.ts": "41d07fd10c9550ae51995620cc998de5e99add35edb31c2bb592864c76c13688",
       "dashboard.ts": "b217bbe260c7674d4efad1dd1b61136653858884f5b9b2134cfdf7d1de5a44ee",
       "editTable.ts": "0f7a808f50053cd52b183d156bb4fd46bb125b8058f8774deb61c7f02894a350",

--- a/chat2db-community-client/src/components/Output/index.tsx
+++ b/chat2db-community-client/src/components/Output/index.tsx
@@ -11,6 +11,7 @@ import { useWorkspaceStore } from '@/store/workspace';
 import { copyToClipboard, getTemporaryId } from '@/utils';
 import { useTreeStore } from '@/store/tree';
 import { TreeNodeData } from '@/typings';
+import { SquareArrowOutUpRight } from 'lucide-react';
 
 interface IProps {
   className?: string;
@@ -150,10 +151,10 @@ export default memo<IProps>((props) => {
     getHistoryList();
   }, [getHistoryList]);
 
-  const openHistoryTab = useCallback(
-    async (item: IDatasource) => {
+  const openHistoryConsole = useCallback(
+    async (item: IDatasource, readOnly: boolean) => {
       const detail = await getFullHistoryRecord(item);
-      const tabId = getTemporaryId(`execution-log-${item.id || Date.now()}`);
+      const tabId = getTemporaryId(`${readOnly ? 'execution-log' : 'execution-log-copy'}-${item.id || Date.now()}`);
       const sourceInfo =
         dataSourceInfoMap[getHistorySourceKey(detail)] || dataSourceInfoMap[getHistorySourceKey(item)];
       const cachedSourceName =
@@ -167,7 +168,7 @@ export default memo<IProps>((props) => {
         type: WorkspaceTabType.CONSOLE,
         title,
         uniqueData: {
-          consoleId: tabId,
+          consoleId: readOnly ? tabId : undefined,
           dataSourceId: detail.dataSourceId || undefined,
           dataSourceName: dataSourceName === '-' ? undefined : dataSourceName,
           databaseType: detail.type || sourceInfo?.extraParams?.databaseType || undefined,
@@ -177,11 +178,24 @@ export default memo<IProps>((props) => {
           ddl: detail.ddl || '',
           connectable: detail.connectable ?? undefined,
           popoverContent,
-          readOnly: true,
+          readOnly,
         },
       });
     },
     [addWorkspaceTab, dataSourceInfoMap, dataSourceNameMap, getFullHistoryRecord],
+  );
+
+  const openHistoryTab = useCallback(
+    (item: IDatasource) => openHistoryConsole(item, true),
+    [openHistoryConsole],
+  );
+
+  const openEditableHistoryTab = useCallback(
+    (event: React.MouseEvent, item: IDatasource) => {
+      event.stopPropagation();
+      return openHistoryConsole(item, false);
+    },
+    [openHistoryConsole],
   );
 
   const copyHistorySql = useCallback(
@@ -280,6 +294,13 @@ export default memo<IProps>((props) => {
                     </div>
                   </div>
                   <div className={classnames(styles.recordActions, 'output-record-actions')}>
+                    <IconButton
+                      className={styles.actionButton}
+                      icon={SquareArrowOutUpRight}
+                      size="sm"
+                      title={i18n('common.button.openInNewConsole')}
+                      onClick={(event) => openEditableHistoryTab(event, item)}
+                    />
                     <IconButton
                       className={styles.actionButton}
                       code="icon-copy"

--- a/chat2db-community-client/src/i18n/en-US/common.ts
+++ b/chat2db-community-client/src/i18n/en-US/common.ts
@@ -76,6 +76,7 @@ export default {
   'common.button.copyName': 'Copy name',
   'common.button.copySuccessfully': 'Copy Successfully',
   'common.button.createConsole': 'Create Console',
+  'common.button.openInNewConsole': 'Open in new console',
   'common.button.exportWord': 'Export to Word',
   'common.button.exportExcel': 'Export to Excel',
   'common.button.exportHtml': 'Export to Html',

--- a/chat2db-community-client/src/i18n/es-ES/common.ts
+++ b/chat2db-community-client/src/i18n/es-ES/common.ts
@@ -76,6 +76,7 @@ export default {
   'common.button.copyName': 'Copiar nombre',
   'common.button.copySuccessfully': 'Copiado correctamente',
   'common.button.createConsole': 'Crear consola',
+  'common.button.openInNewConsole': 'Abrir en una consola nueva',
   'common.button.exportWord': 'Exportar a Word',
   'common.button.exportExcel': 'Exportar a Excel',
   'common.button.exportHtml': 'Exportar a HTML',

--- a/chat2db-community-client/src/i18n/ja-JP/common.ts
+++ b/chat2db-community-client/src/i18n/ja-JP/common.ts
@@ -76,6 +76,7 @@ export default {
   'common.button.copyName': '名前をコピー',
   'common.button.copySuccessfully': 'コピー成功',
   'common.button.createConsole': '新しいコンソールを作成',
+  'common.button.openInNewConsole': '新しいコンソールで開く',
   'common.button.exportWord': 'Wordにエクスポート',
   'common.button.exportExcel': 'Excelにエクスポート',
   'common.button.exportHtml': 'Htmlにエクスポート',

--- a/chat2db-community-client/src/i18n/ko-KR/common.ts
+++ b/chat2db-community-client/src/i18n/ko-KR/common.ts
@@ -76,6 +76,7 @@ export default {
   'common.button.copyName': '이름 복사',
   'common.button.copySuccessfully': '복사되었습니다',
   'common.button.createConsole': '콘솔 만들기',
+  'common.button.openInNewConsole': '새 콘솔에서 열기',
   'common.button.exportWord': 'Word로 내보내기',
   'common.button.exportExcel': 'Excel로 내보내기',
   'common.button.exportHtml': 'HTML로 내보내기',

--- a/chat2db-community-client/src/i18n/zh-CN/common.ts
+++ b/chat2db-community-client/src/i18n/zh-CN/common.ts
@@ -76,6 +76,7 @@ export default {
   'common.button.copyName': '复制名称',
   'common.button.copySuccessfully': '复制成功',
   'common.button.createConsole': '新建控制台',
+  'common.button.openInNewConsole': '在新控制台中打开',
   'common.button.exportWord': '导出到Word',
   'common.button.exportExcel': '导出到Excel',
   'common.button.exportHtml': '导出到Html',


### PR DESCRIPTION
## Related issue

Closes #2242

## Summary

Adds an explicit action to open an execution-history record in a new editable SQL console. The temporary console carries over the original SQL, data source, database, schema, database type, and connection metadata while remaining independent from the immutable history record.

The existing row click continues to open the read-only history view. A Lucide open-in-new icon next to the copy action creates the editable draft instead.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn eslint src/components/Output/index.tsx --max-warnings=0` - passed
  - `yarn test:i18n --write-source-hashes` - passed; validated 25 frontend modules, 2 properties bundles, and 5 READMEs
  - `yarn lint` - passed
  - `yarn build:web:community --app_version=5.3.0` - passed, including configured prebuild tests
  - `git diff --check` - passed
- Manual verification: Verified on the local Community runtime that the new action opens an editable temporary SQL tab with the original connection context and does not change the read-only history view.
- UI evidence: N/A - verified interactively; no screenshot was captured.

## Risk and compatibility

- Public API or stored data: N/A - no API or persisted history contract changes.
- Database or driver compatibility: N/A - the existing history metadata is copied without database-specific behavior changes.
- Network, privacy, or security: N/A - no new requests or data exposure paths.
- Community / Local / Pro boundary: The shared frontend component changes only the history-to-console interaction and does not add edition-specific behavior.
- Backward compatibility: Existing history row clicks and copy actions are unchanged.

## Reviewer map

- Start here: `chat2db-community-client/src/components/Output/index.tsx`, especially `openHistoryConsole` and the new record action.
- Failure condition: The new action opens a read-only tab, loses the original data source/database/schema binding, or mutates the execution-history record.
- Rollback or disable path: Revert this PR; the existing read-only history view and copy action remain the fallback workflow.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex implemented and verified the change under maintainer direction.
