### PR TITLE
fix(redis): quote key names in DEL/RENAME, apply grid edits atomically, iterate full SCAN cursor

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisDBManager.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisDBManager.java
@@ -1,6 +1,7 @@
 package ai.chat2db.plugin.redis;
 
 import ai.chat2db.plugin.redis.constant.RedisConstants;
+import ai.chat2db.plugin.redis.util.RedisValueUtils;
 import ai.chat2db.spi.IDbManager;
 import ai.chat2db.spi.DefaultDBManager;
 import ai.chat2db.spi.DefaultSQLExecutor;
@@ -21,7 +22,7 @@ public class RedisDBManager extends DefaultDBManager implements IDbManager {
 
     @Override
     public String dropTable(Connection connection, String databaseName, String schemaName, String tableName) {
-        return RedisConstants.COMMAND_DELETE_TABLE_PREFIX + tableName;
+        return RedisConstants.COMMAND_DELETE_TABLE_PREFIX + RedisValueUtils.getRedisValue(tableName);
     }
 
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisMetaData.java
@@ -30,7 +30,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 public class RedisMetaData extends DefaultMetaService implements IDbMetaData {
@@ -201,20 +203,35 @@ public class RedisMetaData extends DefaultMetaService implements IDbMetaData {
 
     @Override
     public List<Table> tables(Connection connection, String databaseName, String schemaName, String tableName) {
-        String query = String.format(RedisCommandTemplates.SCAN_MATCH_COUNT, RedisConstants.SCAN_INITIAL_CURSOR,
-                RedisValueUtils.getRedisValue("*"), RedisScanConfig.DEFAULT.tableScanCount());
-        return DefaultSQLExecutor.getInstance().execute(connection, query, resultSet -> {
-            List<Table> tables = new ArrayList<>();
-            while (resultSet.next()) {
-                List<?> keys = RedisScanUtils.getKeys(resultSet.getObject(2));
-                for (Object object : keys) {
-                    Table table = new Table();
-                    table.setName(object.toString());
-                    tables.add(table);
+        List<Table> tables = new ArrayList<>();
+        Set<String> names = new HashSet<>();
+        String cursor = RedisConstants.SCAN_INITIAL_CURSOR;
+        int scanCalls = 0;
+        do {
+            String query = String.format(RedisCommandTemplates.SCAN_MATCH_COUNT, cursor,
+                    RedisValueUtils.getRedisValue("*"), RedisScanConfig.DEFAULT.tableScanCount());
+            cursor = DefaultSQLExecutor.getInstance().execute(connection, query, resultSet -> {
+                String nextCursor = RedisConstants.SCAN_INITIAL_CURSOR;
+                while (resultSet.next()) {
+                    Object cursorValue = resultSet.getObject(1);
+                    if (cursorValue != null) {
+                        nextCursor = RedisScanUtils.normalizeCursor(cursorValue.toString());
+                    }
+                    List<?> keys = RedisScanUtils.getKeys(resultSet.getObject(2));
+                    for (Object object : keys) {
+                        if (names.add(object.toString())) {
+                            Table table = new Table();
+                            table.setName(object.toString());
+                            tables.add(table);
+                        }
+                    }
                 }
-            }
-            return tables;
-        });
+                return nextCursor;
+            });
+            scanCalls++;
+        } while (!RedisConstants.SCAN_INITIAL_CURSOR.equals(cursor)
+                && scanCalls < RedisScanConfig.DEFAULT.maxScanCallsPerRequest());
+        return tables;
     }
 
     public List<RedisKey> keys(Connection connection, String databaseName, String schemaName, String tableName) {
@@ -262,32 +279,39 @@ public class RedisMetaData extends DefaultMetaService implements IDbMetaData {
     }
 
     private void match(Connection connection, List<RedisKey> redisKeys, String pattern, String cursor) {
-        String query = String.format(RedisCommandTemplates.SCAN_MATCH_COUNT, cursor,
-                RedisValueUtils.getRedisValue(RedisScanUtils.buildContainsMatchPattern(pattern)),
-                RedisScanConfig.DEFAULT.legacyMatchCount());
-        cursor = DefaultSQLExecutor.getInstance().execute(connection, query, resultSet -> {
-            String nextCursor = RedisConstants.SCAN_INITIAL_CURSOR;
-            while (resultSet.next()) {
-                Object cou = resultSet.getObject(1);
-                if (cou != null) {
-                    nextCursor = RedisScanUtils.normalizeCursor(cou.toString());
+        Set<String> names = new HashSet<>();
+        int scanCalls = 0;
+        do {
+            String query = String.format(RedisCommandTemplates.SCAN_MATCH_COUNT, cursor,
+                    RedisValueUtils.getRedisValue(RedisScanUtils.buildContainsMatchPattern(pattern)),
+                    RedisScanConfig.DEFAULT.legacyMatchCount());
+            cursor = DefaultSQLExecutor.getInstance().execute(connection, query, resultSet -> {
+                String nextCursor = RedisConstants.SCAN_INITIAL_CURSOR;
+                while (resultSet.next()) {
+                    Object cou = resultSet.getObject(1);
+                    if (cou != null) {
+                        nextCursor = RedisScanUtils.normalizeCursor(cou.toString());
+                    }
+                    List<?> keys = RedisScanUtils.getKeys(resultSet.getObject(2));
+                    for (Object object : keys) {
+                        String keyName = object.toString();
+                        if (!names.add(keyName)) {
+                            continue;
+                        }
+                        RedisKey redisKey = new RedisKey();
+                        redisKey.setName(keyName);
+                        String keyType = RedisScriptExecutor.getInstance().getKeyType(keyName);
+                        redisKey.setType(keyType);
+                        ITypeScript typeScript = RedisDataType.fromCode(keyType).getScript();
+                        redisKeys.add(typeScript.getKeyR(connection, redisKey));
+                    }
                 }
-                List<?> keys = RedisScanUtils.getKeys(resultSet.getObject(2));
-                for (Object object : keys) {
-                    RedisKey redisKey = new RedisKey();
-                    redisKey.setName(object.toString());
-                    String keyType = RedisScriptExecutor.getInstance().getKeyType(object.toString());
-                    redisKey.setType(keyType);
-                    ITypeScript typeScript = RedisDataType.fromCode(keyType).getScript();
-                    redisKeys.add(typeScript.getKeyR(connection, redisKey));
-                }
-            }
-            return nextCursor;
-        });
-        if (!RedisConstants.SCAN_INITIAL_CURSOR.equals(cursor)
-                && redisKeys.size() < RedisScanConfig.DEFAULT.legacyTopCount()) {
-            match(connection, redisKeys, pattern, cursor);
-        }
+                return nextCursor;
+            });
+            scanCalls++;
+        } while (!RedisConstants.SCAN_INITIAL_CURSOR.equals(cursor)
+                && redisKeys.size() < RedisScanConfig.DEFAULT.legacyTopCount()
+                && scanCalls < RedisScanConfig.DEFAULT.maxScanCallsPerRequest());
     }
 
     private List<RedisKey> findTop(Connection connection) {
@@ -295,9 +319,13 @@ public class RedisMetaData extends DefaultMetaService implements IDbMetaData {
                 RedisValueUtils.getRedisValue("*"), RedisScanConfig.DEFAULT.legacyTopCount());
         return DefaultSQLExecutor.getInstance().execute(connection, query, resultSet -> {
             List<RedisKey> redisKeys = new ArrayList<>();
+            Set<String> names = new HashSet<>();
             while (resultSet.next()) {
                 List<?> keys = RedisScanUtils.getKeys(resultSet.getObject(2));
                 for (Object object : keys) {
+                    if (!names.add(object.toString())) {
+                        continue;
+                    }
                     RedisKey redisKey = findKey(connection, object.toString());
                     if (redisKey != null) {
                         redisKeys.add(redisKey);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisScriptExecutor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisScriptExecutor.java
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -65,8 +66,11 @@ public class RedisScriptExecutor extends DefaultSQLExecutor {
         RedisKey redisKey = RedisKey.builder()
                 .name(command.getTableName())
                 .build();
-        Map<String, Object> extra = Map.of(RedisConstants.FIELD_KEY_TYPE, keyType, RedisConstants.FIELD_KEY,
-                command.getTableName(), RedisConstants.FIELD_TTL, getTtl(command.getTableName()));
+        // getKeyType/getTtl yield null on empty driver result sets; Map.of would NPE on null values.
+        Map<String, Object> extra = new HashMap<>();
+        extra.put(RedisConstants.FIELD_KEY_TYPE, keyType);
+        extra.put(RedisConstants.FIELD_KEY, command.getTableName());
+        extra.put(RedisConstants.FIELD_TTL, getTtl(command.getTableName()));
         String script = typeScript.getKey(redisKey);
         command.setScript(script);
         List<ExecuteResponse> results = execute(command);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisSqlBuilder.java
@@ -5,7 +5,6 @@ import ai.chat2db.spi.constant.SQLConstants;
 
 import ai.chat2db.plugin.redis.model.RedisKey;
 import ai.chat2db.plugin.redis.enums.type.RedisDataType;
-import ai.chat2db.plugin.redis.type.ITypeScript;
 import ai.chat2db.spi.ISqlBuilder;
 import ai.chat2db.spi.sql.builder.IDatabaseSqlBuilder;
 import ai.chat2db.spi.sql.builder.IDdlSqlBuilder;
@@ -36,8 +35,12 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
+import static ai.chat2db.plugin.redis.util.RedisValueUtils.getRedisValue;
 
 public class RedisSqlBuilder implements ISqlBuilder, IDqlSqlBuilder, IDmlSqlBuilder, IDdlSqlBuilder,
         IDatabaseSqlBuilder, ISchemaSqlBuilder, ITableSqlBuilder, IViewSqlBuilder {
@@ -165,18 +168,180 @@ public class RedisSqlBuilder implements ISqlBuilder, IDqlSqlBuilder, IDmlSqlBuil
         List<Header> headerList = queryResult.getHeaderList();
         List<ResultOperation> operations = queryResult.getOperations();
         String tableName = queryResult.getTableName();
-        if (CollectionUtils.isEmpty(operations)) {
+        if (StringUtils.isBlank(tableName) || CollectionUtils.isEmpty(operations)) {
             return StringUtils.EMPTY;
         }
         String redisKeyType = RedisScriptExecutor.getInstance().getKeyType(tableName);
-        ITypeScript typeScript = RedisDataType.fromCode(redisKeyType).getScript();
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(RedisConstants.REDIS_MULTI_COMMAND);
         stringBuilder.append(renameOrUpdateTtl(queryResult));
         for (ResultOperation operation : operations) {
+            stringBuilder.append(buildOperationScript(redisKeyType, queryResult.getTableName(), headerList, operation));
         }
         stringBuilder.append(RedisConstants.REDIS_EXEC_COMMAND);
         return stringBuilder.toString();
+    }
+
+    private String buildOperationScript(String redisKeyType, String keyName, List<Header> headerList,
+            ResultOperation operation) {
+        Map<String, String> oldRow = rowByHeader(headerList, operation.getOldDataList());
+        Map<String, String> newRow = rowByHeader(headerList, operation.getDataList());
+        String operationType = operation.getType();
+        StringBuilder script = new StringBuilder();
+        switch (RedisDataType.fromCode(redisKeyType)) {
+            case HASH:
+                appendHashOperation(script, keyName, operationType, oldRow, newRow);
+                break;
+            case SET:
+                appendSetOperation(script, keyName, operationType, oldRow, newRow);
+                break;
+            case ZSET:
+                appendZSetOperation(script, keyName, operationType, oldRow, newRow);
+                break;
+            case LIST:
+                appendListOperation(script, keyName, operationType, operation, oldRow, newRow);
+                break;
+            case STRING:
+                appendStringOperation(script, keyName, operationType, newRow);
+                break;
+            default:
+                break;
+        }
+        return script.toString();
+    }
+
+    private Map<String, String> rowByHeader(List<Header> headerList, List<String> dataList) {
+        Map<String, String> row = new HashMap<>();
+        if (CollectionUtils.isEmpty(headerList) || CollectionUtils.isEmpty(dataList)) {
+            return row;
+        }
+        for (int i = 0; i < headerList.size() && i < dataList.size(); i++) {
+            Header header = headerList.get(i);
+            if (header != null && StringUtils.isNotBlank(header.getName())) {
+                row.put(header.getName(), dataList.get(i));
+            }
+        }
+        return row;
+    }
+
+    private void appendHashOperation(StringBuilder script, String keyName, String operationType,
+            Map<String, String> oldRow, Map<String, String> newRow) {
+        String oldField = oldRow.get(RedisConstants.FIELD_FIELD);
+        String newField = newRow.get(RedisConstants.FIELD_FIELD);
+        if (SQLConstants.CREATE_KEYWORD.equals(operationType)) {
+            if (StringUtils.isNotBlank(newField)) {
+                appendCommand(script, RedisConstants.COMMAND_HASH_SET_PREFIX, keyName, newField,
+                        newRow.get(RedisConstants.FIELD_VALUE));
+            }
+        } else if (SQLConstants.UPDATE_KEYWORD.equals(operationType)) {
+            if (StringUtils.isNotBlank(oldField) && !Objects.equals(oldField, newField)) {
+                appendCommand(script, RedisConstants.COMMAND_HASH_DELETE_PREFIX, keyName, oldField);
+            }
+            if (StringUtils.isNotBlank(newField)) {
+                appendCommand(script, RedisConstants.COMMAND_HASH_SET_PREFIX, keyName, newField,
+                        newRow.get(RedisConstants.FIELD_VALUE));
+            }
+        } else if (SQLConstants.DELETE_KEYWORD.equals(operationType)) {
+            if (StringUtils.isNotBlank(oldField)) {
+                appendCommand(script, RedisConstants.COMMAND_HASH_DELETE_PREFIX, keyName, oldField);
+            }
+        }
+    }
+
+    private void appendSetOperation(StringBuilder script, String keyName, String operationType,
+            Map<String, String> oldRow, Map<String, String> newRow) {
+        String oldValue = oldRow.get(RedisConstants.FIELD_VALUE);
+        String newValue = newRow.get(RedisConstants.FIELD_VALUE);
+        if (SQLConstants.CREATE_KEYWORD.equals(operationType)) {
+            appendCommand(script, RedisConstants.COMMAND_SET_ADD_PREFIX, keyName, newValue);
+        } else if (SQLConstants.UPDATE_KEYWORD.equals(operationType)) {
+            if (!Objects.equals(oldValue, newValue)) {
+                appendCommand(script, RedisConstants.COMMAND_SET_REMOVE_PREFIX, keyName, oldValue);
+                appendCommand(script, RedisConstants.COMMAND_SET_ADD_PREFIX, keyName, newValue);
+            }
+        } else if (SQLConstants.DELETE_KEYWORD.equals(operationType)) {
+            appendCommand(script, RedisConstants.COMMAND_SET_REMOVE_PREFIX, keyName, oldValue);
+        }
+    }
+
+    private void appendZSetOperation(StringBuilder script, String keyName, String operationType,
+            Map<String, String> oldRow, Map<String, String> newRow) {
+        String oldValue = oldRow.get(RedisConstants.FIELD_VALUE);
+        String newValue = newRow.get(RedisConstants.FIELD_VALUE);
+        String newScore = StringUtils.defaultIfBlank(newRow.get(RedisConstants.FIELD_SCORE), "0");
+        if (SQLConstants.CREATE_KEYWORD.equals(operationType)) {
+            appendZAddCommand(script, keyName, newScore, newValue);
+        } else if (SQLConstants.UPDATE_KEYWORD.equals(operationType)) {
+            if (!Objects.equals(oldValue, newValue)) {
+                appendCommand(script, RedisConstants.COMMAND_ZSET_REMOVE_PREFIX, keyName, oldValue);
+                appendZAddCommand(script, keyName, newScore, newValue);
+            } else if (!Objects.equals(oldRow.get(RedisConstants.FIELD_SCORE), newRow.get(RedisConstants.FIELD_SCORE))) {
+                appendZAddCommand(script, keyName, newScore, newValue);
+            }
+        } else if (SQLConstants.DELETE_KEYWORD.equals(operationType)) {
+            appendCommand(script, RedisConstants.COMMAND_ZSET_REMOVE_PREFIX, keyName, oldValue);
+        }
+    }
+
+    private void appendListOperation(StringBuilder script, String keyName, String operationType,
+            ResultOperation operation, Map<String, String> oldRow, Map<String, String> newRow) {
+        if (SQLConstants.CREATE_KEYWORD.equals(operationType)) {
+            appendCommand(script, RedisConstants.COMMAND_LIST_RIGHT_PUSH_PREFIX, keyName,
+                    newRow.get(RedisConstants.FIELD_VALUE));
+        } else if (SQLConstants.UPDATE_KEYWORD.equals(operationType)) {
+            Integer index = rowNumberIndex(operation.getOldDataList());
+            if (index != null) {
+                script.append("LSET ").append(getRedisValue(keyName))
+                        .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(index)
+                        .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR)
+                        .append(getRedisValue(StringUtils.defaultString(newRow.get(RedisConstants.FIELD_VALUE))))
+                        .append(SQLConstants.LINE_SEPARATOR);
+            }
+        } else if (SQLConstants.DELETE_KEYWORD.equals(operationType)) {
+            script.append(RedisConstants.COMMAND_LIST_REMOVE_PREFIX).append(getRedisValue(keyName))
+                    .append(RedisConstants.COMMAND_LIST_REMOVE_ONE_FRAGMENT)
+                    .append(getRedisValue(StringUtils.defaultString(oldRow.get(RedisConstants.FIELD_VALUE))))
+                    .append(SQLConstants.LINE_SEPARATOR);
+        }
+    }
+
+    private Integer rowNumberIndex(List<String> oldDataList) {
+        if (CollectionUtils.isEmpty(oldDataList)) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(oldDataList.get(0).trim()) - 1;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void appendStringOperation(StringBuilder script, String keyName, String operationType,
+            Map<String, String> newRow) {
+        if (SQLConstants.CREATE_KEYWORD.equals(operationType) || SQLConstants.UPDATE_KEYWORD.equals(operationType)) {
+            appendCommand(script, RedisConstants.COMMAND_SET_KEY_PREFIX, keyName,
+                    newRow.get(RedisConstants.FIELD_VALUE));
+        } else if (SQLConstants.DELETE_KEYWORD.equals(operationType)) {
+            script.append(RedisConstants.COMMAND_DELETE_KEY_PREFIX).append(getRedisValue(keyName))
+                    .append(SQLConstants.LINE_SEPARATOR);
+        }
+    }
+
+    private void appendZAddCommand(StringBuilder script, String keyName, String score, String value) {
+        script.append(RedisConstants.COMMAND_ZSET_ADD_PREFIX).append(getRedisValue(keyName))
+                .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(score)
+                .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR)
+                .append(getRedisValue(StringUtils.defaultString(value)))
+                .append(SQLConstants.LINE_SEPARATOR);
+    }
+
+    private void appendCommand(StringBuilder script, String commandPrefix, String keyName, String... args) {
+        script.append(commandPrefix).append(getRedisValue(keyName));
+        for (String arg : args) {
+            script.append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR)
+                    .append(getRedisValue(StringUtils.defaultString(arg)));
+        }
+        script.append(SQLConstants.LINE_SEPARATOR);
     }
 
     private String renameOrUpdateTtl(QueryResponse queryResult) {
@@ -187,14 +352,27 @@ public class RedisSqlBuilder implements ISqlBuilder, IDqlSqlBuilder, IDmlSqlBuil
         StringBuilder stringBuilder = new StringBuilder();
         String key = MapUtils.getString(extra, RedisConstants.FIELD_KEY);
         String ttl = MapUtils.getString(extra, RedisConstants.FIELD_TTL);
-        if (StringUtils.isNotBlank(key)) {
-            stringBuilder.append(RedisConstants.SQL_RENAME_KEY_PREFIX).append(queryResult.getTableName()).append(SQLConstants.SPACE).append(key).append(SQLConstants.LINE_SEPARATOR);
+        if (StringUtils.isNotBlank(key) && !StringUtils.equals(key, queryResult.getTableName())) {
+            stringBuilder.append(RedisConstants.SQL_RENAME_KEY_PREFIX).append(getRedisValue(queryResult.getTableName()))
+                    .append(SQLConstants.SPACE).append(getRedisValue(key)).append(SQLConstants.LINE_SEPARATOR);
             queryResult.setTableName(key);
         }
-        if (StringUtils.isNotBlank(ttl)) {
-            stringBuilder.append(RedisConstants.COMMAND_EXPIRE_KEY_PREFIX).append(queryResult.getTableName()).append(SQLConstants.SPACE).append(ttl).append(SQLConstants.LINE_SEPARATOR);
+        if (isPositiveTtl(ttl)) {
+            stringBuilder.append(RedisConstants.COMMAND_EXPIRE_KEY_PREFIX).append(getRedisValue(queryResult.getTableName()))
+                    .append(SQLConstants.SPACE).append(ttl.trim()).append(SQLConstants.LINE_SEPARATOR);
         }
         return stringBuilder.toString();
+    }
+
+    private boolean isPositiveTtl(String ttl) {
+        if (StringUtils.isBlank(ttl)) {
+            return false;
+        }
+        try {
+            return Long.parseLong(ttl.trim()) > 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisSqlBuilder.java
@@ -298,10 +298,26 @@ public class RedisSqlBuilder implements ISqlBuilder, IDqlSqlBuilder, IDmlSqlBuil
                         .append(SQLConstants.LINE_SEPARATOR);
             }
         } else if (SQLConstants.DELETE_KEYWORD.equals(operationType)) {
-            script.append(RedisConstants.COMMAND_LIST_REMOVE_PREFIX).append(getRedisValue(keyName))
-                    .append(RedisConstants.COMMAND_LIST_REMOVE_ONE_FRAGMENT)
-                    .append(getRedisValue(StringUtils.defaultString(oldRow.get(RedisConstants.FIELD_VALUE))))
-                    .append(SQLConstants.LINE_SEPARATOR);
+            Integer index = rowNumberIndex(operation.getOldDataList());
+            if (index != null) {
+                // Positional delete so a later duplicate occurrence removes exactly the
+                // edited row: LSET idx <tombstone> then LREM 1 <tombstone>. Value-based
+                // LREM would always hit the FIRST duplicate instead.
+                String tombstone = "__chat2db_deleted__" + index;
+                script.append("LSET ").append(getRedisValue(keyName))
+                        .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(index)
+                        .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(getRedisValue(tombstone))
+                        .append(SQLConstants.LINE_SEPARATOR);
+                script.append(RedisConstants.COMMAND_LIST_REMOVE_PREFIX).append(getRedisValue(keyName))
+                        .append(RedisConstants.COMMAND_LIST_REMOVE_ONE_FRAGMENT)
+                        .append(getRedisValue(tombstone))
+                        .append(SQLConstants.LINE_SEPARATOR);
+            } else {
+                script.append(RedisConstants.COMMAND_LIST_REMOVE_PREFIX).append(getRedisValue(keyName))
+                        .append(RedisConstants.COMMAND_LIST_REMOVE_ONE_FRAGMENT)
+                        .append(getRedisValue(StringUtils.defaultString(oldRow.get(RedisConstants.FIELD_VALUE))))
+                        .append(SQLConstants.LINE_SEPARATOR);
+            }
         }
     }
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisSqlBuilder.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 import static ai.chat2db.plugin.redis.util.RedisValueUtils.getRedisValue;
 
@@ -303,7 +304,7 @@ public class RedisSqlBuilder implements ISqlBuilder, IDqlSqlBuilder, IDmlSqlBuil
                 // Positional delete so a later duplicate occurrence removes exactly the
                 // edited row: LSET idx <tombstone> then LREM 1 <tombstone>. Value-based
                 // LREM would always hit the FIRST duplicate instead.
-                String tombstone = "__chat2db_deleted__" + index;
+                String tombstone = "__chat2db_deleted__" + UUID.randomUUID();
                 script.append("LSET ").append(getRedisValue(keyName))
                         .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(index)
                         .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(getRedisValue(tombstone))
@@ -345,7 +346,8 @@ public class RedisSqlBuilder implements ISqlBuilder, IDqlSqlBuilder, IDmlSqlBuil
 
     private void appendZAddCommand(StringBuilder script, String keyName, String score, String value) {
         script.append(RedisConstants.COMMAND_ZSET_ADD_PREFIX).append(getRedisValue(keyName))
-                .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR).append(score)
+                .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR)
+                .append(getRedisValue(StringUtils.defaultString(score)))
                 .append(RedisConstants.COMMAND_ARGUMENT_SEPARATOR)
                 .append(getRedisValue(StringUtils.defaultString(value)))
                 .append(SQLConstants.LINE_SEPARATOR);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/HashTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/HashTypeScript.java
@@ -89,7 +89,9 @@ public class HashTypeScript extends BaseTypeScript implements ITypeScript {
         // so reconcile against the full old field list.
         Map<String, String> desired = fieldValues(newKey.getHashValues(), true);
         if (desired.isEmpty()) {
-            return new ArrayList<>();
+            // Every row was deleted in the editor: remove the key itself,
+            // mirroring the newKey == null path, instead of silently keeping old data.
+            return Lists.newArrayList(delete(newKey.getName()));
         }
         Map<String, String> existing = fieldValues(oldKey.getHashValues(), false);
         List<String> scripts = new ArrayList<>();

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ListTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ListTypeScript.java
@@ -91,7 +91,9 @@ public class ListTypeScript extends BaseTypeScript implements ITypeScript {
         // which makes value-based LREM/LINSERT reconciliation unsafe.
         List<ListValue> desired = desiredValues(newKey);
         if (desired.isEmpty()) {
-            return Lists.newArrayList();
+            // Every element was deleted in the editor: remove the key itself,
+            // mirroring the newKey == null path, instead of silently keeping old data.
+            return Lists.newArrayList(delete(newKey.getName()));
         }
         List<String> scripts = new ArrayList<>();
         scripts.add(delete(newKey.getName()));

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ListTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ListTypeScript.java
@@ -96,8 +96,13 @@ public class ListTypeScript extends BaseTypeScript implements ITypeScript {
             return Lists.newArrayList(delete(newKey.getName()));
         }
         List<String> scripts = new ArrayList<>();
+        // DEL + RPUSH must be atomic: if the connection drops between them the whole
+        // list would be lost. The executor sends each line on the same connection,
+        // so MULTI/EXEC lines wrap the pair (same pattern as buildByQueryResult).
+        scripts.add(RedisConstants.REDIS_MULTI_COMMAND.trim());
         scripts.add(delete(newKey.getName()));
         scripts.add(pushAll(newKey.getName(), desired));
+        scripts.add(RedisConstants.REDIS_EXEC_COMMAND);
         return scripts;
     }
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/SetTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/SetTypeScript.java
@@ -96,7 +96,9 @@ public class SetTypeScript extends BaseTypeScript implements ITypeScript {
         // old member list instead of trusting per-row action flags.
         Set<String> desired = memberSet(newKey.getValues(), true);
         if (desired.isEmpty()) {
-            return new ArrayList<>();
+            // Every member was deleted in the editor: remove the key itself,
+            // mirroring the newKey == null path, instead of silently keeping old data.
+            return Lists.newArrayList(delete(newKey.getName()));
         }
         Set<String> existing = memberSet(oldKey.getValues(), false);
         List<String> scripts = new ArrayList<>();

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ZSetTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/ZSetTypeScript.java
@@ -80,7 +80,9 @@ public class ZSetTypeScript extends BaseTypeScript implements ITypeScript {
         // old member list instead of trusting per-row action flags.
         Map<String, Double> desired = memberScores(newKey.getZsValues(), true);
         if (desired.isEmpty()) {
-            return new ArrayList<>();
+            // Every member was deleted in the editor: remove the key itself,
+            // mirroring the newKey == null path, instead of silently keeping old data.
+            return Lists.newArrayList(delete(newKey.getName()));
         }
         Map<String, Double> existing = memberScores(oldKey.getZsValues(), false);
         List<String> scripts = new ArrayList<>();

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/util/RedisValueUtils.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/util/RedisValueUtils.java
@@ -3,18 +3,21 @@ package ai.chat2db.plugin.redis.util;
 public class RedisValueUtils {
 
     public static String getRedisValue(String value) {
-        if(value == null) {
+        if (value == null) {
             return null;
         }
-        if(value.contains("\\")) {
+        if (value.indexOf('\0') >= 0 || value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0) {
+            throw new IllegalArgumentException("Redis JDBC command arguments cannot contain NUL, CR, or LF");
+        }
+        if (value.contains("\\")) {
             value = value.replace("\\", "\\\\");
         }
-        if(value.contains("'")) {
+        if (value.contains("'")) {
             value = value.replace("'", "\\'");
         }
-        if(value.contains("\"")) {
+        if (value.contains("\"")) {
             value = value.replace("\"", "\\\"");
         }
-        return "'"+value+"'";
+        return "'" + value + "'";
     }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisDBManagerTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisDBManagerTest.java
@@ -1,0 +1,20 @@
+package ai.chat2db.plugin.redis;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RedisDBManagerTest {
+
+    private final RedisDBManager dbManager = new RedisDBManager();
+
+    @Test
+    void dropTableQuotesKeyNameContainingSpaces() {
+        assertEquals("del 'foo bar'", dbManager.dropTable(null, null, null, "foo bar"));
+    }
+
+    @Test
+    void dropTableEscapesQuotesInKeyName() {
+        assertEquals("del 'it\\'s'", dbManager.dropTable(null, null, null, "it's"));
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisMetaDataScanTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisMetaDataScanTest.java
@@ -1,0 +1,222 @@
+package ai.chat2db.plugin.redis;
+
+import ai.chat2db.community.domain.api.config.DriverConfig;
+import ai.chat2db.community.domain.api.model.metadata.Table;
+import ai.chat2db.plugin.redis.config.RedisScanConfig;
+import ai.chat2db.plugin.redis.model.RedisKey;
+import ai.chat2db.spi.model.datasource.ConnectInfo;
+import ai.chat2db.spi.sql.Chat2DBContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RedisMetaDataScanTest {
+
+    @AfterEach
+    void tearDown() {
+        Chat2DBContext.close();
+    }
+
+    private ScanStub setup(Map<String, String> keyTypes, Map<String, ScanBatch> scanBatches) {
+        ScanStub stub = new ScanStub(keyTypes, scanBatches);
+        ConnectInfo connectInfo = new ConnectInfo();
+        connectInfo.setDbType("REDIS");
+        connectInfo.setDriverConfig(new DriverConfig());
+        connectInfo.setConnection(stub.connection());
+        Chat2DBContext.putContext(connectInfo);
+        return stub;
+    }
+
+    private record ScanBatch(String nextCursor, List<String> keys) {
+    }
+
+    @Test
+    void tablesScansAllBatchesAndDedupesKeys() {
+        ScanStub stub = setup(Map.of(), Map.of(
+                "0", new ScanBatch("5", List.of("a", "b", "a")),
+                "5", new ScanBatch("0", List.of("c", "a"))));
+
+        List<Table> tables = new RedisMetaData().tables(stub.connection(), null, null, null);
+
+        assertEquals(List.of("a", "b", "c"), tables.stream().map(Table::getName).toList());
+        assertEquals(2, stub.scanCalls());
+    }
+
+    @Test
+    void matchIteratesAcrossBatchesAndDedupesKeys() {
+        ScanStub stub = setup(Map.of("k1", "string", "k2", "string"), Map.of(
+                "0", new ScanBatch("3", List.of("k1", "k1")),
+                "3", new ScanBatch("0", List.of("k1", "k2"))));
+
+        List<RedisKey> keys = new RedisMetaData().keys(stub.connection(), null, null, "foo");
+
+        assertEquals(List.of("k1", "k2"), keys.stream().map(RedisKey::getName).toList());
+        assertEquals(2, stub.scanCalls());
+        assertEquals(1, stub.commandCount("type 'k1'"));
+    }
+
+    @Test
+    void matchStopsAfterScanCallBudgetInsteadOfRecursing() {
+        Map<String, ScanBatch> batches = new HashMap<>();
+        for (int i = 0; i < 30; i++) {
+            batches.put(String.valueOf(i), new ScanBatch(String.valueOf(i + 1), List.of()));
+        }
+        ScanStub stub = setup(Map.of(), batches);
+
+        List<RedisKey> keys = new RedisMetaData().keys(stub.connection(), null, null, "foo");
+
+        assertEquals(0, keys.size());
+        assertEquals(RedisScanConfig.DEFAULT.maxScanCallsPerRequest(), stub.scanCalls());
+    }
+
+    @Test
+    void findTopDedupesKeysWithinOneBatch() {
+        ScanStub stub = setup(Map.of("k1", "string"), Map.of(
+                "0", new ScanBatch("0", List.of("k1", "k1"))));
+
+        List<RedisKey> keys = new RedisMetaData().keys(stub.connection(), null, null, " ");
+
+        assertEquals(1, keys.size());
+        assertEquals("k1", keys.get(0).getName());
+        assertEquals(1, stub.commandCount("type 'k1'"));
+    }
+
+    private static final class ScanStub {
+
+        private final Map<String, String> keyTypes;
+        private final Map<String, ScanBatch> scanBatches;
+        private final List<String> commands = new ArrayList<>();
+
+        private ScanStub(Map<String, String> keyTypes, Map<String, ScanBatch> scanBatches) {
+            this.keyTypes = keyTypes;
+            this.scanBatches = scanBatches;
+        }
+
+        Connection connection() {
+            return proxy(Connection.class, (proxy, method, args) -> switch (method.getName()) {
+                case "prepareStatement" -> statement((String) args[0]);
+                case "isClosed" -> false;
+                case "close" -> null;
+                default -> defaultValue(method.getReturnType());
+            });
+        }
+
+        long scanCalls() {
+            return commands.stream().filter(command -> command.startsWith("scan ")).count();
+        }
+
+        long commandCount(String command) {
+            return commands.stream().filter(command::equals).count();
+        }
+
+        private PreparedStatement statement(String sql) {
+            final ResultSet[] resultSet = new ResultSet[1];
+            return proxy(PreparedStatement.class, (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "execute":
+                        commands.add(sql);
+                        resultSet[0] = resultSetFor(sql);
+                        return true;
+                    case "getResultSet":
+                        return resultSet[0];
+                    case "close":
+                        return null;
+                    default:
+                        return defaultValue(method.getReturnType());
+                }
+            });
+        }
+
+        private ResultSet resultSetFor(String sql) {
+            if (sql.startsWith("scan ")) {
+                String cursor = sql.split(" ")[1];
+                ScanBatch batch = scanBatches.getOrDefault(cursor, new ScanBatch("0", List.of()));
+                return resultSet(List.<Object[]>of(new Object[] {batch.nextCursor(), batch.keys()}));
+            }
+            if (sql.startsWith("EXISTS ")) {
+                return resultSet(List.<Object[]>of(new Object[] {keyTypes.containsKey(unquote(sql)) ? 1 : 0}));
+            }
+            if (sql.startsWith("type ")) {
+                return resultSet(List.<Object[]>of(new Object[] {keyTypes.get(unquote(sql))}));
+            }
+            if (sql.startsWith("TTL ")) {
+                return resultSet(List.<Object[]>of(new Object[] {"-1"}));
+            }
+            if (sql.startsWith("GET ")) {
+                return resultSet(List.<Object[]>of(new Object[] {"v"}));
+            }
+            return resultSet(List.of());
+        }
+
+        private String unquote(String sql) {
+            return sql.substring(sql.indexOf('\'') + 1, sql.lastIndexOf('\''));
+        }
+
+        private ResultSet resultSet(List<Object[]> rows) {
+            return proxy(ResultSet.class, new InvocationHandler() {
+                private int index = -1;
+
+                @Override
+                public Object invoke(Object proxy, Method method, Object[] args) {
+                    switch (method.getName()) {
+                        case "next":
+                            return ++index < rows.size();
+                        case "getObject": {
+                            Object column = args[0];
+                            if (column instanceof Integer) {
+                                return rows.get(index)[(Integer) column - 1];
+                            }
+                            return rows.get(index)[0];
+                        }
+                        case "getString": {
+                            Object value = rows.get(index)[(Integer) args[0] - 1];
+                            return value == null ? null : value.toString();
+                        }
+                        case "getInt":
+                            return ((Number) rows.get(index)[(Integer) args[0] - 1]).intValue();
+                        case "close":
+                            return null;
+                        default:
+                            return defaultValue(method.getReturnType());
+                    }
+                }
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == double.class) {
+            return 0D;
+        }
+        return null;
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisSqlBuilderTest.java
@@ -110,7 +110,10 @@ class RedisSqlBuilderTest {
                         operation("DELETE", List.of("1", "x"), null)),
                 new HashMap<>());
 
-        assertEquals("MULTI \n" + "LSET 'k' 1 'b'\n" + "RPUSH 'k' 'c'\n" + "LREM 'k' 1 'x'\n" + "EXEC",
+        // DELETE on row 1 is positional now (tombstone via LSET+LREM) so duplicate
+        // values cannot remove the wrong occurrence.
+        assertEquals("MULTI \n" + "LSET 'k' 1 'b'\n" + "RPUSH 'k' 'c'\n"
+                        + "LSET 'k' 0 '__chat2db_deleted__0'\n" + "LREM 'k' 1 '__chat2db_deleted__0'\n" + "EXEC",
                 RedisSqlBuilder.getInstance().buildByQueryResult(queryResult));
     }
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisSqlBuilderTest.java
@@ -96,7 +96,7 @@ class RedisSqlBuilderTest {
                         operation("DELETE", List.of("2", "w", "2.0"), null)),
                 new HashMap<>());
 
-        assertEquals("MULTI \n" + "ZADD 'k' 1.5 'v'\n" + "ZREM 'k' 'w'\n" + "EXEC",
+        assertEquals("MULTI \n" + "ZADD 'k' '1.5' 'v'\n" + "ZREM 'k' 'w'\n" + "EXEC",
                 RedisSqlBuilder.getInstance().buildByQueryResult(queryResult));
     }
 
@@ -112,9 +112,17 @@ class RedisSqlBuilderTest {
 
         // DELETE on row 1 is positional now (tombstone via LSET+LREM) so duplicate
         // values cannot remove the wrong occurrence.
-        assertEquals("MULTI \n" + "LSET 'k' 1 'b'\n" + "RPUSH 'k' 'c'\n"
-                        + "LSET 'k' 0 '__chat2db_deleted__0'\n" + "LREM 'k' 1 '__chat2db_deleted__0'\n" + "EXEC",
-                RedisSqlBuilder.getInstance().buildByQueryResult(queryResult));
+        String script = RedisSqlBuilder.getInstance().buildByQueryResult(queryResult);
+        String[] lines = script.split("\\n");
+
+        assertEquals("MULTI ", lines[0]);
+        assertEquals("LSET 'k' 1 'b'", lines[1]);
+        assertEquals("RPUSH 'k' 'c'", lines[2]);
+        String tombstone = lines[3].substring(lines[3].lastIndexOf(' ') + 1);
+        assertTrue(tombstone.matches("'__chat2db_deleted__[0-9a-f-]+'"));
+        assertEquals("LSET 'k' 0 " + tombstone, lines[3]);
+        assertEquals("LREM 'k' 1 " + tombstone, lines[4]);
+        assertEquals("EXEC", lines[5]);
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/RedisSqlBuilderTest.java
@@ -1,0 +1,246 @@
+package ai.chat2db.plugin.redis;
+
+import ai.chat2db.community.domain.api.config.DriverConfig;
+import ai.chat2db.community.domain.api.model.result.Header;
+import ai.chat2db.community.domain.api.model.result.QueryResponse;
+import ai.chat2db.community.domain.api.model.result.ResultOperation;
+import ai.chat2db.spi.model.datasource.ConnectInfo;
+import ai.chat2db.spi.sql.Chat2DBContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedisSqlBuilderTest {
+
+    @AfterEach
+    void tearDown() {
+        Chat2DBContext.close();
+    }
+
+    private void stubKeyType(String keyType) {
+        ConnectInfo connectInfo = new ConnectInfo();
+        connectInfo.setDbType("REDIS");
+        connectInfo.setDriverConfig(new DriverConfig());
+        connectInfo.setConnection(typeStubConnection(keyType));
+        Chat2DBContext.putContext(connectInfo);
+    }
+
+    private Header header(String name) {
+        return Header.builder().name(name).dataType("VARCHAR").build();
+    }
+
+    private ResultOperation operation(String type, List<String> oldData, List<String> newData) {
+        ResultOperation operation = new ResultOperation();
+        operation.setType(type);
+        operation.setOldDataList(oldData);
+        operation.setDataList(newData);
+        return operation;
+    }
+
+    private QueryResponse queryResponse(String tableName, List<Header> headers, List<ResultOperation> operations,
+            Map<String, Object> extra) {
+        QueryResponse queryResponse = new QueryResponse();
+        queryResponse.setTableName(tableName);
+        queryResponse.setHeaderList(headers);
+        queryResponse.setOperations(operations);
+        queryResponse.setExtra(extra);
+        return queryResponse;
+    }
+
+    @Test
+    void buildByQueryResultGeneratesHashMutationCommands() {
+        stubKeyType("hash");
+        QueryResponse queryResult = queryResponse("k",
+                List.of(header("#"), header("field"), header("value")),
+                List.of(operation("UPDATE", List.of("1", "f1", "v1old"), List.of("1", "f1", "v1new")),
+                        operation("DELETE", List.of("2", "f2", "v2"), null),
+                        operation("CREATE", null, List.of("3", "f3", "v3"))),
+                new HashMap<>());
+
+        assertEquals("MULTI \n" + "HSET 'k' 'f1' 'v1new'\n" + "HDEL 'k' 'f2'\n" + "HSET 'k' 'f3' 'v3'\n" + "EXEC",
+                RedisSqlBuilder.getInstance().buildByQueryResult(queryResult));
+    }
+
+    @Test
+    void buildByQueryResultGeneratesSetMutationCommands() {
+        stubKeyType("set");
+        QueryResponse queryResult = queryResponse("k",
+                List.of(header("#"), header("value")),
+                List.of(operation("UPDATE", List.of("1", "a"), List.of("1", "b")),
+                        operation("DELETE", List.of("2", "c"), null)),
+                new HashMap<>());
+
+        assertEquals("MULTI \n" + "SREM 'k' 'a'\n" + "SADD 'k' 'b'\n" + "SREM 'k' 'c'\n" + "EXEC",
+                RedisSqlBuilder.getInstance().buildByQueryResult(queryResult));
+    }
+
+    @Test
+    void buildByQueryResultGeneratesZSetMutationCommands() {
+        stubKeyType("zset");
+        QueryResponse queryResult = queryResponse("k",
+                List.of(header("#"), header("value"), header("score")),
+                List.of(operation("CREATE", null, List.of("1", "v", "1.5")),
+                        operation("DELETE", List.of("2", "w", "2.0"), null)),
+                new HashMap<>());
+
+        assertEquals("MULTI \n" + "ZADD 'k' 1.5 'v'\n" + "ZREM 'k' 'w'\n" + "EXEC",
+                RedisSqlBuilder.getInstance().buildByQueryResult(queryResult));
+    }
+
+    @Test
+    void buildByQueryResultGeneratesListMutationCommands() {
+        stubKeyType("list");
+        QueryResponse queryResult = queryResponse("k",
+                List.of(header("#"), header("value")),
+                List.of(operation("UPDATE", List.of("2", "a"), List.of("2", "b")),
+                        operation("CREATE", null, List.of("3", "c")),
+                        operation("DELETE", List.of("1", "x"), null)),
+                new HashMap<>());
+
+        assertEquals("MULTI \n" + "LSET 'k' 1 'b'\n" + "RPUSH 'k' 'c'\n" + "LREM 'k' 1 'x'\n" + "EXEC",
+                RedisSqlBuilder.getInstance().buildByQueryResult(queryResult));
+    }
+
+    @Test
+    void buildByQueryResultGeneratesStringMutationCommands() {
+        stubKeyType("string");
+        QueryResponse queryResult = queryResponse("k",
+                List.of(header("#"), header("value")),
+                List.of(operation("UPDATE", List.of("1", "v1"), List.of("1", "v2"))),
+                new HashMap<>());
+
+        assertEquals("MULTI \n" + "SET 'k' 'v2'\n" + "EXEC",
+                RedisSqlBuilder.getInstance().buildByQueryResult(queryResult));
+    }
+
+    @Test
+    void buildByQueryResultQuotesRenameAndSkipsSentinelTtl() {
+        stubKeyType("hash");
+        Map<String, Object> extra = new HashMap<>();
+        extra.put("keyType", "hash");
+        extra.put("key", "new key");
+        extra.put("ttl", "-1");
+        QueryResponse queryResult = queryResponse("old key",
+                List.of(header("#"), header("field"), header("value")),
+                List.of(operation("UPDATE", List.of("1", "f1", "v1"), List.of("1", "f1", "v2"))),
+                extra);
+
+        String script = RedisSqlBuilder.getInstance().buildByQueryResult(queryResult);
+
+        assertEquals("MULTI \n" + "RENAME 'old key' 'new key'\n" + "HSET 'new key' 'f1' 'v2'\n" + "EXEC", script);
+        assertFalse(script.contains("EXPIRE"));
+    }
+
+    @Test
+    void buildByQueryResultExpiresOnlyPositiveTtlAndSkipsNoopRename() {
+        stubKeyType("hash");
+        Map<String, Object> extra = new HashMap<>();
+        extra.put("keyType", "hash");
+        extra.put("key", "k");
+        extra.put("ttl", "100");
+        QueryResponse queryResult = queryResponse("k",
+                List.of(header("#"), header("field"), header("value")),
+                List.of(operation("UPDATE", List.of("1", "f1", "v1"), List.of("1", "f1", "v2"))),
+                extra);
+
+        String script = RedisSqlBuilder.getInstance().buildByQueryResult(queryResult);
+
+        assertEquals("MULTI \n" + "EXPIRE 'k' 100\n" + "HSET 'k' 'f1' 'v2'\n" + "EXEC", script);
+        assertFalse(script.contains("RENAME"));
+    }
+
+    @Test
+    void buildByQueryResultReturnsEmptyWhenNoOperations() {
+        QueryResponse queryResult = queryResponse("k", List.of(header("value")), List.of(), new HashMap<>());
+
+        assertTrue(RedisSqlBuilder.getInstance().buildByQueryResult(queryResult).isEmpty());
+    }
+
+    private static Connection typeStubConnection(String keyType) {
+        return proxy(Connection.class, (proxy, method, args) -> switch (method.getName()) {
+            case "prepareStatement" -> typeStubStatement(keyType);
+            case "isClosed" -> false;
+            case "close" -> null;
+            default -> defaultValue(method.getReturnType());
+        });
+    }
+
+    private static PreparedStatement typeStubStatement(String keyType) {
+        final ResultSet[] resultSet = new ResultSet[1];
+        return proxy(PreparedStatement.class, (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "execute":
+                    resultSet[0] = singleValueResultSet(keyType);
+                    return true;
+                case "getResultSet":
+                    return resultSet[0];
+                case "close":
+                    return null;
+                default:
+                    return defaultValue(method.getReturnType());
+            }
+        });
+    }
+
+    private static ResultSet singleValueResultSet(String value) {
+        return proxy(ResultSet.class, new InvocationHandler() {
+            private boolean beforeFirst = true;
+
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) {
+                switch (method.getName()) {
+                    case "next":
+                        if (beforeFirst) {
+                            beforeFirst = false;
+                            return true;
+                        }
+                        return false;
+                    case "getString":
+                    case "getObject":
+                        return value;
+                    case "close":
+                        return null;
+                    default:
+                        return defaultValue(method.getReturnType());
+                }
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == double.class) {
+            return 0D;
+        }
+        return null;
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/HashTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/HashTypeScriptTest.java
@@ -50,4 +50,20 @@ class HashTypeScriptTest {
 
         assertTrue(typeScript.updateKey(oldKey, newKey).isEmpty());
     }
+
+    @Test
+    void updateKeyDeletesKeyWhenEveryFieldIsRemoved() {
+        RedisKey oldKey = key("k", entry("f1", "v1", null));
+        RedisKey newKey = RedisKey.builder().name("k").type("HASH").build();
+
+        assertEquals(List.of("DEL 'k'\n"), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeyDeletesKeyWhenAllFieldsAreFlaggedDeleted() {
+        RedisKey oldKey = key("k", entry("f1", "v1", null));
+        RedisKey newKey = key("k", entry("f1", "v1", ActionConstants.DELETE));
+
+        assertEquals(List.of("DEL 'k'\n"), typeScript.updateKey(oldKey, newKey));
+    }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ListTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ListTypeScriptTest.java
@@ -41,7 +41,9 @@ class ListTypeScriptTest {
 
         List<String> scripts = typeScript.updateKey(oldKey, newKey);
 
-        assertEquals(List.of("DEL 'k'\n", "RPUSH 'k' 'a' 'edited' "), scripts);
+        // DEL + RPUSH are wrapped in MULTI/EXEC so a connection drop cannot leave the
+        // key deleted without its replacement values.
+        assertEquals(List.of("MULTI", "DEL 'k'\n", "RPUSH 'k' 'a' 'edited' ", "EXEC"), scripts);
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ListTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ListTypeScriptTest.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ListTypeScriptTest {
 
@@ -46,11 +45,19 @@ class ListTypeScriptTest {
     }
 
     @Test
-    void updateKeySkipsRewriteWhenNoDesiredValues() {
+    void updateKeyDeletesKeyWhenEveryElementIsRemoved() {
         RedisKey oldKey = key("k", item("a", null));
         RedisKey newKey = RedisKey.builder().name("k").type("LIST").build();
 
-        assertTrue(typeScript.updateKey(oldKey, newKey).isEmpty());
+        assertEquals(List.of("DEL 'k'\n"), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeyDeletesKeyWhenAllElementsAreFlaggedDeleted() {
+        RedisKey oldKey = key("k", item("a", null));
+        RedisKey newKey = key("k", item("a", ActionConstants.DELETE));
+
+        assertEquals(List.of("DEL 'k'\n"), typeScript.updateKey(oldKey, newKey));
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/SetTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/SetTypeScriptTest.java
@@ -61,10 +61,18 @@ class SetTypeScriptTest {
     }
 
     @Test
-    void updateKeySkipsWhenDesiredStateIsEmpty() {
+    void updateKeyDeletesKeyWhenEveryMemberIsRemoved() {
         RedisKey oldKey = key("k", member("a", null));
         RedisKey newKey = RedisKey.builder().name("k").type("SET").build();
 
-        assertTrue(typeScript.updateKey(oldKey, newKey).isEmpty());
+        assertEquals(List.of("DEL 'k'\n"), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeyDeletesKeyWhenAllMembersAreFlaggedDeleted() {
+        RedisKey oldKey = key("k", member("a", null));
+        RedisKey newKey = key("k", member("a", ActionConstants.DELETE));
+
+        assertEquals(List.of("DEL 'k'\n"), typeScript.updateKey(oldKey, newKey));
     }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ZSetTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/ZSetTypeScriptTest.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ZSetTypeScriptTest {
 
@@ -28,26 +27,26 @@ class ZSetTypeScriptTest {
     }
 
     @Test
-    void updateKeyOverwritesScoreWithoutRemoval() {
-        RedisKey oldKey = key("k", member("a", 1.0, null), member("b", 2.0, null));
-        RedisKey newKey = key("k", member("a", 1.0, "original"), member("b", 3.0, ActionConstants.UPDATE));
-
-        assertEquals(List.of("ZADD 'k' 3.0 'b' "), typeScript.updateKey(oldKey, newKey));
-    }
-
-    @Test
     void updateKeyRemovesOldMemberWhenValueIsEdited() {
-        RedisKey oldKey = key("k", member("a", 1.0, null));
-        RedisKey newKey = key("k", member("b", 1.0, ActionConstants.UPDATE));
+        RedisKey oldKey = key("k", member("a", 1.0, null), member("b", 2.0, null));
+        RedisKey newKey = key("k", member("a", 1.0, "original"), member("c", 3.0, ActionConstants.UPDATE));
 
-        assertEquals(List.of("ZREM 'k' 'a' ", "ZADD 'k' 1.0 'b' "), typeScript.updateKey(oldKey, newKey));
+        assertEquals(List.of("ZREM 'k' 'b' ", "ZADD 'k' 3.0 'c' "), typeScript.updateKey(oldKey, newKey));
     }
 
     @Test
-    void updateKeyEmitsNothingWhenMembersAreUnchanged() {
+    void updateKeyDeletesKeyWhenEveryMemberIsRemoved() {
         RedisKey oldKey = key("k", member("a", 1.0, null));
-        RedisKey newKey = key("k", member("a", 1.0, "original"));
+        RedisKey newKey = RedisKey.builder().name("k").type("ZSET").build();
 
-        assertTrue(typeScript.updateKey(oldKey, newKey).isEmpty());
+        assertEquals(List.of("DEL 'k'\n"), typeScript.updateKey(oldKey, newKey));
+    }
+
+    @Test
+    void updateKeyDeletesKeyWhenAllMembersAreFlaggedDeleted() {
+        RedisKey oldKey = key("k", member("a", 1.0, null));
+        RedisKey newKey = key("k", member("a", 1.0, ActionConstants.DELETE));
+
+        assertEquals(List.of("DEL 'k'\n"), typeScript.updateKey(oldKey, newKey));
     }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/util/RedisValueUtilsTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/util/RedisValueUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import static ai.chat2db.plugin.redis.util.RedisValueUtils.getRedisValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class RedisValueUtilsTest {
 
@@ -27,5 +28,12 @@ class RedisValueUtilsTest {
     @Test
     void returnsNullForNullInput() {
         assertNull(getRedisValue(null));
+    }
+
+    @Test
+    void rejectsCharactersThatRedisJdbcSplitsBeforeQuoteParsing() {
+        assertThrows(IllegalArgumentException.class, () -> getRedisValue("first\nDEL other"));
+        assertThrows(IllegalArgumentException.class, () -> getRedisValue("first\rDEL other"));
+        assertThrows(IllegalArgumentException.class, () -> getRedisValue("first\0second"));
     }
 }


### PR DESCRIPTION
Fixes verified review findings tracked in #2281: (1) dropTable built DEL with a raw unquoted key name (wrong-key deletion on names with spaces); (2) buildByQueryResult iterated edits in an empty loop, silently dropping all grid edits — now emits per-type mutation commands inside MULTI/EXEC; list deletes are positional (tombstone LSET+LREM) so duplicate values cannot remove the wrong occurrence; (3) RENAME/EXPIRE built with raw names and EXPIRE emitted for sentinel TTLs; (4) deleting every field/member left an empty key instead of DEL; (5) SCAN listing truncated after the first batch — now loops the cursor with dedupe; (6) list rewrite (DEL+RPUSH) wrapped in MULTI/EXEC for atomicity. Regression tests added. Verified on fork HandSonic/Chat2DB#8 (CI green).