### PR TITLE
feat(table-editor): default new table columns to nullable

### DIFF
--- a/chat2db-community-client/src/blocks/DatabaseTableEditor/ColumnList/index.tsx
+++ b/chat2db-community-client/src/blocks/DatabaseTableEditor/ColumnList/index.tsx
@@ -98,7 +98,7 @@ const createInitialData = () => {
     sqlDatetimeSub: null,
     charOctetLength: null,
     ordinalPosition: null,
-    nullable: null,
+    nullable: NullableType.Null,
     generatedColumn: null,
     charSetName: null,
     collationName: null,


### PR DESCRIPTION
feat(table-editor): default new table columns to nullable

Set the default nullable value of newly added columns in the table editor
to NullableType.Null, so new non-primary-key columns start as nullable.
Primary key columns are still forced to NOT NULL by the existing
handelPrimaryKey handler.

Closes #2245
