### PR TITLE
260728 fix selectboundinfo key index

### DIFF
--- a/chat2db-community-client/src/components/SelectBoundInfo/index.tsx
+++ b/chat2db-community-client/src/components/SelectBoundInfo/index.tsx
@@ -258,8 +258,8 @@ const SelectBoundInfo = memo(
 
     return (
       <div className={styles.selectBoundInfo}>
-        {selectedList.map((item, index) => {
-          return <DropdownItem eachOption={item} key={index} handleOptionChange={handleOptionChange} />;
+        {selectedList.map((item) => {
+          return <DropdownItem eachOption={item} key={item.treeNodeType} handleOptionChange={handleOptionChange} />;
         })}
       </div>
     );


### PR DESCRIPTION
fix(ui): use stable treeNodeType as React key in SelectBoundInfo

Replace key={index} with key={item.treeNodeType} in SelectedList
rendering to prevent React from incorrectly reusing DOM nodes when
the selection list reorders. Each item has a guaranteed unique
treeNodeType, making it a stable key.

Closes #2153
