### PR TITLE
fix(clickhouse): preserve Decimal precision when scale is null (#2192)

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/pom.xml
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/pom.xml
@@ -19,6 +19,11 @@
             <groupId>ai.chat2db</groupId>
             <artifactId>chat2db-community-mysql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <artifactId>chat2db-community-clickhouse</artifactId>
     <build>

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/enums/type/ClickHouseColumnTypeEnum.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/enums/type/ClickHouseColumnTypeEnum.java
@@ -186,15 +186,13 @@ public enum ClickHouseColumnTypeEnum implements IColumnBuilder {
 
 
         if (Arrays.asList(Decimal).contains(type)) {
-            if (column.getColumnSize() == null || column.getDecimalDigits() == null) {
+            if (column.getColumnSize() == null) {
                 return columnType;
             }
-            if (column.getColumnSize() != null && column.getDecimalDigits() == null) {
-                return StringUtils.join(columnType, "(", column.getColumnSize() + ")");
+            if (column.getDecimalDigits() == null) {
+                return StringUtils.join(columnType, "(", column.getColumnSize(), ",0)");
             }
-            if (column.getColumnSize() != null && column.getDecimalDigits() != null) {
-                return StringUtils.join(columnType, "(", column.getColumnSize() + "," + column.getDecimalDigits() + ")");
-            }
+            return StringUtils.join(columnType, "(", column.getColumnSize(), ",", column.getDecimalDigits(), ")");
         }
 
         return columnType;

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/test/java/ai/chat2db/plugin/clickhouse/enums/type/ClickHouseColumnTypeEnumTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/test/java/ai/chat2db/plugin/clickhouse/enums/type/ClickHouseColumnTypeEnumTest.java
@@ -1,0 +1,38 @@
+package ai.chat2db.plugin.clickhouse.enums.type;
+
+import ai.chat2db.community.domain.api.model.metadata.TableColumn;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ClickHouseColumnTypeEnumTest {
+
+    @Test
+    void buildsBareDecimalWhenPrecisionIsMissing() {
+        assertEquals("`amount` Decimal", buildDecimal(null, null));
+    }
+
+    @Test
+    void defaultsScaleToZeroWhenOnlyPrecisionIsAvailable() {
+        assertEquals("`amount` Decimal(10,0)", buildDecimal(10, null));
+    }
+
+    @Test
+    void rendersExplicitZeroScale() {
+        assertEquals("`amount` Decimal(10,0)", buildDecimal(10, 0));
+    }
+
+    @Test
+    void rendersExplicitScale() {
+        assertEquals("`amount` Decimal(10,2)", buildDecimal(10, 2));
+    }
+
+    private String buildDecimal(Integer precision, Integer scale) {
+        TableColumn column = new TableColumn();
+        column.setName("amount");
+        column.setColumnType("DECIMAL");
+        column.setColumnSize(precision);
+        column.setDecimalDigits(scale);
+        return ClickHouseColumnTypeEnum.Decimal.buildCreateColumnSql(column).trim();
+    }
+}


### PR DESCRIPTION
Title: fix(clickhouse): preserve Decimal precision when scale is null

Description:

Fixes #2192

The buildDataType method in ClickHouseColumnTypeEnum uses columnSize == null || decimalDigits == null as a guard condition for Decimal types. This causes an early return that drops precision when columnSize is set but decimalDigits is null.

Before
Decimal(10) (precision=10, scale=null) → Decimal (precision dropped, broken DDL)
Decimal(10,5) → Decimal(10,5)
After
Decimal(10) → Decimal(10,0) (preserves precision, uses 0 as default scale)
Decimal(10,5) → Decimal(10,5) (unchanged)
Changes
Changed guard from columnSize == null || decimalDigits == null to columnSize == null only
Fixed the size-only branch to output Decimal(P,0) (ClickHouse requires both P and S)
Removed unreachable dead code in the previous two-branch else if structure