### PR TITLE
fix(spi): guard empty UPDATE SET clause, quote-aware now() replacement, null-safe DBStructUtils

### DIFF
--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSqlBuilder.java
@@ -776,6 +776,7 @@ public class DefaultSqlBuilder implements ISqlBuilder, IIdentifierSqlBuilder, ID
             return SQLConstants.EMPTY;
         }
         script.append(SQL_UPDATE).append(tableName).append(SQL_SET);
+        int assignmentsStart = script.length();
         IValueProcessor valueProcessor = Chat2DBContext.getDbMetaData().getValueProcessor();
         for (int i = 1; i < row.size(); i++) {
             String newValue = row.get(i);
@@ -796,6 +797,10 @@ public class DefaultSqlBuilder implements ISqlBuilder, IIdentifierSqlBuilder, ID
                     .append(SQLConstants.EQUAL_SQL)
                     .append(newSqlValue)
                     .append(SQLConstants.COMMA);
+        }
+        if (script.length() == assignmentsStart) {
+            // no column changed: skip the row instead of emitting 'UPDATE t SET WHERE ...'
+            return SQLConstants.EMPTY;
         }
         script.deleteCharAt(script.length() - 1);
         script.append(buildWhere(headerList, odlRow, metaSchema, keyColumns, valueProcessor));

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/util/DBStructUtils.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/util/DBStructUtils.java
@@ -57,7 +57,7 @@ public class DBStructUtils {
                 createTableSQL.append(",\n");
             }
             String columnName = column.getName();
-            String dataType = column.getColumnType();
+            String dataType = StringUtils.defaultIfBlank(column.getColumnType(), "VARCHAR");
             String nullable = Objects.equals(column.getNullable(), 0) ? " NOT NULL" : "";
             Integer columnSize = column.getColumnSize();
             Integer decimalDigits = column.getDecimalDigits();

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/util/DBStructUtils.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/util/DBStructUtils.java
@@ -65,9 +65,9 @@ public class DBStructUtils {
             String commentClause = (columnComment != null && !columnComment.isEmpty()) ? " COMMENT '" + columnComment + "'" : "";
             String columnDefinition = columnName + " " + dataType;
 
-            if ((dataType.equalsIgnoreCase("VARCHAR") || dataType.equalsIgnoreCase("CHAR")) && columnSize != null) {
+            if ((StringUtils.equalsIgnoreCase(dataType, "VARCHAR") || StringUtils.equalsIgnoreCase(dataType, "CHAR")) && columnSize != null) {
                 columnDefinition += "(" + columnSize + ")";
-            } else if ((dataType.equalsIgnoreCase("DECIMAL") || dataType.equalsIgnoreCase("NUMERIC")) && columnSize != null) {
+            } else if ((StringUtils.equalsIgnoreCase(dataType, "DECIMAL") || StringUtils.equalsIgnoreCase(dataType, "NUMERIC")) && columnSize != null) {
                 columnDefinition += decimalDigits == null ? "(" + columnSize + ")" : "(" + columnSize + "," + decimalDigits + ")";
             }
             columnDefinition += nullable + commentClause;

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/util/SqlUtils.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/util/SqlUtils.java
@@ -281,23 +281,55 @@ public class SqlUtils {
     }
 
 
+    private static final Pattern DEFAULT_NOW_PATTERN = Pattern.compile("(?i)default now ?\\(\\)");
+
     private static String updateNow(String sql, DbType dbType) {
         if (StringUtils.isBlank(sql) || !DbType.mysql.equals(dbType)) {
             return sql;
         }
-        if (sql.contains("default now()")) {
-            return sql.replace("default now()", "default CURRENT_TIMESTAMP");
+        Matcher matcher = DEFAULT_NOW_PATTERN.matcher(sql);
+        if (!matcher.find()) {
+            return sql;
         }
-        if (sql.contains("DEFAULT now()")) {
-            return sql.replace("DEFAULT now()", "default CURRENT_TIMESTAMP");
+        StringBuilder result = new StringBuilder(sql.length());
+        char quote = 0;
+        for (int i = 0; i < sql.length(); ) {
+            char c = sql.charAt(i);
+            if (quote != 0) {
+                // inside a quoted region: copy verbatim, never rewrite 'default now()' here
+                result.append(c);
+                if (c == '\\' && quote != '`' && i + 1 < sql.length()) {
+                    result.append(sql.charAt(i + 1));
+                    i += 2;
+                    continue;
+                }
+                if (c == quote) {
+                    if (i + 1 < sql.length() && sql.charAt(i + 1) == quote) {
+                        result.append(quote);
+                        i += 2;
+                        continue;
+                    }
+                    quote = 0;
+                }
+                i++;
+                continue;
+            }
+            if (c == '\'' || c == '"' || c == '`') {
+                quote = c;
+                result.append(c);
+                i++;
+                continue;
+            }
+            matcher.region(i, sql.length());
+            if (matcher.lookingAt()) {
+                result.append("default CURRENT_TIMESTAMP");
+                i = matcher.end();
+                continue;
+            }
+            result.append(c);
+            i++;
         }
-        if (sql.contains("default now ()")) {
-            return sql.replace("default now ()", "default CURRENT_TIMESTAMP");
-        }
-        if (sql.contains("DEFAULT now ()")) {
-            return sql.replace("DEFAULT now ()", "DEFAULT CURRENT_TIMESTAMP");
-        }
-        return sql;
+        return result.toString();
     }
 
     public static String getSqlValue(String value, String dataType) {

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/util/SqlUtils.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/util/SqlUtils.java
@@ -281,20 +281,42 @@ public class SqlUtils {
     }
 
 
-    private static final Pattern DEFAULT_NOW_PATTERN = Pattern.compile("(?i)default now ?\\(\\)");
+    private static final Pattern DEFAULT_NOW_PATTERN = Pattern.compile("(?i)\\bdefault\\s+now\\s*\\(\\s*\\)");
 
     private static String updateNow(String sql, DbType dbType) {
         if (StringUtils.isBlank(sql) || !DbType.mysql.equals(dbType)) {
             return sql;
         }
         Matcher matcher = DEFAULT_NOW_PATTERN.matcher(sql);
+        matcher.useTransparentBounds(true);
         if (!matcher.find()) {
             return sql;
         }
         StringBuilder result = new StringBuilder(sql.length());
         char quote = 0;
+        boolean lineComment = false;
+        boolean blockComment = false;
         for (int i = 0; i < sql.length(); ) {
             char c = sql.charAt(i);
+            if (lineComment) {
+                result.append(c);
+                if (c == '\n' || c == '\r') {
+                    lineComment = false;
+                }
+                i++;
+                continue;
+            }
+            if (blockComment) {
+                result.append(c);
+                if (c == '*' && i + 1 < sql.length() && sql.charAt(i + 1) == '/') {
+                    result.append('/');
+                    blockComment = false;
+                    i += 2;
+                    continue;
+                }
+                i++;
+                continue;
+            }
             if (quote != 0) {
                 // inside a quoted region: copy verbatim, never rewrite 'default now()' here
                 result.append(c);
@@ -312,6 +334,25 @@ public class SqlUtils {
                     quote = 0;
                 }
                 i++;
+                continue;
+            }
+            if (c == '#') {
+                lineComment = true;
+                result.append(c);
+                i++;
+                continue;
+            }
+            if (c == '-' && i + 1 < sql.length() && sql.charAt(i + 1) == '-'
+                    && (i + 2 == sql.length() || Character.isWhitespace(sql.charAt(i + 2)))) {
+                lineComment = true;
+                result.append("--");
+                i += 2;
+                continue;
+            }
+            if (c == '/' && i + 1 < sql.length() && sql.charAt(i + 1) == '*') {
+                blockComment = true;
+                result.append("/*");
+                i += 2;
                 continue;
             }
             if (c == '\'' || c == '"' || c == '`') {

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/DefaultSqlBuilderSegmentTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/DefaultSqlBuilderSegmentTest.java
@@ -1,21 +1,28 @@
 package ai.chat2db.spi;
 
+import ai.chat2db.community.domain.api.config.DBConfig;
+import ai.chat2db.community.domain.api.config.DriverConfig;
 import ai.chat2db.community.domain.api.config.TableBuilderConfig;
 import ai.chat2db.community.domain.api.model.metadata.Database;
 import ai.chat2db.community.domain.api.model.metadata.Schema;
 import ai.chat2db.community.domain.api.model.metadata.Table;
 import ai.chat2db.community.domain.api.model.result.Header;
 import ai.chat2db.community.domain.api.model.result.ResultOperation;
+import ai.chat2db.spi.model.datasource.ConnectInfo;
 import ai.chat2db.spi.model.request.DropTableRequest;
 import ai.chat2db.spi.model.request.PageLimitRequest;
 import ai.chat2db.spi.model.request.TruncateTableRequest;
+import ai.chat2db.spi.sql.Chat2DBContext;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DefaultSqlBuilderSegmentTest {
 
@@ -105,4 +112,68 @@ class DefaultSqlBuilderSegmentTest {
         header.setColumnType("VARCHAR");
         return header;
     }
+
+    @Test
+    void updateSqlReturnsEmptyWhenNoColumnChanged() throws Exception {
+        withStubPluginContext();
+        try {
+            String sql = updateSql(List.of("1", "Alice", "30"), List.of("1", "Alice", "30"));
+
+            assertEquals("", sql);
+        } finally {
+            cleanupStubPluginContext();
+        }
+    }
+
+    @Test
+    void updateSqlBuildsSetClauseForChangedColumn() throws Exception {
+        withStubPluginContext();
+        try {
+            String sql = updateSql(List.of("1", "Alice", "31"), List.of("1", "Alice", "30"));
+
+            assertTrue(sql.startsWith("UPDATE users set "), "actual sql: <" + sql + ">");
+            assertFalse(sql.contains("set where"));
+            assertTrue(sql.contains("age ="), "actual sql: <" + sql + ">");
+            assertTrue(sql.contains("where name ="), "actual sql: <" + sql + ">");
+        } finally {
+            cleanupStubPluginContext();
+        }
+    }
+
+    private String updateSql(List<String> row, List<String> oldRow) throws Exception {
+        Method method = DefaultSqlBuilder.class.getDeclaredMethod("getUpdateSql",
+                String.class, List.class, List.class, List.class, IDbMetaData.class, List.class, boolean.class);
+        method.setAccessible(true);
+        List<Header> headers = new ArrayList<>();
+        Header rowNumber = new Header();
+        rowNumber.setName("row_number");
+        headers.add(rowNumber);
+        headers.add(nameHeader());
+        Header age = new Header();
+        age.setName("age");
+        age.setColumnType("INT");
+        headers.add(age);
+        return (String) method.invoke(builder, "users", headers, row, oldRow,
+                new DefaultMetaService(), List.of("name"), false);
+    }
+
+    private static void withStubPluginContext() {
+        Chat2DBContext.PLUGIN_MAP.put(TEST_DB_TYPE, new IPlugin() {
+            @Override
+            public DBConfig getDBConfig() {
+                return new DBConfig();
+            }
+        });
+        ConnectInfo info = new ConnectInfo();
+        info.setDbType(TEST_DB_TYPE);
+        info.setDriverConfig(new DriverConfig());
+        Chat2DBContext.putContext(info);
+    }
+
+    private static void cleanupStubPluginContext() {
+        Chat2DBContext.removeContext();
+        Chat2DBContext.PLUGIN_MAP.remove(TEST_DB_TYPE);
+    }
+
+    private static final String TEST_DB_TYPE = "TEST_STUB_DB_FOR_UPDATE_SQL";
 }

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/util/DBStructUtilsTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/util/DBStructUtilsTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DBStructUtilsTest {
 
@@ -66,5 +68,17 @@ class DBStructUtilsTest {
                 CREATE TABLE orders (
                 \tamount DECIMAL(12)
                 );""", sql);
+    }
+
+    @Test
+    void generateCreateTableSQLToleratesNullColumnType() {
+        TableColumn column = new TableColumn();
+        column.setName("expr");
+        column.setColumnType(null);
+        column.setColumnSize(10);
+
+        String sql = assertDoesNotThrow(() -> DBStructUtils.generateCreateTableSQL("users", List.of(column)));
+
+        assertTrue(sql.contains("expr"));
     }
 }

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/util/DBStructUtilsTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/util/DBStructUtilsTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DBStructUtilsTest {
 
@@ -77,8 +75,9 @@ class DBStructUtilsTest {
         column.setColumnType(null);
         column.setColumnSize(10);
 
-        String sql = assertDoesNotThrow(() -> DBStructUtils.generateCreateTableSQL("users", List.of(column)));
-
-        assertTrue(sql.contains("expr"));
+        assertEquals("""
+                CREATE TABLE users (
+                \texpr VARCHAR(10)
+                );""", DBStructUtils.generateCreateTableSQL("users", List.of(column)));
     }
 }

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/util/SqlUtilsTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/util/SqlUtilsTest.java
@@ -1,6 +1,9 @@
 package ai.chat2db.spi.util;
 
+import com.alibaba.druid.DbType;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -15,5 +18,39 @@ class SqlUtilsTest {
     void trimTrailingSemicolonUsesInputSqlLength() {
         assertEquals("SELECT COUNT(*) FROM users",
                 SqlUtils.trimTrailingSemicolon("SELECT COUNT(*) FROM users;"));
+    }
+
+    @Test
+    void updateNowRewritesColumnDefaultInDdl() throws Exception {
+        assertEquals("CREATE TABLE t (a DATETIME default CURRENT_TIMESTAMP);",
+                updateNow("CREATE TABLE t (a DATETIME DEFAULT now());"));
+        assertEquals("CREATE TABLE t (a DATETIME default CURRENT_TIMESTAMP);",
+                updateNow("CREATE TABLE t (a DATETIME default now ());"));
+    }
+
+    @Test
+    void updateNowLeavesQuotedStringLiteralsUntouched() throws Exception {
+        String singleQuoted = "INSERT INTO t (a) VALUES ('default now()');";
+        assertEquals(singleQuoted, updateNow(singleQuoted));
+
+        String escapedQuote = "INSERT INTO t (a) VALUES ('it''s default now()');";
+        assertEquals(escapedQuote, updateNow(escapedQuote));
+
+        String doubleQuoted = "INSERT INTO t (a) VALUES (\"DEFAULT now ()\");";
+        assertEquals(doubleQuoted, updateNow(doubleQuoted));
+    }
+
+    @Test
+    void updateNowEmitsConsistentCasingAcrossVariants() throws Exception {
+        assertEquals("x default CURRENT_TIMESTAMP", updateNow("x DEFAULT now()"));
+        assertEquals("x default CURRENT_TIMESTAMP", updateNow("x default now()"));
+        assertEquals("x default CURRENT_TIMESTAMP", updateNow("x DEFAULT now ()"));
+        assertEquals("x default CURRENT_TIMESTAMP", updateNow("x default now ()"));
+    }
+
+    private static String updateNow(String sql) throws Exception {
+        Method method = SqlUtils.class.getDeclaredMethod("updateNow", String.class, DbType.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, sql, DbType.mysql);
     }
 }

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/util/SqlUtilsTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/util/SqlUtilsTest.java
@@ -41,6 +41,24 @@ class SqlUtilsTest {
     }
 
     @Test
+    void updateNowLeavesCommentsAndLongerIdentifiersUntouched() throws Exception {
+        String sql = """
+                -- default now()
+                # DEFAULT now ()
+                /* default now() */
+                SELECT nodefault now();
+                """;
+
+        assertEquals(sql, updateNow(sql));
+    }
+
+    @Test
+    void updateNowAcceptsSqlWhitespaceAroundFunctionTokens() throws Exception {
+        assertEquals("x default CURRENT_TIMESTAMP",
+                updateNow("x default\t now ( \n )"));
+    }
+
+    @Test
     void updateNowEmitsConsistentCasingAcrossVariants() throws Exception {
         assertEquals("x default CURRENT_TIMESTAMP", updateNow("x DEFAULT now()"));
         assertEquals("x default CURRENT_TIMESTAMP", updateNow("x default now()"));


### PR DESCRIPTION
Fixes verified review findings tracked in #2281: (1) getUpdateSql with all columns unchanged produced 'UPDATE t SET WHERE ...' (deleteCharAt eating into SET) — now returns empty; (2) updateNow did raw string replacement corrupting 'default now()' inside quoted literals — now quote-aware; (3) DBStructUtils.buildColumnDdl NPE'd on null TYPE_NAME from generic drivers — null guard added (sibling buildAlterTable already had one). Regression tests added (79 green). Verified on fork HandSonic/Chat2DB#18 (meaningful CI green) plus adversarial review.