### PR TITLE
fix(ui): refine workspace tabs and navigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Run active workspace tab locator contract
         run: yarn run test:active-tab-locator
 
+      - name: Run local file tab title contract
+        run: yarn run test:local-file-tab-title
+
       - name: Run saved console tree refresh contract
         run: yarn run test:saved-console-tree-refresh
 

--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -49,6 +49,7 @@
     "test:sql-execution-batch": "tsx src/service/sqlExecutionBatch.test.ts",
     "test:sql-execution-request-tracker": "tsx src/service/sqlExecutionRequestTracker.test.ts",
     "test:sql-execution-stream": "tsx src/service/sqlExecutionStream.test.ts",
+    "test:local-file-tab-title": "tsx src/pages/main/workspace/utils/localTextFile.test.ts",
     "test:sql-in-clipboard": "tsx src/utils/sqlInClipboard.test.ts && tsx src/components/SQLEditor/helper/sqlInsertValueDefaults.test.ts",
     "test:tree-title-highlight": "tsx src/blocks/NewTree/components/TitleRender/highlightSearchText.test.ts",
     "test:verification-code-countdown": "tsx src/utils/verificationCodeCountdown.test.ts && tsx src/utils/latestRequest.test.ts",

--- a/chat2db-community-client/src/blocks/SearchResult/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/index.tsx
@@ -405,6 +405,11 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
       popover: i18n('common.text.output'),
       label: i18n('common.text.output'),
       key: CONSOLE_TAB_ID,
+      styles: {
+        flex: '0 0 96px',
+        width: '96px',
+        maxWidth: '96px',
+      },
       children: (
         <ExecutionConsole
           records={props.executionLogRecords || []}

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -1,9 +1,8 @@
 import { Confetti, IconButton, IconfontSvg } from '@chat2db/ui';
 import { Tooltip, type InputRef } from 'antd';
-import { Layers, MessagesSquare } from 'lucide-react';
+import { Layers, LayoutDashboard, MessageSquarePlus } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import ChartNoAxesCombined from '@/components/LucideIcons/ChartNoAxesCombined';
 import i18n from '@/i18n';
 import { INavItem } from '@/typings/main';
 import feedback from '@/utils/feedback';
@@ -42,7 +41,7 @@ function CommunityMainPage() {
     () => [
       {
         key: 'stream',
-        icon: MessagesSquare,
+        icon: MessageSquarePlus,
         isLoad: false,
         component: <Stream />,
         name: i18n('stream.nav.title'),
@@ -56,7 +55,7 @@ function CommunityMainPage() {
       },
       {
         key: 'dashboard',
-        icon: ChartNoAxesCombined,
+        icon: LayoutDashboard,
         isLoad: false,
         component: <Dashboard />,
         name: i18n('dashboard.title'),

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
@@ -53,7 +53,11 @@ import { copyToClipboard, getTemporaryId, isTemporaryId } from '@/utils';
 import { useIndexDBStore } from '@/store/indexDB';
 import { getDatabaseSupport } from '@/utils/database';
 import ConsoleERModal from '@/blocks/ERModal/ConsoleERModal';
-import { getLocalTextFileIcon, SQL_FILE_EXTENSION_NAME } from '../../utils/localTextFile';
+import {
+  getLocalTextFileIcon,
+  getLocalTextFileTabPresentation,
+  SQL_FILE_EXTENSION_NAME,
+} from '../../utils/localTextFile';
 import { EditorType } from '@/components/SQLEditor';
 import { ShortcutAction } from '@/constants/shortcut';
 
@@ -1495,13 +1499,17 @@ const WorkspaceTabs = memo(() => {
 
   const getWorkspaceTabItems = (tabs: IWorkspaceTab[]) => {
     return tabs.map((item) => {
-      const popoverContent = item.uniqueData?.popoverContent;
+      const localFileTabPresentation =
+        item.type === WorkspaceTabType.LocalSQLFile
+          ? getLocalTextFileTabPresentation(item.uniqueData?.filePath, item.title)
+          : undefined;
+      const popoverContent = localFileTabPresentation?.popover || item.uniqueData?.popoverContent;
       return {
         prefixIcon:
           item.type === WorkspaceTabType.LocalSQLFile
             ? getLocalTextFileIcon(item.uniqueData?.fileExtension)
             : workspaceTabConfig[item.type]?.icon,
-        label: item.title,
+        label: localFileTabPresentation?.label ?? item.title,
         popover: popoverContent ? <div style={{ padding: '4px 6px' }}>{popoverContent}</div> : undefined,
         key: item.id,
         editableName: item.type === WorkspaceTabType.CONSOLE,

--- a/chat2db-community-client/src/pages/main/workspace/utils/localTextFile.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/localTextFile.test.ts
@@ -1,0 +1,46 @@
+import { getLocalTextFileTabPresentation } from './localTextFile';
+
+function assertEqual(actual: unknown, expected: unknown, message: string) {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`${message}: expected ${expectedJson}, got ${actualJson}`);
+  }
+}
+
+assertEqual(
+  getLocalTextFileTabPresentation('/Users/example/Desktop/test.sql', 'fallback.sql'),
+  {
+    label: 'test.sql',
+    popover: '/Users/example/Desktop/test.sql',
+  },
+  'uses a POSIX file name as the label and preserves the path for hover',
+);
+assertEqual(
+  getLocalTextFileTabPresentation('C:\\Users\\example\\Desktop\\test.sql', 'fallback.sql'),
+  {
+    label: 'test.sql',
+    popover: 'C:\\Users\\example\\Desktop\\test.sql',
+  },
+  'uses a Windows file name as the label and preserves the path for hover',
+);
+assertEqual(
+  getLocalTextFileTabPresentation('\\\\server\\share\\queries\\report.sql', 'fallback.sql'),
+  {
+    label: 'report.sql',
+    popover: '\\\\server\\share\\queries\\report.sql',
+  },
+  'uses a UNC file name as the label and preserves the path for hover',
+);
+assertEqual(
+  getLocalTextFileTabPresentation('release.sql', 'fallback.sql'),
+  { label: 'release.sql', popover: 'release.sql' },
+  'preserves a bare file name and exposes it on hover',
+);
+assertEqual(
+  getLocalTextFileTabPresentation(undefined, 'saved-title.sql'),
+  { label: 'saved-title.sql', popover: undefined },
+  'falls back to the persisted title when the path is missing',
+);
+
+console.log('local text file tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/utils/localTextFile.ts
+++ b/chat2db-community-client/src/pages/main/workspace/utils/localTextFile.ts
@@ -12,3 +12,22 @@ export const LOCAL_TEXT_FILE_ICON_MAP: Record<string, string> = {
 export const getLocalTextFileIcon = (fileExtension?: string) => {
   return LOCAL_TEXT_FILE_ICON_MAP[(fileExtension || '').toLowerCase()] || LOCAL_TEXT_FILE_FALLBACK_ICON;
 };
+
+const getLocalTextFileName = (filePath: string) => {
+  const normalizedPath = (filePath || '').replace(/\\/g, '/');
+  const fileName = normalizedPath.slice(normalizedPath.lastIndexOf('/') + 1);
+  return fileName || filePath;
+};
+
+export const getLocalTextFileTabPresentation = (filePath: string | undefined, fallbackLabel: string) => {
+  if (!filePath) {
+    return {
+      label: fallbackLabel,
+      popover: undefined,
+    };
+  }
+  return {
+    label: getLocalTextFileName(filePath),
+    popover: filePath,
+  };
+};


### PR DESCRIPTION
## Related issue

Closes #2351
Closes #2352
Closes #2355

## Summary

- Show only the file name in local SQL file workspace tabs while preserving the absolute path for file operations.
- Use Lucide `MessageSquarePlus` for conversations and `LayoutDashboard` for Dashboard.
- Give the static Output tab a compact fixed width of 96 px while keeping query-result tabs at 200 px.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `yarn lint:eslint` passed; `yarn test:local-file-tab-title` passed; `yarn test:result-tab-preferences` passed; `yarn test:search-result-tab-selection` passed; `git diff --check` passed.
- Manual verification: Started Community backend on `10825`, main-checkout frontend on `8889`, and the local JCEF preview against `http://127.0.0.1:8889`; webpack connected and the workspace rendered.
- UI evidence: Verified in the local JCEF preview; the requester confirmed the combined result looks correct.

## Risk and compatibility

- Public API or stored data: N/A; frontend display changes only.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Changes are scoped to the Community frontend.
- Backward compatibility: Existing absolute file paths and query-result tab widths are preserved.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/SearchResult/index.tsx`, `chat2db-community-client/src/pages/main/CommunityMainPage.tsx`, and `chat2db-community-client/src/pages/main/workspace/utils/localTextFile.ts`.
- Failure condition: Output tabs remain 200 px, navigation shows the previous icons, or local file tabs expose absolute paths.
- Rollback or disable path: Revert the three commits in this PR.

## Contributor declaration

- [x] I linked the Issues that define this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below.

AI assistance: Codex assisted with implementation, tests, runtime startup, and PR consolidation.