### PR TITLE
fix(client): fix editor clipboard copy in non-secure HTTP contexts

### DIFF
--- a/chat2db-community-client/src/components/SQLEditor/editor/SQLEditorWithOperation/index.tsx
+++ b/chat2db-community-client/src/components/SQLEditor/editor/SQLEditorWithOperation/index.tsx
@@ -26,6 +26,7 @@ import { EditorTableIdentifier } from '../../helper/tableIdentifier';
 import { useTreeStore } from '@/store/tree';
 import { isTemporaryId } from '@/utils';
 import { readClipboard } from '@/utils/clipboard';
+import { copyToClipboard } from '@/utils/copy';
 import executeSql from '@/service/executeSql';
 import { parseClipboardTextToSqlInTokens } from '@/utils/sqlInClipboard';
 import {
@@ -658,7 +659,7 @@ const SQLEditorWithOperation = forwardRef<ISQLEditorWithOperationRef, ISQLEditor
     const selectedText = sqlEditorRef.current?.getSelectedContent() || '';
 
     if (selectedText) {
-      navigator.clipboard.writeText(selectedText);
+      copyToClipboard(selectedText);
     }
 
     if (editor) {
@@ -753,7 +754,7 @@ const SQLEditorWithOperation = forwardRef<ISQLEditorWithOperationRef, ISQLEditor
 
     if (selectedText && selection && editor) {
       // Copy to the clipboard first.
-      navigator.clipboard.writeText(selectedText);
+      copyToClipboard(selectedText);
 
       // Then delete the selection.
       editor.executeEdits('cut', [


### PR DESCRIPTION
## Related issue

Closes #2361 

## Summary

- Fixed SQL Editor `Copy` and `Cut` operations failing when Chat2DB Web is deployed over non-HTTPS (HTTP) environments.
- Replaced direct `navigator.clipboard.writeText` calls in `SQLEditorWithOperation/index.tsx` with the `copyToClipboard` utility helper from `@/utils/copy`.
- The `copyToClipboard` helper automatically falls back to standard DOM `<textarea>` selection + `document.execCommand('copy')` when `navigator.clipboard` is restricted or throws an error in non-secure contexts.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn run lint`: PASSED (0 errors, 0 warnings)
  - `yarn run test:sql-in-clipboard`: PASSED
  - `yarn run build:web:community --app_version=0.0.0`: PASSED (Compiled successfully in 38.00s)
- Manual verification: Verified copy/cut operations use the fallback mechanism correctly in non-secure HTTP browser contexts.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A
- Database or driver compatibility: N/A
- Network, privacy, or security: N/A
- Community / Local / Pro boundary: N/A
- Backward compatibility: N/A

## Reviewer map

- Start here: `chat2db-community-client/src/components/SQLEditor/editor/SQLEditorWithOperation/index.tsx`
- Failure condition: N/A
- Rollback or disable path: Revert changes in `SQLEditorWithOperation/index.tsx`

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Code refactoring and build verification assisted by Antigravity AI pair programmer.