### PR TITLE
fix(bi): restore chart fields after desktop query

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
@@ -50,6 +50,7 @@ import {
   ClosedSqlExecutionResults,
   SqlExecutionEvent,
   SqlExecutionResultIdentity,
+  appendCompletedQueryResult,
   attachExecutionIdentity,
   clearClosedSqlExecutionResults,
   isSqlExecutionResultClosed,
@@ -105,6 +106,11 @@ interface IProps {
   onExecuteSQLCallback?: (params: { databaseInfo: IDatabaseBaseInfo; data: any }) => void;
   isConsole?: boolean;
   sqlActionEnabled?: boolean;
+}
+
+interface DesktopExecutionCallbackState {
+  databaseInfo: IDatabaseBaseInfo;
+  data: IManageResultData[];
 }
 
 export interface SQLExecuteRef {
@@ -195,6 +201,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
   const executionSequenceByIdRef = useRef<Record<string, number>>({});
   const executionSequenceByRequestRef = useRef<Record<number, number>>({});
   const keepExistingOutputByExecutionSequenceRef = useRef<Record<number, boolean>>({});
+  const desktopExecutionCallbackBySequenceRef = useRef<Record<number, DesktopExecutionCallbackState>>({});
   const currentStatementSequenceByExecutionIdRef = useRef<Record<string, number>>({});
   const [resultBatchKey, setResultBatchKey] = useState(0);
   const [forceOutputTab, setForceOutputTab] = useState(false);
@@ -336,6 +343,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
     if (executionSequence !== undefined) {
       delete keepExistingOutputByExecutionSequenceRef.current[executionSequence];
       delete resultDisplayBatchSequenceByExecutionRef.current[executionSequence];
+      delete desktopExecutionCallbackBySequenceRef.current[executionSequence];
     }
   }, []);
   const handleSqlExecutionRequestStart = useCallback(
@@ -494,6 +502,12 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
         return;
       }
       if (event.eventType === 'updateCount' || event.eventType === 'resultFinished') {
+        if (event.eventType === 'resultFinished') {
+          const callbackState = desktopExecutionCallbackBySequenceRef.current[executionSequence];
+          if (callbackState) {
+            callbackState.data = appendCompletedQueryResult(callbackState.data, event);
+          }
+        }
         const statementSequence =
           getEventStatementSequence(event, currentStatementSequenceByExecutionIdRef.current[event.executionId]) || 1;
         const result = processResultDataList([event.message], {
@@ -541,7 +555,14 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
         return;
       }
       if (event.eventType === 'finished' || event.eventType === 'failed' || event.eventType === 'cancelled') {
-        cleanupTerminalExecution();
+        try {
+          const callbackState = desktopExecutionCallbackBySequenceRef.current[executionSequence];
+          if (event.eventType === 'finished' && callbackState?.data.length) {
+            onExecuteSQLCallback?.(callbackState);
+          }
+        } finally {
+          cleanupTerminalExecution();
+        }
       }
     },
     [
@@ -550,6 +571,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
       getExecutionSequence,
       handleRefreshTreeByExecuteSQL,
       keepExecutionLogHistory,
+      onExecuteSQLCallback,
     ],
   );
   const { executing, canExecuteSQL, executeSQL, stopExecuteSQL } = useSqlExecutor({
@@ -682,6 +704,15 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
 
     const webExecutionId = isDesktop ? undefined : uuidv4();
     const executionLogContext = getExecutionLogContext(boundInfo);
+    if (isDesktop && onExecuteSQLCallback) {
+      desktopExecutionCallbackBySequenceRef.current[executionSequence] = {
+        databaseInfo: {
+          ...boundInfo,
+          ...params,
+        },
+        data: [],
+      };
+    }
     if (webExecutionId) {
       executionSequenceByIdRef.current[webExecutionId] = executionSequence;
       setSqlExecutionLogState((state) =>
@@ -804,6 +835,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
         }
         delete keepExistingOutputByExecutionSequenceRef.current[executionSequence];
         delete resultDisplayBatchSequenceByExecutionRef.current[executionSequence];
+        delete desktopExecutionCallbackBySequenceRef.current[executionSequence];
       });
   };
 

--- a/chat2db-community-client/src/service/sqlExecutionStream.test.ts
+++ b/chat2db-community-client/src/service/sqlExecutionStream.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import type { IManageResultData } from '@/typings';
 import {
+  appendCompletedQueryResult,
   clearClosedSqlExecutionResults,
   cancelSqlExecutionWithReconciliation,
   isSqlExecutionResultClosed,
@@ -42,6 +43,40 @@ assert.deepEqual(restoredAfterClear[0].dataList, [['first']]);
 const appendedRows = mergeRows(restoredAfterClear, chunk([['second']]));
 assert.equal(appendedRows.length, 1, 'later chunks stay in the same execution result');
 assert.deepEqual(appendedRows[0].dataList, [['first'], ['second']]);
+
+const completedQuery = chunk([['finished']]);
+const ignoredRowsEvent = appendCompletedQueryResult([], {
+  executionId: 'execution-1',
+  eventType: 'rows',
+  message: chunk([['streamed']]),
+});
+assert.deepEqual(ignoredRowsEvent, [], 'row chunks do not trigger completed-result callbacks');
+
+const completedResults = appendCompletedQueryResult(ignoredRowsEvent, {
+  executionId: 'execution-1',
+  eventType: 'resultFinished',
+  message: completedQuery,
+});
+assert.deepEqual(completedResults, [completedQuery], 'a completed query result is retained for callback consumers');
+
+const emptyCompletedQuery = chunk([]);
+const completedResultsWithEmptyQuery = appendCompletedQueryResult(completedResults, {
+  executionId: 'execution-1',
+  eventType: 'resultFinished',
+  message: emptyCompletedQuery,
+});
+assert.deepEqual(
+  completedResultsWithEmptyQuery,
+  [completedQuery, emptyCompletedQuery],
+  'an empty query result still retains its headers for callback consumers',
+);
+
+const ignoredUpdate = appendCompletedQueryResult(completedResultsWithEmptyQuery, {
+  executionId: 'execution-1',
+  eventType: 'updateCount',
+  message: { ...chunk([]), dataList: null },
+});
+assert.equal(ignoredUpdate, completedResultsWithEmptyQuery, 'non-query results do not enter query callbacks');
 
 const closedResults: ClosedSqlExecutionResults = new Map();
 markSqlExecutionResultsClosed(closedResults, [

--- a/chat2db-community-client/src/service/sqlExecutionStream.ts
+++ b/chat2db-community-client/src/service/sqlExecutionStream.ts
@@ -28,6 +28,16 @@ export interface SqlExecutionEvent<T = any> {
   message: T;
 }
 
+export function appendCompletedQueryResult(
+  current: IManageResultData[],
+  event: SqlExecutionEvent,
+): IManageResultData[] {
+  if (event.eventType !== 'resultFinished' || !Array.isArray(event.message?.dataList)) {
+    return current;
+  }
+  return [...current, event.message as IManageResultData];
+}
+
 export interface SqlExecutionStartResult {
   executionId: string;
 }


### PR DESCRIPTION
## Related issue

Closes #2375

## Summary

- Retain completed tabular `resultFinished` payloads for the active Desktop/JCEF SQL execution.
- Invoke the existing `onExecuteSQLCallback` once when that execution emits a successful terminal `finished` event, allowing `EditorChartSql` to persist `headerList` and `dataList` for chart field selectors.
- Preserve the existing empty desktop promise result so streamed rows are not inserted into the result grid a second time.
- Release callback state on success, failure, cancellation, start failure, and promise finalization.
- Add regression coverage that ignores row chunks and update-count events while retaining completed query results, including zero-row results with headers.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:sql-execution-stream` - passed before and after rebasing onto the latest `origin/main`.
  - `yarn lint:eslint` - passed for the complete frontend source tree.
  - `yarn eslint src/service/sqlExecutionStream.ts src/service/sqlExecutionStream.test.ts src/pages/main/workspace/components/SQLExecute/index.tsx --max-warnings=0` - passed after rebase.
  - `yarn test:i18n` - passed.
  - `yarn build:web:community` - compiled successfully.
  - `yarn build:web:desktop` - compiled successfully.
- Manual verification: Source event flow was verified end to end. A packaged desktop click-through was not available in this worktree.
- UI evidence: The observed user flow and reproduction steps are recorded in #2375; no public screenshot is attached because the supplied screenshots include datasource context.

## Risk and compatibility

- Public API or stored data: No changes.
- Database or driver compatibility: No changes; the fix consumes the existing `resultFinished` event payload.
- Network, privacy, or security: No changes.
- Community / Local / Pro boundary: The Community Desktop/JCEF frontend path is fixed. The Web execution path is unchanged.
- Backward compatibility: The desktop execution promise still resolves with an empty array, preserving existing streamed result-tab behavior and preventing duplicate insertion. The new callback handoff is active only when a consumer already supplies `onExecuteSQLCallback`.

## Reviewer map

- Start here: `chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx`, where per-execution callback state is collected and published on `finished`.
- Failure condition: A successful desktop chart query displays rows but returning to the chart still yields empty field selectors, or the result grid shows duplicate tabs.
- Rollback or disable path: Revert this commit; no migration or persisted-state cleanup is required.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with source-path analysis, implementation, regression tests, independent patch review, and the Issue/PR descriptions.
