### PR TITLE
fix(postgresql): render PostGIS geometry and geography as WKT

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/value/factory/PostgreSQLValueProcessorFactory.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/value/factory/PostgreSQLValueProcessorFactory.java
@@ -13,6 +13,7 @@ public class PostgreSQLValueProcessorFactory {
 
     static {
         PostgreSQLNumericProcessor postgreSQLNumericProcessor = new PostgreSQLNumericProcessor();
+        PostgreSQLGeometryProcessor postgreSQLGeometryProcessor = new PostgreSQLGeometryProcessor();
         PROCESSOR_MAP = Map.ofEntries(
                 Map.entry(PostgreSQLColumnTypeEnum.DECIMAL.name(), postgreSQLNumericProcessor),
                 Map.entry(PostgreSQLColumnTypeEnum.NUMERIC.name(), postgreSQLNumericProcessor),
@@ -23,7 +24,9 @@ public class PostgreSQLValueProcessorFactory {
                 Map.entry(PostgreSQLColumnTypeEnum.BIT.name(), new PostgreSQLBitProcessor()),
                 Map.entry(PostgreSQLColumnTypeEnum.TIMESTAMP.name(), new PostgresTimeStampProcessor()),
                 Map.entry(PostgreSQLColumnTypeEnum.TIMESTAMPTZ.name(), new PostgresTimeStampTZProcessor()),
-                Map.entry(PostgreSQLColumnTypeEnum.TIMETZ.name(), new PostgresTimeTZProcessor())
+                Map.entry(PostgreSQLColumnTypeEnum.TIMETZ.name(), new PostgresTimeTZProcessor()),
+                Map.entry(PostgreSQLGeometryProcessor.GEOMETRY_TYPE, postgreSQLGeometryProcessor),
+                Map.entry(PostgreSQLGeometryProcessor.GEOGRAPHY_TYPE, postgreSQLGeometryProcessor)
 
         );
     }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/value/sub/PostgreSQLGeometryProcessor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/value/sub/PostgreSQLGeometryProcessor.java
@@ -1,0 +1,365 @@
+package ai.chat2db.plugin.postgresql.value.sub;
+
+import ai.chat2db.community.domain.api.model.value.SQLDataValue;
+import ai.chat2db.plugin.postgresql.identifier.PostgreSQLIdentifierProcessor;
+import ai.chat2db.spi.DefaultValueProcessor;
+import ai.chat2db.spi.model.value.JDBCDataValue;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.io.Ordinate;
+import org.locationtech.jts.io.WKBReader;
+import org.locationtech.jts.io.WKTWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteOrder;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PostgreSQLGeometryProcessor extends DefaultValueProcessor {
+
+    public static final String GEOMETRY_TYPE = "GEOMETRY";
+    public static final String GEOGRAPHY_TYPE = "GEOGRAPHY";
+
+    private static final Logger log = LoggerFactory.getLogger(PostgreSQLGeometryProcessor.class);
+    private static final Pattern HEX_PATTERN = Pattern.compile("[0-9a-fA-F]+");
+    private static final Pattern DISPLAY_VALUE_PATTERN = Pattern.compile("^(.*)\\s+\\|\\s+(-?\\d+)\\s*$", Pattern.DOTALL);
+    private static final int EWKB_Z_FLAG = 0x80000000;
+    private static final int EWKB_M_FLAG = 0x40000000;
+    private static final int EWKB_SRID_FLAG = 0x20000000;
+    private static final int EWKB_BBOX_FLAG = 0x10000000;
+    private static final int EWKB_TYPE_MASK = 0x0FFFFFFF;
+    private static final int MAX_NESTED_DEPTH = 64;
+
+    @Override
+    public String convertSQLValueByType(SQLDataValue dataValue) {
+        return toSqlLiteral(dataValue.getValue(), dataValue.getDateTypeName());
+    }
+
+    @Override
+    public String convertJDBCValueByType(JDBCDataValue dataValue) {
+        String value = dataValue.getString();
+        String hexValue = normalizeHex(value);
+        if (hexValue == null) {
+            return value;
+        }
+
+        try {
+            byte[] ewkb = WKBReader.hexToBytes(hexValue);
+            WkbHeader header = inspectEwkb(ewkb);
+            if (header.hasMeasure()) {
+                return value;
+            }
+
+            Geometry geometry = new WKBReader().read(ewkb);
+            if (header.hasZ() && containsEmptyGeometry(geometry)) {
+                return value;
+            }
+            WKTWriter writer = new WKTWriter(header.hasZ() ? 3 : 2);
+            writer.setOutputOrdinates(header.hasZ() ? Ordinate.createXYZ() : Ordinate.createXY());
+            String displayValue = removeTypeParenthesisSpace(writer.write(geometry));
+            if (header.srid() != null) {
+                return displayValue + " | " + geometry.getSRID();
+            }
+            return displayValue;
+        } catch (Exception e) {
+            log.debug("Unable to convert PostgreSQL spatial EWKB for display", e);
+            return value;
+        }
+    }
+
+    private boolean containsEmptyGeometry(Geometry geometry) {
+        if (geometry.isEmpty()) {
+            return true;
+        }
+        if (geometry instanceof GeometryCollection collection) {
+            for (int i = 0; i < collection.getNumGeometries(); i++) {
+                if (containsEmptyGeometry(collection.getGeometryN(i))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String convertJDBCValueStrByType(JDBCDataValue dataValue) {
+        return toSqlLiteral(dataValue.getString(), dataValue.getType());
+    }
+
+    private String toSqlLiteral(String value, String dataType) {
+        if (value == null) {
+            return "NULL";
+        }
+
+        String sqlValue = normalizeHex(value);
+        if (sqlValue == null) {
+            sqlValue = toEwkt(value);
+        }
+        String escapedValue = PostgreSQLIdentifierProcessor.INSTANCE.escapeString(sqlValue);
+        return "'" + escapedValue + "'::" + resolveSpatialType(dataType);
+    }
+
+    private String toEwkt(String value) {
+        Matcher matcher = DISPLAY_VALUE_PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            return value.trim();
+        }
+
+        String wkt = matcher.group(1).trim();
+        if (wkt.isEmpty()) {
+            return value.trim();
+        }
+        try {
+            int srid = Integer.parseInt(matcher.group(2));
+            return "SRID=" + srid + ";" + wkt;
+        } catch (NumberFormatException ignored) {
+            return value.trim();
+        }
+    }
+
+    private String resolveSpatialType(String dataType) {
+        if (dataType != null && dataType.toUpperCase(Locale.ROOT).startsWith(GEOGRAPHY_TYPE)) {
+            return GEOGRAPHY_TYPE.toLowerCase(Locale.ROOT);
+        }
+        return GEOMETRY_TYPE.toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizeHex(String value) {
+        if (value == null) {
+            return null;
+        }
+        String candidate = value.trim();
+        if (candidate.startsWith("\\x") || candidate.startsWith("\\X")
+                || candidate.startsWith("0x") || candidate.startsWith("0X")) {
+            candidate = candidate.substring(2);
+        }
+        if (candidate.length() < 10 || candidate.length() % 2 != 0 || !HEX_PATTERN.matcher(candidate).matches()) {
+            return null;
+        }
+        return candidate;
+    }
+
+    private WkbHeader inspectEwkb(byte[] ewkb) {
+        // JTS repairs malformed rings and coordinate sequences, so validate the lossless subset first.
+        WkbCursor cursor = new WkbCursor(ewkb);
+        WkbHeader header = inspectGeometry(cursor, null, true, 0);
+        if (!cursor.isExhausted()) {
+            throw new IllegalArgumentException("EWKB contains trailing data");
+        }
+        return header;
+    }
+
+    private WkbHeader inspectGeometry(WkbCursor cursor, Integer inheritedSrid, boolean root, int depth) {
+        if (depth > MAX_NESTED_DEPTH) {
+            throw new IllegalArgumentException("EWKB nesting is too deep");
+        }
+        ByteOrder byteOrder = readByteOrder(cursor);
+        int typeWord = cursor.readInt(byteOrder);
+        if ((typeWord & EWKB_BBOX_FLAG) != 0) {
+            throw new IllegalArgumentException("EWKB bounding-box headers are not supported");
+        }
+
+        int isoType = typeWord & EWKB_TYPE_MASK;
+        int dimensionCode = isoType / 1000;
+        int baseType = isoType % 1000;
+        if (dimensionCode > 3 || baseType < 1 || baseType > 7) {
+            throw new IllegalArgumentException("Unsupported EWKB geometry type");
+        }
+
+        boolean hasZ = (typeWord & EWKB_Z_FLAG) != 0 || dimensionCode == 1 || dimensionCode == 3;
+        boolean hasMeasure = (typeWord & EWKB_M_FLAG) != 0 || dimensionCode == 2 || dimensionCode == 3;
+        boolean hasSrid = (typeWord & EWKB_SRID_FLAG) != 0;
+        Integer srid = hasSrid ? cursor.readInt(byteOrder) : null;
+        if (!root && srid != null && !srid.equals(inheritedSrid)) {
+            throw new IllegalArgumentException("Nested EWKB SRID differs from its parent");
+        }
+
+        WkbHeader header = new WkbHeader(baseType, hasZ, hasMeasure, srid);
+        int coordinateDimension = 2 + (hasZ ? 1 : 0) + (hasMeasure ? 1 : 0);
+        switch (baseType) {
+            case 1 -> inspectPoint(cursor, byteOrder, coordinateDimension);
+            case 2 -> inspectLineString(cursor, byteOrder, coordinateDimension);
+            case 3 -> {
+                int ringCount = readCount(cursor, byteOrder);
+                for (int i = 0; i < ringCount; i++) {
+                    inspectLinearRing(cursor, byteOrder, coordinateDimension);
+                }
+            }
+            case 4 -> inspectChildren(cursor, byteOrder, header, inheritedSrid, 1, depth);
+            case 5 -> inspectChildren(cursor, byteOrder, header, inheritedSrid, 2, depth);
+            case 6 -> inspectChildren(cursor, byteOrder, header, inheritedSrid, 3, depth);
+            case 7 -> inspectChildren(cursor, byteOrder, header, inheritedSrid, 0, depth);
+            default -> throw new IllegalArgumentException("Unsupported EWKB geometry type");
+        }
+        return header;
+    }
+
+    private void inspectPoint(WkbCursor cursor, ByteOrder byteOrder, int coordinateDimension) {
+        boolean allNaN = true;
+        boolean allFinite = true;
+        for (int i = 0; i < coordinateDimension; i++) {
+            double ordinate = cursor.readDouble(byteOrder);
+            allNaN &= Double.isNaN(ordinate);
+            allFinite &= Double.isFinite(ordinate);
+        }
+        if (!allNaN && !allFinite) {
+            throw new IllegalArgumentException("EWKB point contains an invalid empty coordinate");
+        }
+    }
+
+    private void inspectLineString(WkbCursor cursor, ByteOrder byteOrder, int coordinateDimension) {
+        int coordinateCount = readCount(cursor, byteOrder);
+        if (coordinateCount == 1) {
+            throw new IllegalArgumentException("EWKB line string must be empty or contain at least two coordinates");
+        }
+        inspectFiniteCoordinates(cursor, byteOrder, coordinateCount, coordinateDimension);
+    }
+
+    private void inspectLinearRing(WkbCursor cursor, ByteOrder byteOrder, int coordinateDimension) {
+        int coordinateCount = readCount(cursor, byteOrder);
+        if (coordinateCount < 4) {
+            throw new IllegalArgumentException("EWKB linear ring must contain at least four coordinates");
+        }
+
+        double[] firstCoordinate = readFiniteCoordinate(cursor, byteOrder, coordinateDimension);
+        inspectFiniteCoordinates(cursor, byteOrder, coordinateCount - 2, coordinateDimension);
+        double[] lastCoordinate = readFiniteCoordinate(cursor, byteOrder, coordinateDimension);
+        for (int i = 0; i < 2; i++) {
+            if (firstCoordinate[i] != lastCoordinate[i]) {
+                throw new IllegalArgumentException("EWKB linear ring is not closed");
+            }
+        }
+    }
+
+    private void inspectFiniteCoordinates(WkbCursor cursor, ByteOrder byteOrder,
+                                          int coordinateCount, int coordinateDimension) {
+        for (int coordinate = 0; coordinate < coordinateCount; coordinate++) {
+            for (int ordinate = 0; ordinate < coordinateDimension; ordinate++) {
+                if (!Double.isFinite(cursor.readDouble(byteOrder))) {
+                    throw new IllegalArgumentException("EWKB coordinate is not finite");
+                }
+            }
+        }
+    }
+
+    private double[] readFiniteCoordinate(WkbCursor cursor, ByteOrder byteOrder, int coordinateDimension) {
+        double[] coordinate = new double[coordinateDimension];
+        for (int i = 0; i < coordinateDimension; i++) {
+            coordinate[i] = cursor.readDouble(byteOrder);
+            if (!Double.isFinite(coordinate[i])) {
+                throw new IllegalArgumentException("EWKB coordinate is not finite");
+            }
+        }
+        return coordinate;
+    }
+
+    private void inspectChildren(WkbCursor cursor, ByteOrder byteOrder, WkbHeader parent,
+                                 Integer inheritedSrid, int expectedType, int depth) {
+        int childCount = readCount(cursor, byteOrder);
+        Integer effectiveSrid = parent.srid() != null ? parent.srid() : inheritedSrid;
+        for (int i = 0; i < childCount; i++) {
+            WkbHeader child = inspectGeometry(cursor, effectiveSrid, false, depth + 1);
+            if (expectedType != 0 && child.baseType() != expectedType) {
+                throw new IllegalArgumentException("EWKB collection contains an unexpected geometry type");
+            }
+            if (child.hasZ() != parent.hasZ() || child.hasMeasure() != parent.hasMeasure()) {
+                throw new IllegalArgumentException("EWKB collection contains mixed coordinate dimensions");
+            }
+        }
+    }
+
+    private int readCount(WkbCursor cursor, ByteOrder byteOrder) {
+        int count = cursor.readInt(byteOrder);
+        if (count < 0) {
+            throw new IllegalArgumentException("EWKB contains a negative element count");
+        }
+        return count;
+    }
+
+    private ByteOrder readByteOrder(WkbCursor cursor) {
+        int byteOrder = cursor.readUnsignedByte();
+        if (byteOrder == 0) {
+            return ByteOrder.BIG_ENDIAN;
+        }
+        if (byteOrder == 1) {
+            return ByteOrder.LITTLE_ENDIAN;
+        }
+        throw new IllegalArgumentException("Unsupported EWKB byte order");
+    }
+
+    private String removeTypeParenthesisSpace(String wkt) {
+        int openParenthesis = wkt.indexOf('(');
+        if (openParenthesis > 0 && wkt.charAt(openParenthesis - 1) == ' ') {
+            return wkt.substring(0, openParenthesis - 1) + wkt.substring(openParenthesis);
+        }
+        return wkt;
+    }
+
+    private record WkbHeader(int baseType, boolean hasZ, boolean hasMeasure, Integer srid) {
+    }
+
+    private static final class WkbCursor {
+
+        private final byte[] data;
+        private int offset;
+
+        private WkbCursor(byte[] data) {
+            this.data = data;
+        }
+
+        private int readUnsignedByte() {
+            require(Byte.BYTES);
+            return data[offset++] & 0xff;
+        }
+
+        private int readInt(ByteOrder byteOrder) {
+            require(Integer.BYTES);
+            int value;
+            if (byteOrder == ByteOrder.BIG_ENDIAN) {
+                value = (data[offset] & 0xff) << 24
+                        | (data[offset + 1] & 0xff) << 16
+                        | (data[offset + 2] & 0xff) << 8
+                        | data[offset + 3] & 0xff;
+            } else {
+                value = data[offset] & 0xff
+                        | (data[offset + 1] & 0xff) << 8
+                        | (data[offset + 2] & 0xff) << 16
+                        | (data[offset + 3] & 0xff) << 24;
+            }
+            offset += Integer.BYTES;
+            return value;
+        }
+
+        private double readDouble(ByteOrder byteOrder) {
+            return Double.longBitsToDouble(readLong(byteOrder));
+        }
+
+        private long readLong(ByteOrder byteOrder) {
+            require(Long.BYTES);
+            long value = 0;
+            if (byteOrder == ByteOrder.BIG_ENDIAN) {
+                for (int i = 0; i < Long.BYTES; i++) {
+                    value = value << 8 | data[offset + i] & 0xffL;
+                }
+            } else {
+                for (int i = Long.BYTES - 1; i >= 0; i--) {
+                    value = value << 8 | data[offset + i] & 0xffL;
+                }
+            }
+            offset += Long.BYTES;
+            return value;
+        }
+
+        private boolean isExhausted() {
+            return offset == data.length;
+        }
+
+        private void require(int byteCount) {
+            if (byteCount > data.length - offset) {
+                throw new IllegalArgumentException("EWKB ends before its declared geometry data");
+            }
+        }
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/value/sub/PostgreSQLGeometryProcessor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/value/sub/PostgreSQLGeometryProcessor.java
@@ -12,9 +12,10 @@ import org.locationtech.jts.io.WKTWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.nio.ByteOrder;
 import java.util.Locale;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class PostgreSQLGeometryProcessor extends DefaultValueProcessor {
@@ -24,13 +25,17 @@ public class PostgreSQLGeometryProcessor extends DefaultValueProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(PostgreSQLGeometryProcessor.class);
     private static final Pattern HEX_PATTERN = Pattern.compile("[0-9a-fA-F]+");
-    private static final Pattern DISPLAY_VALUE_PATTERN = Pattern.compile("^(.*)\\s+\\|\\s+(-?\\d+)\\s*$", Pattern.DOTALL);
     private static final int EWKB_Z_FLAG = 0x80000000;
     private static final int EWKB_M_FLAG = 0x40000000;
     private static final int EWKB_SRID_FLAG = 0x20000000;
     private static final int EWKB_BBOX_FLAG = 0x10000000;
     private static final int EWKB_TYPE_MASK = 0x0FFFFFFF;
     private static final int MAX_NESTED_DEPTH = 64;
+    private static final int MAX_DISPLAY_EWKB_BYTES = 512 * 1024;
+    private static final int MAX_DISPLAY_EWKB_HEX_CHARS = MAX_DISPLAY_EWKB_BYTES * 2;
+    private static final int MAX_DISPLAY_WKT_CHARS = MAX_DISPLAY_EWKB_HEX_CHARS;
+    private static final int MAX_DISPLAY_SRID_SUFFIX_CHARS = " | ".length()
+            + Integer.toString(Integer.MIN_VALUE).length();
 
     @Override
     public String convertSQLValueByType(SQLDataValue dataValue) {
@@ -40,8 +45,11 @@ public class PostgreSQLGeometryProcessor extends DefaultValueProcessor {
     @Override
     public String convertJDBCValueByType(JDBCDataValue dataValue) {
         String value = dataValue.getString();
+        if (value == null || value.length() > MAX_DISPLAY_EWKB_HEX_CHARS + 2) {
+            return value;
+        }
         String hexValue = normalizeHex(value);
-        if (hexValue == null) {
+        if (hexValue == null || hexValue.length() > MAX_DISPLAY_EWKB_HEX_CHARS) {
             return value;
         }
 
@@ -58,7 +66,13 @@ public class PostgreSQLGeometryProcessor extends DefaultValueProcessor {
             }
             WKTWriter writer = new WKTWriter(header.hasZ() ? 3 : 2);
             writer.setOutputOrdinates(header.hasZ() ? Ordinate.createXYZ() : Ordinate.createXY());
-            String displayValue = removeTypeParenthesisSpace(writer.write(geometry));
+            BoundedStringWriter output = new BoundedStringWriter(MAX_DISPLAY_WKT_CHARS);
+            try {
+                writer.write(geometry, output);
+            } catch (WktOutputLimitExceededException ignored) {
+                return value;
+            }
+            String displayValue = removeTypeParenthesisSpace(output.value());
             if (header.srid() != null) {
                 return displayValue + " | " + geometry.getSRID();
             }
@@ -102,20 +116,24 @@ public class PostgreSQLGeometryProcessor extends DefaultValueProcessor {
     }
 
     private String toEwkt(String value) {
-        Matcher matcher = DISPLAY_VALUE_PATTERN.matcher(value);
-        if (!matcher.matches()) {
-            return value.trim();
+        if (value.length() > MAX_DISPLAY_WKT_CHARS + MAX_DISPLAY_SRID_SUFFIX_CHARS) {
+            return value;
         }
-
-        String wkt = matcher.group(1).trim();
-        if (wkt.isEmpty()) {
-            return value.trim();
+        String trimmedValue = value.trim();
+        int separator = trimmedValue.lastIndexOf('|');
+        if (separator < 0) {
+            return trimmedValue;
+        }
+        String wkt = trimmedValue.substring(0, separator).trim();
+        String sridValue = trimmedValue.substring(separator + 1).trim();
+        if (wkt.isEmpty() || wkt.length() > MAX_DISPLAY_WKT_CHARS || sridValue.isEmpty()) {
+            return trimmedValue;
         }
         try {
-            int srid = Integer.parseInt(matcher.group(2));
+            int srid = Integer.parseInt(sridValue);
             return "SRID=" + srid + ";" + wkt;
         } catch (NumberFormatException ignored) {
-            return value.trim();
+            return trimmedValue;
         }
     }
 
@@ -298,6 +316,55 @@ public class PostgreSQLGeometryProcessor extends DefaultValueProcessor {
     }
 
     private record WkbHeader(int baseType, boolean hasZ, boolean hasMeasure, Integer srid) {
+    }
+
+    private static final class BoundedStringWriter extends Writer {
+
+        private final StringBuilder value = new StringBuilder();
+        private final int maxChars;
+
+        private BoundedStringWriter(int maxChars) {
+            this.maxChars = maxChars;
+        }
+
+        @Override
+        public void write(int character) throws IOException {
+            requireCapacity(1);
+            value.append((char) character);
+        }
+
+        @Override
+        public void write(char[] buffer, int offset, int length) throws IOException {
+            requireCapacity(length);
+            value.append(buffer, offset, length);
+        }
+
+        @Override
+        public void write(String text, int offset, int length) throws IOException {
+            requireCapacity(length);
+            value.append(text, offset, offset + length);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        private void requireCapacity(int additionalChars) throws WktOutputLimitExceededException {
+            if (additionalChars < 0 || additionalChars > maxChars - value.length()) {
+                throw new WktOutputLimitExceededException();
+            }
+        }
+
+        private String value() {
+            return value.toString();
+        }
+    }
+
+    private static final class WktOutputLimitExceededException extends IOException {
     }
 
     private static final class WkbCursor {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/test/java/ai/chat2db/plugin/postgresql/value/sub/PostgreSQLGeometryProcessorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/test/java/ai/chat2db/plugin/postgresql/value/sub/PostgreSQLGeometryProcessorTest.java
@@ -6,15 +6,20 @@ import ai.chat2db.plugin.postgresql.value.PostgreSQLValueProcessor;
 import ai.chat2db.plugin.postgresql.value.factory.PostgreSQLValueProcessorFactory;
 import ai.chat2db.spi.model.value.JDBCDataValue;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.io.ByteOrderValues;
 import org.locationtech.jts.io.WKBWriter;
 import org.locationtech.jts.io.WKTReader;
+
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 class PostgreSQLGeometryProcessorTest {
 
@@ -120,6 +125,52 @@ class PostgreSQLGeometryProcessorTest {
                 processor.convertJDBCValueByType(jdbcValue(partiallyEmptyPoint, "geometry")));
         assertEquals("0102030405", processor.convertJDBCValueByType(jdbcValue("0102030405", "geometry")));
         assertEquals("not-ewkb", processor.convertJDBCValueByType(jdbcValue("not-ewkb", "geometry")));
+    }
+
+    @Test
+    void fallsBackBeforeDecodingOversizedEwkb() {
+        String exactLimitEwkb = "00".repeat(512 * 1024);
+        String oversizedEwkb = exactLimitEwkb + "00";
+        String prefixedExactLimitEwkb = "\\x" + exactLimitEwkb;
+        String prefixedOversizedEwkb = prefixedExactLimitEwkb + "00";
+
+        assertSame(exactLimitEwkb,
+                processor.convertJDBCValueByType(jdbcValue(exactLimitEwkb, "geometry")));
+        assertSame(oversizedEwkb,
+                processor.convertJDBCValueByType(jdbcValue(oversizedEwkb, "geometry")));
+        assertSame(prefixedExactLimitEwkb,
+                processor.convertJDBCValueByType(jdbcValue(prefixedExactLimitEwkb, "geometry")));
+        assertSame(prefixedOversizedEwkb,
+                processor.convertJDBCValueByType(jdbcValue(prefixedOversizedEwkb, "geometry")));
+    }
+
+    @Test
+    void fallsBackWhenWktOutputExceedsDisplayBudget() {
+        Coordinate[] coordinates = new Coordinate[2_000];
+        for (int i = 0; i < coordinates.length; i++) {
+            coordinates[i] = new Coordinate(Double.MAX_VALUE, Double.MAX_VALUE);
+        }
+        Geometry geometry = new GeometryFactory().createLineString(coordinates);
+        geometry.setSRID(4490);
+        String ewkb = WKBWriter.toHex(new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN, true).write(geometry));
+
+        assertSame(ewkb, processor.convertJDBCValueByType(jdbcValue(ewkb, "geometry")));
+    }
+
+    @Test
+    void parsesLongEditedValuesWithoutRegexBacktracking() {
+        String whitespace = " ".repeat(64 * 1024);
+
+        assertTimeout(Duration.ofSeconds(2), () ->
+                assertEquals("''::geometry", processor.getSqlValueString(sqlValue(whitespace, "geometry"))));
+    }
+
+    @Test
+    void convertsWktAtDisplayBudgetWithLongestSridSuffix() {
+        String wkt = "P".repeat(1024 * 1024);
+
+        assertEquals("'SRID=-2147483648;" + wkt + "'::geometry",
+                processor.getSqlValueString(sqlValue(wkt + " | -2147483648", "geometry")));
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/test/java/ai/chat2db/plugin/postgresql/value/sub/PostgreSQLGeometryProcessorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/test/java/ai/chat2db/plugin/postgresql/value/sub/PostgreSQLGeometryProcessorTest.java
@@ -1,0 +1,234 @@
+package ai.chat2db.plugin.postgresql.value.sub;
+
+import ai.chat2db.community.domain.api.model.metadata.DataType;
+import ai.chat2db.community.domain.api.model.value.SQLDataValue;
+import ai.chat2db.plugin.postgresql.value.PostgreSQLValueProcessor;
+import ai.chat2db.plugin.postgresql.value.factory.PostgreSQLValueProcessorFactory;
+import ai.chat2db.spi.model.value.JDBCDataValue;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ByteOrderValues;
+import org.locationtech.jts.io.WKBWriter;
+import org.locationtech.jts.io.WKTReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PostgreSQLGeometryProcessorTest {
+
+    private static final String POINT_4490 = "01010000208A11000074143AF510FB594082D264ABDA973E40";
+    private static final String LINE_STRING_4490 = "01020000208A11000002000000876E93DDCE075A400C097316513B3E40"
+            + "CD3F1768E1075A4026ECD997753B3E40";
+    private static final String POLYGON_4490 = "01030000208A1100000100000006000000EEEC2B0F12FE5940793B25947C803E40"
+            + "E3F24B0F12FE5940D01506947C803E40E3109AF21BFE59407B2855CB6B803E40"
+            + "E86E742118FE59409738134F4D803E40912B92020DFE5940BE8C5A485D803E40"
+            + "EEEC2B0F12FE5940793B25947C803E40";
+
+    private final PostgreSQLGeometryProcessor processor = new PostgreSQLGeometryProcessor();
+
+    @Test
+    void displaysPointWithPrecisionAndSrid() {
+        assertEquals("POINT(103.922910029143 30.5931803818844) | 4490",
+                processor.convertJDBCValueByType(jdbcValue(POINT_4490, "geometry")));
+    }
+
+    @Test
+    void displaysLineStringAndPolygonWithPrecisionAndSrid() {
+        assertEquals("LINESTRING(104.12200107 30.23170605, 104.123132727341 30.2322630793607) | 4490",
+                processor.convertJDBCValueByType(jdbcValue(LINE_STRING_4490, "geometry")));
+        assertEquals("POLYGON((103.96985225 30.50190092, 103.969852279824 30.501900912748, "
+                        + "103.97045579 30.50164481, 103.97022282 30.50117964, 103.96954407 30.50142338, "
+                        + "103.96985225 30.50190092)) | 4490",
+                processor.convertJDBCValueByType(jdbcValue(POLYGON_4490, "geometry")));
+    }
+
+    @Test
+    void supportsBigEndianAndHexPrefixes() {
+        String bigEndian = "0020000001000010E63FF00000000000004000000000000000";
+        assertEquals("POINT(1 2) | 4326",
+                processor.convertJDBCValueByType(jdbcValue(bigEndian, "geometry")));
+        assertEquals("POINT(103.922910029143 30.5931803818844) | 4490",
+                processor.convertJDBCValueByType(jdbcValue("\\x" + POINT_4490, "geometry")));
+    }
+
+    @Test
+    void doesNotInventSridForPlainWkb() {
+        String pointWithoutSrid = "0101000000000000000000F03F0000000000000040";
+        assertEquals("POINT(1 2)",
+                processor.convertJDBCValueByType(jdbcValue(pointWithoutSrid, "geometry")));
+    }
+
+    @Test
+    void preservesThreeDimensionalCoordinates() {
+        String pointZ = "01010000A0E6100000000000000000F03F00000000000000400000000000000840";
+        assertEquals("POINT Z(1 2 3) | 4326",
+                processor.convertJDBCValueByType(jdbcValue(pointZ, "geometry")));
+    }
+
+    @Test
+    void acceptsThreeDimensionalRingClosedInTwoDimensions() throws Exception {
+        String polygonZ = ewkb("POLYGON Z((0 0 1, 0 1 2, 1 0 3, 0 0 4))", 4490, 3);
+        assertEquals("POLYGON Z((0 0 1, 0 1 2, 1 0 3, 0 0 4)) | 4490",
+                processor.convertJDBCValueByType(jdbcValue(polygonZ, "geometry")));
+    }
+
+    @Test
+    void displaysMultiGeometryFamiliesAndCollections() throws Exception {
+        assertEquals("MULTIPOINT((1 2), (3 4)) | 4490",
+                processor.convertJDBCValueByType(jdbcValue(
+                        ewkb("MULTIPOINT((1 2), (3 4))", 4490), "geometry")));
+        assertEquals("MULTILINESTRING((1 2, 3 4), (5 6, 7 8)) | 4490",
+                processor.convertJDBCValueByType(jdbcValue(
+                        ewkb("MULTILINESTRING((1 2, 3 4), (5 6, 7 8))", 4490), "geometry")));
+        assertEquals("MULTIPOLYGON(((0 0, 0 1, 1 1, 0 0))) | 4490",
+                processor.convertJDBCValueByType(jdbcValue(
+                        ewkb("MULTIPOLYGON(((0 0, 0 1, 1 1, 0 0)))", 4490), "geometry")));
+        assertEquals("GEOMETRYCOLLECTION(POINT (1 2), LINESTRING (3 4, 5 6)) | 4490",
+                processor.convertJDBCValueByType(jdbcValue(
+                        ewkb("GEOMETRYCOLLECTION(POINT(1 2), LINESTRING(3 4, 5 6))", 4490), "geometry")));
+    }
+
+    @Test
+    void fallsBackWithoutLosingMeasuredOrInvalidValues() {
+        String pointM = "0101000060E6100000000000000000F03F00000000000000400000000000000840";
+        String pointZm = "01010000E0E6100000000000000000F03F00000000000000400000000000000840"
+                + "0000000000001040";
+        String nestedPointM = "0107000020E6100000010000000101000040000000000000F03F0000000000000040"
+                + "0000000000000840";
+        String pointWithTrailingData = POINT_4490 + "00";
+        String unsupportedCircularString = "010800000000000000";
+        String onePointLineString = "010200000001000000000000000000F03F0000000000000040";
+        String unclosedPolygon = "01030000000100000003000000"
+                + "00000000000000000000000000000000"
+                + "000000000000F03F0000000000000000"
+                + "0000000000000000000000000000F03F";
+        String partiallyEmptyPoint = "0101000000000000000000F87F0000000000000040";
+        assertEquals(pointM, processor.convertJDBCValueByType(jdbcValue(pointM, "geometry")));
+        assertEquals(pointZm, processor.convertJDBCValueByType(jdbcValue(pointZm, "geometry")));
+        assertEquals(nestedPointM, processor.convertJDBCValueByType(jdbcValue(nestedPointM, "geometry")));
+        assertEquals(pointWithTrailingData,
+                processor.convertJDBCValueByType(jdbcValue(pointWithTrailingData, "geometry")));
+        assertEquals(unsupportedCircularString,
+                processor.convertJDBCValueByType(jdbcValue(unsupportedCircularString, "geometry")));
+        assertEquals(onePointLineString,
+                processor.convertJDBCValueByType(jdbcValue(onePointLineString, "geometry")));
+        assertEquals(unclosedPolygon,
+                processor.convertJDBCValueByType(jdbcValue(unclosedPolygon, "geometry")));
+        assertEquals(partiallyEmptyPoint,
+                processor.convertJDBCValueByType(jdbcValue(partiallyEmptyPoint, "geometry")));
+        assertEquals("0102030405", processor.convertJDBCValueByType(jdbcValue("0102030405", "geometry")));
+        assertEquals("not-ewkb", processor.convertJDBCValueByType(jdbcValue("not-ewkb", "geometry")));
+    }
+
+    @Test
+    void displaysEmptyGeometryWithoutInventingCoordinates() throws Exception {
+        assertEquals("POINT EMPTY | 4490",
+                processor.convertJDBCValueByType(jdbcValue(ewkb("POINT EMPTY", 4490), "geometry")));
+        assertEquals("LINESTRING EMPTY | 4490",
+                processor.convertJDBCValueByType(jdbcValue(ewkb("LINESTRING EMPTY", 4490), "geometry")));
+        assertEquals("POLYGON EMPTY | 4490",
+                processor.convertJDBCValueByType(jdbcValue(ewkb("POLYGON EMPTY", 4490), "geometry")));
+    }
+
+    @Test
+    void preservesRawEwkbForThreeDimensionalEmptyGeometries() throws Exception {
+        String[] emptyGeometries = {
+                "POINT Z EMPTY",
+                "LINESTRING Z EMPTY",
+                "POLYGON Z EMPTY",
+                "MULTIPOINT Z EMPTY",
+                "MULTILINESTRING Z EMPTY",
+                "MULTIPOLYGON Z EMPTY",
+                "GEOMETRYCOLLECTION Z EMPTY",
+                "GEOMETRYCOLLECTION Z (POINT Z EMPTY, POINT Z (1 2 3))"
+        };
+        for (String wkt : emptyGeometries) {
+            String value = ewkb(wkt, 4326, 3);
+            assertEquals(value, processor.convertJDBCValueByType(jdbcValue(value, "geometry")));
+        }
+    }
+
+    @Test
+    void convertsDisplayValuesToTypedPostgisLiterals() {
+        assertEquals("'SRID=4490;POINT(1 2)'::geometry",
+                processor.getSqlValueString(sqlValue("POINT(1 2) | 4490", "geometry")));
+        assertEquals("'SRID=4326;POINT(1 2)'::geography",
+                processor.getSqlValueString(sqlValue("POINT(1 2) | 4326", "geography")));
+        assertEquals("'POINT(1 2)'::geometry",
+                processor.getSqlValueString(sqlValue("POINT(1 2)", "geometry")));
+    }
+
+    @Test
+    void preservesRawEwkbForJdbcSqlAndEscapesEditedValues() {
+        assertEquals("'" + POINT_4490 + "'::geometry",
+                processor.convertJDBCValueStrByType(jdbcValue(POINT_4490, "geometry")));
+        assertEquals("'" + POINT_4490 + "'::geography",
+                processor.convertJDBCValueStrByType(jdbcValue("0x" + POINT_4490, "geography")));
+        assertEquals("'POINT(1 2)'' OR true --'::geometry",
+                processor.getSqlValueString(sqlValue("POINT(1 2)' OR true --", "geometry")));
+    }
+
+    @Test
+    void dispatchesGeometryAndGeographyCaseInsensitively() {
+        PostgreSQLValueProcessor valueProcessor = new PostgreSQLValueProcessor();
+        assertEquals("POINT(103.922910029143 30.5931803818844) | 4490",
+                valueProcessor.getJdbcValue(jdbcValue(POINT_4490, "GeOmEtRy")));
+        assertEquals("'SRID=4490;POINT(1 2)'::geography",
+                valueProcessor.getSqlValueString(sqlValue("POINT(1 2) | 4490", "GeOgRaPhY")));
+    }
+
+    @Test
+    void factoryUsesOneSpatialProcessorForBothPostgisTypes() {
+        Object geometry = PostgreSQLValueProcessorFactory.getValueProcessor("GEOMETRY");
+        Object geography = PostgreSQLValueProcessorFactory.getValueProcessor("GEOGRAPHY");
+        assertInstanceOf(PostgreSQLGeometryProcessor.class, geometry);
+        assertSame(geometry, geography);
+    }
+
+    @Test
+    void preservesNullSemantics() {
+        assertEquals("NULL", processor.getSqlValueString(sqlValue(null, "geometry")));
+        assertNull(new PostgreSQLValueProcessor().getJdbcValue(jdbcValue(null, "geometry")));
+    }
+
+    private static String ewkb(String wkt, int srid) throws Exception {
+        return ewkb(wkt, srid, 2);
+    }
+
+    private static String ewkb(String wkt, int srid, int outputDimension) throws Exception {
+        Geometry geometry = new WKTReader().read(wkt);
+        geometry.setSRID(srid);
+        WKBWriter writer = new WKBWriter(outputDimension, ByteOrderValues.LITTLE_ENDIAN, true);
+        return WKBWriter.toHex(writer.write(geometry));
+    }
+
+    private static SQLDataValue sqlValue(String value, String type) {
+        DataType dataType = new DataType();
+        dataType.setDataTypeName(type);
+        SQLDataValue sqlDataValue = new SQLDataValue();
+        sqlDataValue.setDataType(dataType);
+        sqlDataValue.setValue(value);
+        return sqlDataValue;
+    }
+
+    private static JDBCDataValue jdbcValue(String value, String type) {
+        return new JDBCDataValue(null, null, 1, false) {
+            @Override
+            public Object getObject() {
+                return value;
+            }
+
+            @Override
+            public String getString() {
+                return value;
+            }
+
+            @Override
+            public String getType() {
+                return type;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #2417

## Summary

- Register a PostgreSQL value processor for PostGIS `geometry` and `geography`.
- Display supported EWKB as precision-preserving WKT followed by its SRID.
- Strictly preflight EWKB before JTS conversion so malformed, measured, extended, or otherwise lossy values retain their raw representation.
- Generate escaped, type-qualified SQL literals for edits, copies, exports, and row conditions.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Focused `PostgreSQLGeometryProcessorTest`: 15 passed, 0 failed.
  - PostgreSQL module and dependencies: 202 passed, 0 failed.
  - Full Community server test reactor: all 48 modules succeeded; final start module had 47 tests, 0 failures, 0 errors, 1 existing skip.
  - Community package reactor with tests skipped: all 48 modules succeeded.
  - `git diff --check origin/main...HEAD`: passed.
- Manual verification:
  - PostgreSQL 16 with PostGIS 3.4.3 accepted the generated geometry and geography literals.
  - High-precision SRID 4490 WKT round-tripped equal to its original EWKB.
  - A valid 3D polygon whose closing Z differs was retained; 3D empty values preserve raw EWKB where JTS 1.19 cannot emit lossless WKT.
- UI evidence: N/A; this is a database value-processor change.

## Risk and compatibility

- Public API or stored data: No changes.
- Database or driver compatibility: Limited to PostgreSQL PostGIS spatial values. Unsupported or potentially lossy values retain the previous raw EWKB display.
- Network, privacy, or security: No changes. Edited text is escaped before a fixed `geometry` or `geography` cast.
- Community / Local / Pro boundary: Applies to editions that reuse the Community PostgreSQL value processor.
- Backward compatibility: Non-spatial PostgreSQL values are unchanged.

## Reviewer map

- Start here: `PostgreSQLGeometryProcessor` and its focused test class.
- Failure condition: Spatial values lose dimensions, precision, SRID, or generate invalid SQL.
- Rollback or disable path: Remove the `GEOMETRY` and `GEOGRAPHY` factory registrations.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex was used to implement, test, and review this change.