### PR TITLE
fix(tree): guard editorDataSource splice against findIndex -1

### DIFF
--- a/chat2db-community-client/src/store/tree/index.tsx
+++ b/chat2db-community-client/src/store/tree/index.tsx
@@ -415,10 +415,16 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
     // If it is a data source under group
     if (parentNode) {
       const index = parentNode.children?.findIndex((item) => item.key === `dataSource_${dataSourceDetails.id}`);
-      parentNode.children?.splice(index!, 1, newTreeNode);
+      // findIndex returns -1 when the node was removed/moved since the modal opened;
+      // splice(-1, 1, ...) would replace the last child. Only splice when found.
+      if (index !== undefined && index >= 0) {
+        parentNode.children?.splice(index, 1, newTreeNode);
+      }
     } else {
       const index = newTreeData?.findIndex((item) => item.key === `dataSource_${dataSourceDetails.id}`);
-      newTreeData?.splice(index!, 1, newTreeNode);
+      if (index !== undefined && index >= 0) {
+        newTreeData?.splice(index, 1, newTreeNode);
+      }
     }
     // If it was originally expanded and needs to be collapsed
     set({


### PR DESCRIPTION
## What
`editorDataSource` did `splice(index!, 1, newTreeNode)` where `findIndex` can return `-1` (tree refreshed/moved since the modal opened) → `splice(-1, 1, ...)` replaced the last child instead of the target. The `!` masked the `-1` case.

## Location
`src/store/tree/index.tsx:417-421`

## Fix
Only splice when the index is found (`index >= 0`), in both branches; drop the `!`.

Fixes #2442

🤖 Generated with [Claude Code](https://claude.com/claude-code)