### PR TITLE
fix(bi): guard EditorChartSql data[0] for non-SELECT results

### DIFF
--- a/chat2db-community-client/src/blocks/BI/ChartCardBox/EditorChartSql/index.tsx
+++ b/chat2db-community-client/src/blocks/BI/ChartCardBox/EditorChartSql/index.tsx
@@ -73,7 +73,13 @@ const EditorChartSql = forwardRef((props: IProps, ref: ForwardedRef<EditorChartS
       data,
     } = params;
 
-    const { dataList, headerList } = data[0];
+    // The web execution path constructs data = [] for non-SELECT statements
+    // (DDL/INSERT/UPDATE); data[0] is then undefined and the destructuring throws.
+    const first = data?.[0];
+    if (!first) {
+      return;
+    }
+    const { dataList, headerList } = first;
 
     setDatabaseInfoAndMetaData({
       databaseInfo: { dataSourceId, dataSourceName, databaseType, databaseName, schemaName, sql },


### PR DESCRIPTION
## What
`onExecuteSQLCallback` destructured `data[0]` with no guard; the web execution path builds `data = []` for non-SELECT statements (DDL/INSERT/UPDATE), so `data[0]` was `undefined` and the destructuring threw, crashing the chart SQL editor on switch/save.

## Location
`src/blocks/BI/ChartCardBox/EditorChartSql/index.tsx:76`

## Fix
Guard `const first = data?.[0]; if (!first) return;` before destructuring.

## Note
#2162 (closed) covered a related empty-data path; this addresses the web execution `data = []` path that remained unguarded.

Fixes #2448

🤖 Generated with [Claude Code](https://claude.com/claude-code)