### PR TITLE
fix(sse): stop the SSE stream on useSSERequest unmount

### DIFF
--- a/chat2db-community-client/src/hooks/useSSERequest.ts
+++ b/chat2db-community-client/src/hooks/useSSERequest.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import sseRequest, { AnyObject, SSEOutput, SSERequestOptions, SSERequestParams, SSERequestStatus } from '@/components/SSERequest';
 import useSyncState from '@/hooks/useSyncState';
 import { AnswerPartsType } from '@/constants/chat';
@@ -46,6 +46,14 @@ const useSSERequest = <T = string>(
     () => sseRequest(options),
     [options.baseURL, options.model, options.dangerouslyApiKey, options.lang],
   );
+
+  // Stop the in-flight SSE stream on unmount so the fetch reader and onUpdate
+  // callbacks do not outlive the component (leaked fetch + setState-after-unmount).
+  useEffect(() => {
+    return () => {
+      instance.stop();
+    };
+  }, [instance]);
 
   const request = useCallback(
     async (params: SSERequestParams & AnyObject) => {


### PR DESCRIPTION
## What
`useSSERequest` memoized the SSE instance and exposed `stop`, but never called `instance.stop()` on unmount. The underlying `AbortController` is only aborted on explicit `stop()`, so navigating away mid-stream left the fetch reader running and `onUpdate` firing `setState` on an unmounted component.

## Location
`src/hooks/useSSERequest.ts:45-48` (instance memoized, no cleanup).

## Fix
`useEffect(() => () => instance.stop(), [instance]);` (added `useEffect` import).

Fixes #2460

🤖 Generated with [Claude Code](https://claude.com/claude-code)