### PR TITLE
fix(ai-create-table): closeEventSource stops the AI stream

### DIFF
--- a/chat2db-community-client/src/blocks/DatabaseTableEditor/AICreateTable/index.tsx
+++ b/chat2db-community-client/src/blocks/DatabaseTableEditor/AICreateTable/index.tsx
@@ -36,7 +36,7 @@ const AICreateTable = forwardRef((props: IProps, ref: ForwardedRef<IAICreateTabl
   const draggableResizableModalRef = useRef<DraggableResizableModalRef>(null);
   const [chatInputValue, setChatInputValue] = useState('');
   const [content, setContent] = useState('');
-  const { status, request } = useSSERequest(
+  const { status, request, stop: stopAiStream } = useSSERequest(
     {
       baseURL: '/api/v2/ai/chat',
     },
@@ -68,7 +68,11 @@ const AICreateTable = forwardRef((props: IProps, ref: ForwardedRef<IAICreateTabl
     }
   }, [status]);
 
-  const closeEventSource = () => {};
+  const closeEventSource = () => {
+    // Abort the in-flight AI stream so closing the modal mid-generation
+    // stops the fetch reader and downstream callbacks (stale refs).
+    stopAiStream();
+  };
 
   useEffect(() => {
     if (!content) {


### PR DESCRIPTION
## What
`closeEventSource` was an empty stub called from the modal `onClose`, while `useSSERequest`'s `stop` was not destructured, so closing the AI-create-table modal mid-generation never aborted the stream.

## Location
`src/blocks/DatabaseTableEditor/AICreateTable/index.tsx:39` (destructure omits `stop`), `:71` (stub), `:195-196` (`onClose` calls it).

## Fix
Destructure `stop: stopAiStream` from `useSSERequest` and call it from `closeEventSource`. Pairs with the unmount-stop fix in `useSSERequest` (#2460).

Fixes #2462

🤖 Generated with [Claude Code](https://claude.com/claude-code)