### PR TITLE
fix(sse): abort previous stream before reusing the singleton controller

### DIFF
--- a/chat2db-community-client/src/components/SSERequest/sseHttpsRequest.ts
+++ b/chat2db-community-client/src/components/SSERequest/sseHttpsRequest.ts
@@ -46,6 +46,11 @@ class HTTPSRequestClass {
     callbacks: SSERequestCallbacks<Output>,
     transformStream?: SSEStreamProps<Output>['transformStream'],
   ) => {
+    // The instance is a per-baseURL singleton, so consumers sharing the same
+    // baseURL reuse it. Abort any in-flight stream before replacing the
+    // controller, otherwise the previous stream's AbortController is orphaned
+    // (stop() only touches the latest) and keeps consuming the fetch.
+    this.abortController?.abort();
     this.abortController = new AbortController();
     const requestInit = {
       method: 'POST',


### PR DESCRIPTION
## What
`HTTPSRequestClass` is a per-`baseURL` singleton; `create()` did `this.abortController = new AbortController()` without aborting the previous controller. Consumers sharing the same `baseURL` (`AICreateTable` + `chatContainer` on `/api/v2/ai/chat`) reuse the instance, so a second `create()` orphaned the first stream's controller (`stop()` only touches the latest) and the first stream kept running in the background.

## Location
`src/components/SSERequest/sseHttpsRequest.ts:30-42` (per-baseURL singleton), `:49` (overwrite without abort).

## Fix
`this.abortController?.abort()` before overwriting in `create()`.

## Note
Verification corrected the original claim: `blocks/AI/index` uses `/api/v3/ai/chat/stream` (a different singleton) so it is not affected; the affected pair is `AICreateTable` + `chatContainer`. `onUpdate` is a per-`create()` closure (not last-write-wins).

Fixes #2464

🤖 Generated with [Claude Code](https://claude.com/claude-code)