### PR TITLE
fix(presto): override 4-arg tableDDL to stop UnsupportedOperation

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-presto/src/main/java/ai/chat2db/plugin/presto/PrestoMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-presto/src/main/java/ai/chat2db/plugin/presto/PrestoMetaData.java
@@ -3,8 +3,16 @@ package ai.chat2db.plugin.presto;
 import ai.chat2db.spi.IDbMetaData;
 import ai.chat2db.spi.DefaultMetaService;
 
+import java.sql.Connection;
+
 public class PrestoMetaData extends DefaultMetaService implements IDbMetaData {
-    public String tableDDL(String databaseName, String schemaName,String tableName) {
+    /**
+     * Presto/Trino table DDL retrieval is not supported here. The framework calls
+     * the 4-arg signature; the previous 3-arg method was dead code and the base
+     * 4-arg threw UnsupportedOperationException on the DDL view/export path.
+     */
+    @Override
+    public String tableDDL(Connection connection, String databaseName, String schemaName, String tableName) {
         return "";
     }
 }


### PR DESCRIPTION
## What
`PrestoMetaData` defined a 3-arg `tableDDL(String,String,String)` returning `""`, but `DefaultMetaService` has no such signature — the framework calls the 4-arg `tableDDL(Connection,String,String,String)`, which the base throws `UnsupportedOperationException` for, so the Presto table DDL view/export crashed.

## Location
`chat2db-community-plugins/chat2db-community-presto/.../PrestoMetaData.java:7-9`; base `chat2db-community-spi/.../DefaultMetaService.java:72-73`.

## Fix
Override the 4-arg `tableDDL(Connection, String, String, String)` to return `""` (the 3-arg method's intent). The dead 3-arg method is removed.

Fixes #2477

🤖 Generated with [Claude Code](https://claude.com/claude-code)