### PR TITLE
fix(gbase8s): guard against appending GBASEDBTSERVER twice on reconnect

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-gbase8s/src/main/java/ai/chat2db/plugin/gbase8s/GBase8sDBManager.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-gbase8s/src/main/java/ai/chat2db/plugin/gbase8s/GBase8sDBManager.java
@@ -15,7 +15,7 @@ public class GBase8sDBManager extends GenericDBManager implements IDbManager {
     public Connection getConnection(ConnectInfo connectInfo) {
         String url = connectInfo.getUrl();
         String service = connectInfo.getServiceName();
-        if(StringUtils.isNotBlank(service)){
+        if(StringUtils.isNotBlank(service) && !StringUtils.contains(url, "GBASEDBTSERVER=")){
             url = url + ":" + "GBASEDBTSERVER=" + service;
         }
         connectInfo.setUrl(url);


### PR DESCRIPTION
## What
`getConnection` appended `GBASEDBTSERVER=<service>` without checking whether it was already in the URL; on reconnect (same `ConnectInfo` reused, url already contains the param) it appended again, producing a malformed URL like `...:GBASEDBTSERVER=svc:GBASEDBTSERVER=svc`.

## Location
`chat2db-community-plugins/chat2db-community-gbase8s/.../GBase8sDBManager.java:18`; sibling `InformixDBManager.java:18-19` has the guard.

## Fix
Add `!StringUtils.contains(url, "GBASEDBTSERVER=")` guard, mirroring `InformixDBManager`.

Fixes #2495

🤖 Generated with [Claude Code](https://claude.com/claude-code)