### PR TITLE
fix(jdbc): close asyncDownload Response on failure + log onFailure

### DIFF
--- a/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/JdbcJarUtils.java
+++ b/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/JdbcJarUtils.java
@@ -20,6 +20,9 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class JdbcJarUtils {
 
     private static final OkHttpClient async_client = new OkHttpClient.Builder()
@@ -58,21 +61,26 @@ public class JdbcJarUtils {
         async_client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
+                log.error("asyncDownload failed for: {}", call.request().url(), e);
             }
 
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                if (!response.isSuccessful()) {
-                    throw new IOException("Unexpected code " + response);
-                }
-                try (InputStream is = response.body().byteStream();
-                     FileOutputStream fos = new FileOutputStream(outputPath)) {
-                    byte[] buffer = new byte[2048];
-                    int length;
-                    while ((length = is.read(buffer)) != -1) {
-                        fos.write(buffer, 0, length);
+                // try-with-resources on the response so it is closed on ALL paths
+                // (the !isSuccessful() throw previously leaked the connection).
+                try (response) {
+                    if (!response.isSuccessful()) {
+                        throw new IOException("Unexpected code " + response);
                     }
-                    fos.flush();
+                    try (InputStream is = response.body().byteStream();
+                         FileOutputStream fos = new FileOutputStream(outputPath)) {
+                        byte[] buffer = new byte[2048];
+                        int length;
+                        while ((length = is.read(buffer)) != -1) {
+                            fos.write(buffer, 0, length);
+                        }
+                        fos.flush();
+                    }
                 }
             }
         });


### PR DESCRIPTION
## What
`asyncDownload`'s `onResponse` threw `IOException` on `!isSuccessful()` without closing the `Response`, leaking the OkHttp connection. `onFailure` had an empty body so download failures were silently swallowed — callers thought the jar was downloaded, then class-loading failed.

## Location
`chat2db-community-tools/.../util/JdbcJarUtils.java:60-61` (empty onFailure), `:65-67` (throw without closing). Sync `download` (:81) correctly uses `try (Response response = ...)`.

## Fix
Wrap `onResponse` in `try (response)` (Java 9+ try-with-resources on the parameter) so the response is closed on all paths; log the failure in `onFailure` via `@Slf4j`.

Fixes #2507

🤖 Generated with [Claude Code](https://claude.com/claude-code)