### PR TITLE
fix(settings): synchronize setProperty read-modify-write

### DIFF
--- a/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/SystemSettingsUtil.java
+++ b/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/SystemSettingsUtil.java
@@ -42,7 +42,7 @@ public class SystemSettingsUtil {
         return ConfigUtils.getBasePath() + File.separator + CACHE_PATH;
     }
 
-    public static void setProperty(String key, Object newValue) {
+    public static synchronized void setProperty(String key, Object newValue) {
         if (Objects.isNull(key) || Objects.isNull(newValue)) {
             log.info("key or new value is null");
             return;


### PR DESCRIPTION
## What
`setProperty` did `readSettings`→`put`→`writeSettings` with no synchronization — two concurrent writers could both read the pre-update map and the later `writeSettings` would overwrite the other's key (silent lost update).

## Location
`chat2db-community-tools/.../util/SystemSettingsUtil.java:45-53`.

## Fix
Make `setProperty` `synchronized` so the read-modify-write is atomic on the class lock.

Fixes #2525

🤖 Generated with [Claude Code](https://claude.com/claude-code)