### PR TITLE
fix(dev): keep Community JCEF launcher local and supervised

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -74,7 +74,7 @@
     "start": "APP_VERSION=${npm_config_app_version} UMI_DEV_SERVER_COMPRESS=none umi dev",
     "start:desktop:hot": "cross-env UMI_ENV=desktop cross-env APP_VERSION=${npm_config_app_version} PORT=8888 umi dev",
     "start:desktop:hot:p": "yarn run start:desktop:hot --proxy_target=http://192.168.0.222:11921 --gateway_url=http://192.168.0.222:1921",
-    "start:community:hot": "cross-env UMI_ENV=community cross-env APP_NAME=chat2db-community cross-env DISABLE_MFSU=true cross-env UMI_DEV_SERVER_COMPRESS=none cross-env HOST=127.0.0.1 cross-env PORT=8889 umi dev --public_path=/",
+    "start:community:hot": "cross-env UMI_ENV=community cross-env APP_NAME=chat2db-community cross-env DISABLE_MFSU=true cross-env UMI_DEV_SERVER_COMPRESS=none cross-env HOST=127.0.0.1 cross-env PORT=8889 node --require ./scripts/bind-dev-server-loopback.cjs ./node_modules/umi/bin/umi.js dev --public_path=/",
     "start:offline:hot": "cross-env UMI_ENV=offline cross-env PORT=8888 umi dev",
     "start:proxy:online": "cross-env HMR=none umi dev --webapp=true --public_path=http://localhost:8000/",
     "ui": "yarn add @chat2db/ui",

--- a/chat2db-community-client/scripts/bind-dev-server-loopback.cjs
+++ b/chat2db-community-client/scripts/bind-dev-server-loopback.cjs
@@ -1,0 +1,20 @@
+const http = require('node:http');
+
+const host = process.env.HOST;
+const port = Number(process.env.PORT);
+const originalListen = http.Server.prototype.listen;
+
+// Umi 4.4.5 passes HOST through its config but calls listen(port) without it.
+http.Server.prototype.listen = function listen(...args) {
+  const isUmiListenCall = typeof args[0] === 'number' && (args.length === 1 || typeof args[1] === 'function');
+
+  if (host && Number.isInteger(port) && isUmiListenCall) {
+    // Do not let Umi's portfinder silently move this fixed development endpoint.
+    if (args[0] !== port) {
+      throw new Error(`Umi selected fallback port ${args[0]}; configured port ${port} is unavailable`);
+    }
+    args.splice(1, 0, host);
+  }
+
+  return originalListen.apply(this, args);
+};

--- a/docs/guides/community-jcef-development.md
+++ b/docs/guides/community-jcef-development.md
@@ -5,7 +5,8 @@ frontend and backend, and need to test the same checkout in the JCEF Desktop
 shell.
 
 The launcher does not prepare the development environment. It does not install
-dependencies, build the backend, discover Java runtimes, or check ports.
+dependencies, build the backend, or discover Java runtimes. It only refuses to
+start when either required port is already occupied.
 
 ## Prerequisites
 
@@ -14,7 +15,8 @@ Before starting JCEF Desktop:
 1. Install the project dependencies and build the Community backend by following
    the main README.
 2. Download the JBR with JCEF described below and set `JBR_HOME` to it.
-3. Ensure `127.0.0.1:8889` and `127.0.0.1:10825` are free.
+3. Ensure ports `8889` and `10825` are free on all local interfaces. Umi checks
+   every local interface before selecting its development port.
 4. Stop the Web backend, because JCEF Desktop starts its embedded backend on
    `127.0.0.1:10825`.
 
@@ -59,14 +61,17 @@ JBR_HOME=/path/to/jbr ./script/dev-community-jcef.sh
 ```
 
 The script starts the Community Web frontend with
-`yarn run start:community:hot`, waits until `http://127.0.0.1:8889/` responds,
-and then starts the JCEF backend with `-Dchat2db.jcef.web-frontend=true`.
-That parameter tells JCEF to load the Web frontend instead of packaged frontend
-files. The script does not start a separate Web backend.
+`yarn run start:community:hot`, binds it to `127.0.0.1:8889`, waits up to 180
+seconds for Umi to compile and serve `umi.js`, and then starts the JCEF backend
+with `-Dchat2db.jcef.web-frontend=true`. That parameter tells JCEF to load the
+Web frontend instead of packaged frontend files. The script does not start a
+separate Web backend. It waits up to another 120 seconds for the embedded
+backend's `/api/system` health check to succeed on `127.0.0.1:10825`.
 
-Press `Ctrl+C` to stop both processes. Missing dependencies, build artifacts,
-and runtime files are reported by Yarn, curl, or Java. Port availability remains
-a prerequisite and is not diagnosed by the launcher.
+Press `Ctrl+C` to stop both processes. If either child exits, the launcher stops
+the other one. It prints the checkout, JBR, backend jar, child PIDs, listener
+URLs, readiness result, and attached-log location. Missing dependencies, build
+artifacts, and runtime files are still reported directly by Yarn, curl, or Java.
 
 Without `-Dchat2db.jcef.web-frontend=true`, JCEF continues to load the bundled
 `dist/index.html`. Packaged releases do not pass this parameter and are

--- a/script/dev-community-jcef.sh
+++ b/script/dev-community-jcef.sh
@@ -11,7 +11,13 @@ BACKEND_LIB_DIR="${BACKEND_TARGET_DIR}/lib"
 JAVA_BIN="${JBR_HOME:?JBR_HOME must point to a JBR 17 runtime with JCEF}/bin/java"
 JAVA_OPTIONS=()
 FRONTEND_URL="http://127.0.0.1:8889/"
+FRONTEND_HEALTH_URL="${FRONTEND_URL}umi.js"
+FRONTEND_TIMEOUT_SECONDS=180
+BACKEND_URL="http://127.0.0.1:10825/"
+BACKEND_HEALTH_URL="${BACKEND_URL}api/system"
+BACKEND_TIMEOUT_SECONDS=120
 FRONTEND_PID=""
+BACKEND_PID=""
 
 case "$(uname -s)" in
     Darwin)
@@ -35,16 +41,43 @@ case "$(uname -s)" in
         ;;
 esac
 
+assert_port_available() {
+    local host=$1
+    local port=$2
+    local name=$3
+
+    if ! node -e '
+        const portfinder = require(process.argv[1]);
+        const port = Number(process.argv[2]);
+        portfinder.getPortPromise({ port }).then(
+            (availablePort) => process.exit(availablePort === port ? 0 : 1),
+            () => process.exit(1),
+        );
+    ' "${CLIENT_DIR}/node_modules/@umijs/utils/compiled/portfinder" "${port}"; then
+        echo "[error] ${name} port ${host}:${port} is unavailable; free this port on all local interfaces" >&2
+        exit 1
+    fi
+}
+
+terminate_process() {
+    local pid=$1
+
+    if [ -z "${pid}" ]; then
+        return
+    fi
+    kill -TERM -- "-${pid}" 2>/dev/null \
+        || kill -TERM "${pid}" 2>/dev/null \
+        || true
+}
+
 cleanup() {
     local status=$?
 
     trap - EXIT INT TERM
-    if [ -n "${FRONTEND_PID}" ]; then
-        kill -TERM -- "-${FRONTEND_PID}" 2>/dev/null \
-            || kill -TERM "${FRONTEND_PID}" 2>/dev/null \
-            || true
-        wait "${FRONTEND_PID}" 2>/dev/null || true
-    fi
+    terminate_process "${BACKEND_PID}"
+    terminate_process "${FRONTEND_PID}"
+    [ -z "${BACKEND_PID}" ] || wait "${BACKEND_PID}" 2>/dev/null || true
+    [ -z "${FRONTEND_PID}" ] || wait "${FRONTEND_PID}" 2>/dev/null || true
     exit "${status}"
 }
 
@@ -53,20 +86,37 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 set -m
 
+echo "[dev] checkout: ${ROOT_DIR}"
+echo "[dev] JBR_HOME: ${JBR_HOME}"
+echo "[dev] backend jar: ${BACKEND_JAR}"
+
+assert_port_available 127.0.0.1 8889 frontend
+assert_port_available 127.0.0.1 10825 backend
+
 (
     cd "${CLIENT_DIR}"
     exec yarn run start:community:hot
 ) &
 FRONTEND_PID=$!
 
-echo "[dev] waiting for ${FRONTEND_URL}"
-until curl --fail --silent --output /dev/null "${FRONTEND_URL}"; do
+echo "[dev] frontend pid ${FRONTEND_PID}; waiting up to ${FRONTEND_TIMEOUT_SECONDS}s for ${FRONTEND_HEALTH_URL}"
+FRONTEND_DEADLINE=$((SECONDS + FRONTEND_TIMEOUT_SECONDS))
+while true; do
     if ! kill -0 "${FRONTEND_PID}" 2>/dev/null; then
         echo "[error] frontend exited before it became ready" >&2
         exit 1
     fi
+    FRONTEND_CONTENT_TYPE=$(curl --noproxy '*' --fail --silent --max-time 2 --output /dev/null --write-out '%{content_type}' "${FRONTEND_HEALTH_URL}" 2>/dev/null || true)
+    if [[ "${FRONTEND_CONTENT_TYPE}" == *javascript* ]]; then
+        break
+    fi
+    if [ "${SECONDS}" -ge "${FRONTEND_DEADLINE}" ]; then
+        echo "[error] frontend did not become ready within ${FRONTEND_TIMEOUT_SECONDS}s" >&2
+        exit 1
+    fi
     sleep 1
 done
+echo "[dev] frontend ready: ${FRONTEND_URL} (pid ${FRONTEND_PID})"
 
 "${JAVA_BIN}" \
     "${JAVA_OPTIONS[@]}" \
@@ -81,4 +131,53 @@ done
     -Dserver.address=127.0.0.1 \
     -Dserver.port=10825 \
     -Dspring.profiles.active=dev \
-    -jar "${BACKEND_JAR}"
+    -jar "${BACKEND_JAR}" &
+BACKEND_PID=$!
+
+echo "[dev] JCEF backend pid ${BACKEND_PID}; waiting up to ${BACKEND_TIMEOUT_SECONDS}s for ${BACKEND_HEALTH_URL}"
+BACKEND_DEADLINE=$((SECONDS + BACKEND_TIMEOUT_SECONDS))
+while true; do
+    if ! kill -0 "${FRONTEND_PID}" 2>/dev/null; then
+        echo "[error] frontend exited while the JCEF backend was starting" >&2
+        exit 1
+    fi
+    if ! kill -0 "${BACKEND_PID}" 2>/dev/null; then
+        BACKEND_STATUS=0
+        wait "${BACKEND_PID}" || BACKEND_STATUS=$?
+        if [ "${BACKEND_STATUS}" -eq 0 ]; then
+            BACKEND_STATUS=1
+        fi
+        echo "[error] JCEF backend exited before it became ready" >&2
+        exit "${BACKEND_STATUS}"
+    fi
+    BACKEND_HEALTH_RESPONSE=$(curl --noproxy '*' --fail --silent --max-time 2 "${BACKEND_HEALTH_URL}" 2>/dev/null || true)
+    if [[ "${BACKEND_HEALTH_RESPONSE}" == *'"success":true'* ]]; then
+        break
+    fi
+    if [ "${SECONDS}" -ge "${BACKEND_DEADLINE}" ]; then
+        echo "[error] JCEF backend did not become ready within ${BACKEND_TIMEOUT_SECONDS}s" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "[dev] JCEF backend ready: ${BACKEND_URL} (pid ${BACKEND_PID})"
+echo "[dev] logs are attached to this terminal"
+
+while kill -0 "${FRONTEND_PID}" 2>/dev/null && kill -0 "${BACKEND_PID}" 2>/dev/null; do
+    sleep 1
+done
+
+if ! kill -0 "${BACKEND_PID}" 2>/dev/null; then
+    BACKEND_STATUS=0
+    wait "${BACKEND_PID}" || BACKEND_STATUS=$?
+    exit "${BACKEND_STATUS}"
+fi
+
+FRONTEND_STATUS=0
+wait "${FRONTEND_PID}" || FRONTEND_STATUS=$?
+if [ "${FRONTEND_STATUS}" -eq 0 ]; then
+    FRONTEND_STATUS=1
+fi
+echo "[error] frontend exited while the JCEF backend was running" >&2
+exit "${FRONTEND_STATUS}"


### PR DESCRIPTION
## Related issue

Follow-up to #2358. No approved Issue was provided.

## Summary

PR #2358 configured `HOST=127.0.0.1`, but Umi 4.4.5 passes that value to configuration and banner output while its webpack server still calls `server.listen(port)`. The Community development frontend therefore listened on every interface.

- Adds a small Node preload for `start:community:hot` that injects the configured host into the Umi HTTP listener and refuses silent port fallback.
- Checks fixed-port availability before starting either child.
- Waits for compiled `/umi.js` and backend `/api/system` with finite timeouts.
- Supervises both frontend and JCEF backend process groups and stops the peer when either exits.
- Prints the checkout, JBR, jar, PIDs, URLs, readiness results, and attached log location.
- Keeps the existing development contract: contributors prepare dependencies, JBR with JCEF, backend jar, external `lib/`, encryption key, and free ports. The launcher does not install, discover, download, or build them.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `bash -n script/dev-community-jcef.sh` passed.
  - `shellcheck -S warning script/dev-community-jcef.sh` passed.
  - `node --check scripts/bind-dev-server-loopback.cjs` passed.
  - `prettier --check scripts/bind-dev-server-loopback.cjs` passed.
  - `package.json` JSON parsing and `git diff --check` passed.
  - Occupied-port smoke refused startup before spawning either child.
- Manual verification:
  - Started the real Umi 4.4.5 Community frontend with the preload on isolated port `38889`.
  - `lsof` reported `127.0.0.1:38889`.
  - `http://127.0.0.1:38889/umi.js` returned HTTP 200 with `application/javascript` after compilation.
  - `http://192.168.31.16:38889/` was unreachable.
  - The combined JCEF launcher was not started because the existing `8889` and `10825` development processes were intentionally left untouched.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No change.
- Database or driver compatibility: No change.
- Network, privacy, or security: The Community development frontend changes from wildcard exposure to loopback-only listening.
- Community / Local / Pro boundary: Only the Community `start:community:hot` and opt-in JCEF development launcher change. Packaged Community releases and Local/Pro startup paths are unchanged.
- Backward compatibility: Occupied fixed ports now fail immediately instead of allowing Umi to select another port or waiting indefinitely.

## Reviewer map

- Start here: `chat2db-community-client/scripts/bind-dev-server-loopback.cjs`, then `script/dev-community-jcef.sh`.
- Failure condition: frontend compilation exceeds 180 seconds, backend health exceeds 120 seconds, a fixed port is unavailable, or either child exits.
- Rollback or disable path: revert this commit to restore the #2358 launcher behavior.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for Umi source tracing, launcher implementation, runtime verification, documentation, and independent review.