### PR TITLE
fix(sse): scope cancellation to each request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Run SQL execution stream contract
         run: yarn run test:sql-execution-stream
 
+      - name: Run SSE request ownership contract
+        run: yarn run test:sse-request
+
       - name: Run verification-code countdown lifecycle contract
         run: yarn run test:verification-code-countdown
 

--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -51,6 +51,7 @@
     "test:search-result-tab-selection": "tsx src/blocks/SearchResult/tabSelection.test.ts",
     "test:saved-console-tree-refresh": "tsx src/store/tree/savedConsoleTreeRefresh.test.ts",
     "test:saved-console-lifecycle": "tsx src/store/workspace/utils/savedConsoleLifecycle.test.ts && tsx src/store/workspace/utils/workspaceTabPersistence.test.ts",
+    "test:sse-request": "tsx src/components/SSERequest/requestOwnership.test.ts && tsx src/components/SSERequest/requestTransport.test.ts",
     "test:settings-layout": "tsx src/blocks/Setting/navigation.test.ts && tsx src/blocks/Setting/search.test.ts && tsx src/blocks/Setting/BaseSetting/model.test.ts && tsx src/blocks/Setting/settingsLayout.test.ts",
     "test:shortcut": "tsx src/constants/shortcut.test.ts && tsx src/utils/jcefZoom.test.ts",
     "test:sql-execution-log": "tsx src/service/sqlExecutionLog.test.ts",

--- a/chat2db-community-client/src/components/SSERequest/clientRequestHandle.ts
+++ b/chat2db-community-client/src/components/SSERequest/clientRequestHandle.ts
@@ -1,0 +1,135 @@
+import type { AnyObject, SSERequestCallbacks, SSERequestHandle } from './index';
+import { createRequestHandle, createSSEStreamError } from './requestHandle';
+
+interface ClientRequestEventBus {
+  on: (eventName: string, listener: (output: any) => void) => void;
+  off: (eventName: string, listener: (output: any) => void) => void;
+}
+
+interface ClientRequestHandleOptions<Output> {
+  callbacks: SSERequestCallbacks<Output>;
+  eventBus: ClientRequestEventBus;
+  eventName: string;
+  handleErrorPayload: (value: unknown, requestParams?: AnyObject) => boolean;
+  requestParams?: AnyObject;
+}
+
+const normalizeError = (error: unknown) => (error instanceof Error ? error : new Error('Unknown error!'));
+
+const parseJsonObject = (value: unknown): Record<string, unknown> | undefined => {
+  if (typeof value !== 'string') {
+    return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === 'object' && parsed !== null ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const parseDonePayload = (data: unknown) => {
+  const parsed = parseJsonObject(data);
+  return parsed?.type === 'done' ? parsed : undefined;
+};
+
+export const createClientRequestHandle = <Output = unknown>({
+  callbacks,
+  eventBus,
+  eventName,
+  handleErrorPayload,
+  requestParams,
+}: ClientRequestHandleOptions<Output>): SSERequestHandle => {
+  let settled = false;
+  let resolveDone!: () => void;
+  let rejectDone!: (error: Error) => void;
+  const done = new Promise<void>((resolve, reject) => {
+    resolveDone = resolve;
+    rejectDone = reject;
+  });
+
+  const cleanup = () => {
+    eventBus.off(eventName, listener);
+  };
+
+  const notifyError = (error: Error) => {
+    let rejection = error;
+    try {
+      callbacks.onError(error);
+    } catch (callbackError) {
+      rejection = normalizeError(callbackError);
+    }
+    rejectDone(rejection);
+  };
+
+  const finish = (onFinish: () => void) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    try {
+      onFinish();
+      resolveDone();
+    } catch (error) {
+      notifyError(normalizeError(error));
+    }
+  };
+
+  const fail = (error: unknown) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    notifyError(normalizeError(error));
+  };
+
+  const listener = (sseOutput: any) => {
+    try {
+      if (!sseOutput) {
+        finish(() => callbacks.onSuccess([]));
+        return;
+      }
+
+      const streamError = createSSEStreamError(sseOutput);
+      if (streamError) {
+        callbacks.onUpdate(sseOutput as Output);
+        fail(streamError);
+        return;
+      }
+
+      const parsedDonePayload = parseDonePayload(sseOutput.data);
+      if (sseOutput.data === '[DONE]') {
+        finish(() => callbacks.onSuccess([sseOutput] as Output[]));
+      } else if (parsedDonePayload) {
+        const doneChunk = {
+          ...sseOutput,
+          data: parsedDonePayload,
+        };
+        callbacks.onUpdate(doneChunk as Output);
+        finish(() => callbacks.onSuccess([doneChunk] as Output[]));
+      } else if (handleErrorPayload(sseOutput, requestParams)) {
+        finish(() => callbacks.onSuccess([sseOutput] as Output[]));
+      } else {
+        callbacks.onUpdate(sseOutput);
+      }
+    } catch (error) {
+      fail(error);
+    }
+  };
+
+  const handle = createRequestHandle(done, () => {
+    // JCEF has no request-level cancel command, so stop owns listener cleanup only.
+    finish(() => callbacks.onStop?.());
+  });
+
+  try {
+    eventBus.on(eventName, listener);
+  } catch (error) {
+    fail(error);
+  }
+
+  return handle;
+};

--- a/chat2db-community-client/src/components/SSERequest/index.tsx
+++ b/chat2db-community-client/src/components/SSERequest/index.tsx
@@ -79,11 +79,19 @@ export interface SSERequestCallbacks<Output> {
   onStop?: () => void;
 }
 
+export interface SSERequestHandle extends Promise<void> {
+  /** Resolves when this request succeeds or is stopped, and rejects on request failure. */
+  done: Promise<void>;
+
+  /** Stops only the request represented by this handle. */
+  stop: () => void;
+}
+
 export type SSERequestFunction<Input = AnyObject, Output = SSEOutput> = (
   params: SSERequestParams & Input,
   callbacks: SSERequestCallbacks<Output>,
   transformStream?: SSEStreamProps<Output>['transformStream'],
-) => Promise<void>;
+) => SSERequestHandle;
 
 const SSERequest = (options: SSERequestOptions) => {
   if (isDesktop) {

--- a/chat2db-community-client/src/components/SSERequest/requestHandle.ts
+++ b/chat2db-community-client/src/components/SSERequest/requestHandle.ts
@@ -1,0 +1,63 @@
+import type { SSERequestHandle } from './index';
+
+interface AbortableRequestCallbacks {
+  onError?: (error: Error) => void;
+  onStop?: () => void;
+}
+
+const normalizeError = (error: unknown) => (error instanceof Error ? error : new Error('Unknown error!'));
+
+const parseJsonObject = (value: unknown): Record<string, unknown> | undefined => {
+  if (typeof value !== 'string') {
+    return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === 'object' && parsed !== null ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const createSSEStreamError = (output: any) => {
+  if (typeof output?.event !== 'string' || output.event.trim() !== 'error') {
+    return undefined;
+  }
+
+  const payload = parseJsonObject(output.data);
+  const content = payload?.content;
+  return new Error(typeof content === 'string' && content.trim() ? content : 'AI stream failed');
+};
+
+export const createRequestHandle = (done: Promise<void>, stop: () => void): SSERequestHandle =>
+  Object.assign(done, { done, stop });
+
+export const createAbortableRequestHandle = (
+  execute: (signal: AbortSignal) => Promise<void>,
+  callbacks: AbortableRequestCallbacks = {},
+): SSERequestHandle => {
+  const abortController = new AbortController();
+  let settled = false;
+  const done = Promise.resolve()
+    .then(() => execute(abortController.signal))
+    .catch((error: unknown) => {
+      if (error instanceof Error && error.name === 'AbortError') {
+        callbacks.onStop?.();
+        return;
+      }
+
+      const normalizedError = normalizeError(error);
+      callbacks.onError?.(normalizedError);
+      throw normalizedError;
+    })
+    .finally(() => {
+      settled = true;
+    });
+
+  return createRequestHandle(done, () => {
+    if (!settled) {
+      abortController.abort();
+    }
+  });
+};

--- a/chat2db-community-client/src/components/SSERequest/requestOwner.ts
+++ b/chat2db-community-client/src/components/SSERequest/requestOwner.ts
@@ -1,0 +1,87 @@
+import type { SSERequestCallbacks, SSERequestHandle } from './index';
+
+interface ActiveRequest {
+  generation: number;
+  handle: SSERequestHandle;
+}
+
+/** Owns one active request for a single useSSERequest hook instance. */
+export class SSERequestOwner {
+  private generation = 0;
+  private activeRequest?: ActiveRequest;
+
+  begin() {
+    this.generation += 1;
+    const generation = this.generation;
+    const previousRequest = this.activeRequest;
+    this.activeRequest = undefined;
+    previousRequest?.handle.stop();
+    return generation;
+  }
+
+  attach(generation: number, handle: SSERequestHandle) {
+    if (!this.isCurrentGeneration(generation)) {
+      handle.stop();
+      return false;
+    }
+
+    this.activeRequest = { generation, handle };
+    return true;
+  }
+
+  isCurrentGeneration(generation: number) {
+    return this.generation === generation;
+  }
+
+  owns(generation: number, handle?: SSERequestHandle) {
+    return handle ? this.isActive(generation, handle) : this.isCurrentGeneration(generation);
+  }
+
+  isActive(generation: number, handle: SSERequestHandle) {
+    return (
+      this.isCurrentGeneration(generation) &&
+      this.activeRequest?.generation === generation &&
+      this.activeRequest.handle === handle
+    );
+  }
+
+  release(generation: number, handle: SSERequestHandle) {
+    if (this.isActive(generation, handle)) {
+      this.activeRequest = undefined;
+    }
+  }
+
+  stop() {
+    this.generation += 1;
+    const activeRequest = this.activeRequest;
+    this.activeRequest = undefined;
+    activeRequest?.handle.stop();
+    return Boolean(activeRequest);
+  }
+}
+
+export const guardSSERequestCallbacks = <Output>(
+  callbacks: SSERequestCallbacks<Output>,
+  isActive: () => boolean,
+): SSERequestCallbacks<Output> => ({
+  onSuccess: (chunks) => {
+    if (isActive()) {
+      callbacks.onSuccess(chunks);
+    }
+  },
+  onError: (error) => {
+    if (isActive()) {
+      callbacks.onError(error);
+    }
+  },
+  onUpdate: (chunk) => {
+    if (isActive()) {
+      callbacks.onUpdate(chunk);
+    }
+  },
+  onStop: () => {
+    if (isActive()) {
+      callbacks.onStop?.();
+    }
+  },
+});

--- a/chat2db-community-client/src/components/SSERequest/requestOwnership.test.ts
+++ b/chat2db-community-client/src/components/SSERequest/requestOwnership.test.ts
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import type { SSERequestCallbacks, SSERequestHandle } from './index';
+import { createAbortableRequestHandle, createRequestHandle, createSSEStreamError } from './requestHandle';
+import { guardSSERequestCallbacks, SSERequestOwner } from './requestOwner';
+
+interface PendingRequest {
+  handle: SSERequestHandle;
+  signal: () => AbortSignal;
+  resolve: () => void;
+}
+
+const createPendingRequest = (): PendingRequest => {
+  let requestSignal: AbortSignal | undefined;
+  let resolveRequest!: () => void;
+  const handle = createAbortableRequestHandle(async (signal) => {
+    requestSignal = signal;
+    await new Promise<void>((resolve, reject) => {
+      resolveRequest = resolve;
+      signal.addEventListener(
+        'abort',
+        () => {
+          const error = new Error('The request was stopped');
+          error.name = 'AbortError';
+          reject(error);
+        },
+        { once: true },
+      );
+    });
+  });
+
+  return {
+    handle,
+    signal: () => {
+      assert.ok(requestSignal);
+      return requestSignal;
+    },
+    resolve: () => resolveRequest(),
+  };
+};
+
+const createTrackedHandle = (onStop?: () => void) => {
+  let stopCount = 0;
+  const done = Promise.resolve();
+  const handle: SSERequestHandle = createRequestHandle(done, () => {
+    stopCount += 1;
+    onStop?.();
+  });
+  return { handle, stopCount: () => stopCount };
+};
+
+const testIndependentRequestHandles = async () => {
+  const first = createPendingRequest();
+  const second = createPendingRequest();
+  await Promise.resolve();
+
+  assert.notEqual(first.signal(), second.signal());
+  first.handle.stop();
+  first.handle.stop();
+
+  assert.equal(first.signal().aborted, true);
+  assert.equal(second.signal().aborted, false);
+  await first.handle.done;
+
+  second.resolve();
+  await second.handle.done;
+  assert.equal(second.signal().aborted, false);
+  second.handle.stop();
+  assert.equal(second.signal().aborted, false);
+};
+
+const testStoppedHandleResolvesAndRemainsAwaitable = async () => {
+  let stopCount = 0;
+  let releaseRequest!: () => void;
+  const handle = createAbortableRequestHandle(
+    async (signal) => {
+      await new Promise<void>((resolve, reject) => {
+        releaseRequest = resolve;
+        signal.addEventListener('abort', () => {
+          const error = new Error('The request was stopped');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      });
+    },
+    {
+      onStop: () => {
+        stopCount += 1;
+      },
+    },
+  );
+  await Promise.resolve();
+
+  let awaitFinished = false;
+  const waiting = (async () => {
+    await handle;
+    awaitFinished = true;
+  })();
+
+  assert.equal(awaitFinished, false);
+  handle.stop();
+  await waiting;
+  assert.equal(awaitFinished, true);
+  assert.equal(stopCount, 1);
+  assert.equal(handle.done, handle);
+  await handle.finally(() => undefined);
+
+  releaseRequest();
+};
+
+const testOwnerInvalidatesBeforeStopping = () => {
+  const owner = new SSERequestOwner();
+  let firstGeneration = 0;
+  const first = createTrackedHandle(() => {
+    assert.equal(owner.isActive(firstGeneration, first.handle), false);
+  });
+  firstGeneration = owner.begin();
+  assert.equal(owner.attach(firstGeneration, first.handle), true);
+  assert.equal(owner.isActive(firstGeneration, first.handle), true);
+
+  const secondGeneration = owner.begin();
+  assert.equal(first.stopCount(), 1);
+  assert.equal(owner.isActive(firstGeneration, first.handle), false);
+
+  const second = createTrackedHandle();
+  assert.equal(owner.attach(secondGeneration, second.handle), true);
+  first.handle.stop();
+  assert.equal(owner.isActive(secondGeneration, second.handle), true);
+  assert.equal(second.stopCount(), 0);
+
+  assert.equal(owner.stop(), true);
+  assert.equal(second.stopCount(), 1);
+  assert.equal(owner.stop(), false);
+  assert.equal(second.stopCount(), 1);
+};
+
+const testStaleHandleCannotAttach = () => {
+  const owner = new SSERequestOwner();
+  const generation = owner.begin();
+  owner.stop();
+  const stale = createTrackedHandle();
+
+  assert.equal(owner.attach(generation, stale.handle), false);
+  assert.equal(stale.stopCount(), 1);
+};
+
+const testSSEErrorEventAllowsSpecWhitespace = () => {
+  const error = createSSEStreamError({
+    event: ' error',
+    data: ' {"type":"error","content":"stream failed"}',
+  });
+
+  assert.equal(error?.message, 'stream failed');
+  assert.equal(createSSEStreamError({ event: 'done', data: '{}' }), undefined);
+};
+
+const testGuardedCallbacksIgnoreStaleAndUnmountedRequests = () => {
+  const owner = new SSERequestOwner();
+  let mounted = true;
+  const handleRef: { current?: SSERequestHandle } = {};
+  const generation = owner.begin();
+  const calls: string[] = [];
+  const callbacks: SSERequestCallbacks<string> = {
+    onSuccess: () => calls.push('success'),
+    onError: () => calls.push('error'),
+    onUpdate: () => calls.push('update'),
+    onStop: () => calls.push('stop'),
+  };
+  const guarded = guardSSERequestCallbacks(callbacks, () => mounted && owner.owns(generation, handleRef.current));
+
+  guarded.onUpdate('before-attach');
+  assert.deepEqual(calls, ['update']);
+
+  const tracked = createTrackedHandle();
+  handleRef.current = tracked.handle;
+  assert.equal(owner.attach(generation, tracked.handle), true);
+  guarded.onSuccess([]);
+  assert.deepEqual(calls, ['update', 'success']);
+
+  owner.begin();
+  guarded.onUpdate('stale');
+  guarded.onError(new Error('stale'));
+  guarded.onStop?.();
+  assert.deepEqual(calls, ['update', 'success']);
+
+  const mountedGeneration = owner.begin();
+  const mountedHandle = createTrackedHandle().handle;
+  assert.equal(owner.attach(mountedGeneration, mountedHandle), true);
+  const mountedGuard = guardSSERequestCallbacks(
+    callbacks,
+    () => mounted && owner.owns(mountedGeneration, mountedHandle),
+  );
+  mounted = false;
+  mountedGuard.onUpdate('unmounted');
+  assert.deepEqual(calls, ['update', 'success']);
+};
+
+const main = async () => {
+  await testIndependentRequestHandles();
+  await testStoppedHandleResolvesAndRemainsAwaitable();
+  testOwnerInvalidatesBeforeStopping();
+  testStaleHandleCannotAttach();
+  testSSEErrorEventAllowsSpecWhitespace();
+  testGuardedCallbacksIgnoreStaleAndUnmountedRequests();
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/chat2db-community-client/src/components/SSERequest/requestTransport.test.ts
+++ b/chat2db-community-client/src/components/SSERequest/requestTransport.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import type { SSERequestCallbacks } from './index';
+import { createClientRequestHandle } from './clientRequestHandle';
+import { JcefEventBus } from '@/jcef/eventBus';
+
+interface CallbackState {
+  errors: Error[];
+  stops: number;
+  successes: unknown[][];
+  updates: unknown[];
+}
+
+const createCallbacks = () => {
+  const state: CallbackState = {
+    errors: [],
+    stops: 0,
+    successes: [],
+    updates: [],
+  };
+  const callbacks: SSERequestCallbacks<any> = {
+    onSuccess: (chunks) => state.successes.push(chunks),
+    onError: (error) => state.errors.push(error),
+    onUpdate: (chunk) => state.updates.push(chunk),
+    onStop: () => {
+      state.stops += 1;
+    },
+  };
+  return { callbacks, state };
+};
+
+const createHandle = (eventName: string, callbacks: SSERequestCallbacks<any>) =>
+  createClientRequestHandle({
+    callbacks,
+    eventBus: JcefEventBus,
+    eventName,
+    handleErrorPayload: () => false,
+  });
+
+const testRequestListenersAreIndependent = async () => {
+  const first = createCallbacks();
+  const second = createCallbacks();
+  const firstEvent = 'ai_sse_message_first-request';
+  const secondEvent = 'ai_sse_message_second-request';
+  const firstHandle = createHandle(firstEvent, first.callbacks);
+  const secondHandle = createHandle(secondEvent, second.callbacks);
+
+  JcefEventBus.publish(firstEvent, { data: 'first' });
+  JcefEventBus.publish(secondEvent, { data: 'second' });
+  assert.deepEqual(first.state.updates, [{ data: 'first' }]);
+  assert.deepEqual(second.state.updates, [{ data: 'second' }]);
+
+  firstHandle.stop();
+  await firstHandle.done;
+  assert.equal(first.state.stops, 1);
+
+  JcefEventBus.publish(firstEvent, { data: 'late-first' });
+  JcefEventBus.publish(secondEvent, { data: 'still-second' });
+  assert.deepEqual(first.state.updates, [{ data: 'first' }]);
+  assert.deepEqual(second.state.updates, [{ data: 'second' }, { data: 'still-second' }]);
+
+  JcefEventBus.publish(secondEvent, null);
+  await secondHandle;
+  assert.equal(second.state.successes.length, 1);
+  assert.equal(second.state.errors.length, 0);
+};
+
+const testErrorTerminalRejectsAndCleansUp = async () => {
+  const request = createCallbacks();
+  const eventName = 'ai_sse_message_failed-request';
+  const handle = createHandle(eventName, request.callbacks);
+  const errorTerminal = {
+    event: 'error',
+    data: JSON.stringify({
+      type: 'error',
+      messageType: 'error',
+      content: 'AI stream failed',
+    }),
+  };
+
+  JcefEventBus.publish(eventName, errorTerminal);
+
+  await assert.rejects(handle.done, /AI stream failed/);
+  assert.deepEqual(request.state.updates, [errorTerminal]);
+  assert.equal(request.state.errors.length, 1);
+  assert.equal(request.state.successes.length, 0);
+
+  JcefEventBus.publish(eventName, null);
+  assert.equal(request.state.successes.length, 0);
+};
+
+const testDonePayloadUpdatesBeforeSuccess = async () => {
+  const request = createCallbacks();
+  const eventName = 'ai_sse_message_done-request';
+  const handle = createHandle(eventName, request.callbacks);
+
+  JcefEventBus.publish(eventName, {
+    event: 'done',
+    data: JSON.stringify({ type: 'done', content: '[DONE]' }),
+  });
+
+  await handle.done;
+  assert.deepEqual(request.state.updates, [
+    {
+      event: 'done',
+      data: { type: 'done', content: '[DONE]' },
+    },
+  ]);
+  assert.equal(request.state.successes.length, 1);
+};
+
+const main = async () => {
+  await testRequestListenersAreIndependent();
+  await testErrorTerminalRejectsAndCleansUp();
+  await testDonePayloadUpdatesBeforeSuccess();
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/chat2db-community-client/src/components/SSERequest/sseClientRequest.ts
+++ b/chat2db-community-client/src/components/SSERequest/sseClientRequest.ts
@@ -1,7 +1,9 @@
 import sendClientSSERequest, { IJcefSseRequest } from '@/service/sse';
-import { SSERequestOptions, SSERequestParams, SSERequestCallbacks, AnyObject } from './index';
+import type { SSERequestOptions, SSERequestParams, SSERequestCallbacks, SSERequestHandle, AnyObject } from './index';
+import type { SSEStreamProps } from './sseStream';
 import { JcefEventBus, JavaPushActionType } from '@/jcef/eventBus';
 import { handleSSEErrorPayload } from './errorPayload';
+import { createClientRequestHandle } from './clientRequestHandle';
 
 export type SSEFields = 'data' | 'event' | 'id' | 'retry';
 export type SSEOutput = Partial<Record<SSEFields, any>>;
@@ -9,8 +11,6 @@ export type SSEOutput = Partial<Record<SSEFields, any>>;
 class ClientRequestClass {
   readonly baseURL;
   readonly model;
-  private currentRequest?: IJcefSseRequest;
-  private onStop?: () => void;
 
   private constructor(options: SSERequestOptions) {
     const { baseURL, model } = options;
@@ -35,77 +35,29 @@ class ClientRequestClass {
     return ClientRequestClass.instanceBuffer.get(id)!;
   }
 
-  public async create<Input = AnyObject, Output = SSEOutput>(
+  public create<Input = AnyObject, Output = SSEOutput>(
     params: SSERequestParams & Input,
     callbacks: SSERequestCallbacks<Output>,
-  ) {
-    try {
-    // Remove stale listeners.
-      if (this.currentRequest) {
-        JcefEventBus.off(`${JavaPushActionType.AI_SSE_MESSAGE}_${this.currentRequest.requestId}`);
-      }
-
-      this.onStop = callbacks.onStop;
-      this.currentRequest = sendClientSSERequest(this.baseURL, params);
-
-      const listener = (sseOutput: any) => {
-        if (__PRINT_LOGS__ || window._PRINT_LOGS) {
-          console.log('sse-content', sseOutput);
-        }
-        if (!sseOutput) {
-          return;
-        }
-        try {
-          const parsedDonePayload =
-            typeof sseOutput?.data === 'string' ? safeParseDonePayload(sseOutput.data) : undefined;
-
-          if (sseOutput?.data === '[DONE]') {
-            callbacks.onSuccess([sseOutput] as Output[]);
-            this.stop();
-          } else if (parsedDonePayload) {
-            const doneChunk = {
-              ...sseOutput,
-              data: parsedDonePayload,
-            };
-            callbacks.onUpdate(doneChunk as Output);
-            callbacks.onSuccess([doneChunk] as Output[]);
-            this.stop();
-          } else if (handleSSEErrorPayload(sseOutput, params)) {
-            callbacks.onSuccess([sseOutput] as Output[]);
-            this.stop();
-          } else {
-            callbacks.onUpdate(sseOutput);
+    _transformStream?: SSEStreamProps<Output>['transformStream'],
+  ): SSERequestHandle {
+    const currentRequest: IJcefSseRequest = sendClientSSERequest(this.baseURL, params);
+    const eventName = `${JavaPushActionType.AI_SSE_MESSAGE}_${currentRequest.requestId}`;
+    return createClientRequestHandle({
+      callbacks: {
+        ...callbacks,
+        onUpdate: (output) => {
+          if (__PRINT_LOGS__ || window._PRINT_LOGS) {
+            console.log('sse-content', output);
           }
-        } catch (error) {
-          console.error('push-sse-message', error);
-        }
-      };
-
-      JcefEventBus.on(`${JavaPushActionType.AI_SSE_MESSAGE}_${this.currentRequest?.requestId}`, listener);
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error('Unknown error!');
-      callbacks.onError(err);
-      throw err;
-    }
+          callbacks.onUpdate(output);
+        },
+      },
+      eventBus: JcefEventBus,
+      eventName,
+      handleErrorPayload: handleSSEErrorPayload,
+      requestParams: params,
+    });
   }
-
-  public stop() {
-    JcefEventBus.off(`${JavaPushActionType.AI_SSE_MESSAGE}_${this.currentRequest?.requestId}`);
-    this.currentRequest = undefined;
-    this.onStop?.();
-  }
-}
-
-function safeParseDonePayload(data: string) {
-  try {
-    const parsed = JSON.parse(data);
-    if (parsed?.type === 'done') {
-      return parsed;
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
 }
 
 export default ClientRequestClass;

--- a/chat2db-community-client/src/components/SSERequest/sseHttpsRequest.ts
+++ b/chat2db-community-client/src/components/SSERequest/sseHttpsRequest.ts
@@ -1,13 +1,13 @@
 import sseStream, { SSEOutput, SSEStreamProps } from './sseStream';
 import sseFetch from './sseFetch';
-import { SSERequestOptions, SSERequestParams, SSERequestCallbacks, AnyObject } from './index';
+import type { SSERequestOptions, SSERequestParams, SSERequestCallbacks, SSERequestHandle, AnyObject } from './index';
 import { handleSSEErrorPayload } from './errorPayload';
+import { createAbortableRequestHandle, createSSEStreamError } from './requestHandle';
 
 class HTTPSRequestClass {
   readonly baseURL;
   readonly model;
   private defaultHeaders;
-  private abortController?: AbortController;
 
   private static instanceBuffer: Map<string | typeof fetch, HTTPSRequestClass> = new Map();
 
@@ -41,23 +41,21 @@ class HTTPSRequestClass {
     return HTTPSRequestClass.instanceBuffer.get(id)!;
   }
 
-  public create = async <Input = AnyObject, Output = SSEOutput>(
+  public create = <Input = AnyObject, Output = SSEOutput>(
     params: SSERequestParams & Input,
     callbacks: SSERequestCallbacks<Output>,
     transformStream?: SSEStreamProps<Output>['transformStream'],
-  ) => {
-    this.abortController = new AbortController();
-    const requestInit = {
-      method: 'POST',
-      headers: this.defaultHeaders,
-      body: JSON.stringify({
-        model: this.model,
-        ...params,
-      }),
-      signal: this.abortController.signal,
-    };
-
-    try {
+  ): SSERequestHandle => {
+    return createAbortableRequestHandle(async (signal) => {
+      const requestInit = {
+        method: 'POST',
+        headers: this.defaultHeaders,
+        body: JSON.stringify({
+          model: this.model,
+          ...params,
+        }),
+        signal,
+      };
       const response = await sseFetch(this.baseURL, requestInit);
 
       if (transformStream) {
@@ -85,15 +83,7 @@ class HTTPSRequestClass {
           throw new Error(`The response content-type: ${contentType} is not support!`);
         }
       }
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        callbacks?.onStop?.();
-        return;
-      }
-      const err = error instanceof Error ? error : new Error('Unknown error!');
-      callbacks?.onError?.(err);
-      throw err;
-    }
+    }, callbacks);
   };
 
   private customResponseHandler = async <Output = SSEOutput>(
@@ -124,12 +114,18 @@ class HTTPSRequestClass {
     for await (const chunk of sseStream<Output>({
       readableStream: response.body!,
     })) {
+      const streamError = createSSEStreamError(chunk);
+      if (streamError) {
+        callbacks?.onUpdate?.(chunk);
+        throw streamError;
+      }
+
       if (handleSSEErrorPayload(chunk, requestParams)) {
         callbacks?.onSuccess?.(chunks);
         return;
       }
 
-      if (chunk.data === '[DONE]') {
+      if ((chunk as SSEOutput).data === '[DONE]') {
         callbacks?.onSuccess?.(chunks);
         return;
       }
@@ -157,13 +153,6 @@ class HTTPSRequestClass {
 
     callbacks?.onSuccess?.([chunk]);
   };
-
-  public stop() {
-    if (this.abortController) {
-      this.abortController.abort();
-      this.abortController = undefined;
-    }
-  }
 }
 
 export default HTTPSRequestClass;

--- a/chat2db-community-client/src/hooks/useSSERequest.ts
+++ b/chat2db-community-client/src/hooks/useSSERequest.ts
@@ -1,5 +1,13 @@
-import { useCallback, useState, useMemo, useRef } from 'react';
-import sseRequest, { AnyObject, SSEOutput, SSERequestOptions, SSERequestParams, SSERequestStatus } from '@/components/SSERequest';
+import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
+import sseRequest, {
+  AnyObject,
+  SSEOutput,
+  SSERequestOptions,
+  SSERequestParams,
+  SSERequestStatus,
+  type SSERequestHandle,
+} from '@/components/SSERequest';
+import { guardSSERequestCallbacks, SSERequestOwner } from '@/components/SSERequest/requestOwner';
 import useSyncState from '@/hooks/useSyncState';
 import { AnswerPartsType } from '@/constants/chat';
 import { parseSSEChunkData } from '@/components/SSERequest/errorPayload';
@@ -38,6 +46,8 @@ const useSSERequest = <T = string>(
   const [content, setContent] = useState<T>('' as unknown as T);
   const [status, setStatus] = useSyncState<SSERequestStatus>(SSERequestStatus.IDLE);
   const [error, setError] = useState<Error>();
+  const mountedRef = useRef(true);
+  const requestOwner = useMemo(() => new SSERequestOwner(), []);
 
   const onChunkRef = useRef(options.onChunk);
   onChunkRef.current = options.onChunk;
@@ -47,72 +57,105 @@ const useSSERequest = <T = string>(
     [options.baseURL, options.model, options.dangerouslyApiKey, options.lang],
   );
 
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      requestOwner.stop();
+    };
+  }, [requestOwner]);
+
   const request = useCallback(
     async (params: SSERequestParams & AnyObject) => {
       console.log('[useSSERequest] request called, params:', params);
+      const generation = requestOwner.begin();
       setStatus(SSERequestStatus.LOADING);
       setError(undefined);
       const chunks: Record<string, string>[] = [];
       let accumulatedContent = '';
+      let requestHandle: SSERequestHandle | undefined;
+      let callbackHandledError = false;
+      const isActiveRequest = () => mountedRef.current && requestOwner.owns(generation, requestHandle);
 
       try {
-        await instance.create(params, {
-          onSuccess: () => {
-            console.log('[useSSERequest] onSuccess, chunks count:', chunks.length);
-            setStatus(SSERequestStatus.FINISH);
-          },
-          onError: (err) => {
-            console.log('[useSSERequest] onError:', err);
-            setStatus(SSERequestStatus.ERROR);
-            setError(err);
-          },
-          onUpdate: (chunk) => {
-            console.log('[useSSERequest] onUpdate called, chunk:', chunk);
-            chunks.push(chunk as Record<string, string>);
+        requestHandle = instance.create(
+          params,
+          guardSSERequestCallbacks<SSEOutput>(
+            {
+              onSuccess: () => {
+                console.log('[useSSERequest] onSuccess, chunks count:', chunks.length);
+                setStatus(SSERequestStatus.FINISH);
+              },
+              onError: (err) => {
+                callbackHandledError = true;
+                console.log('[useSSERequest] onError:', err);
+                setStatus(SSERequestStatus.ERROR);
+                setError(err);
+              },
+              onUpdate: (chunk) => {
+                console.log('[useSSERequest] onUpdate called, chunk:', chunk);
+                chunks.push(chunk as Record<string, string>);
 
-            if (transformer) {
-              const parsedData = parseSSEChunkData<IParsedData>(chunk.data);
-              if (!parsedData) {
-                return;
-              }
-              transformer(parsedData);
-            } else {
-              const parsedData = parseSSEChunkData<IParsedData>(chunk.data);
-              if (!parsedData) {
-                console.log('json_parse_error');
-                return;
-              }
-              console.log('[useSSERequest] parsedData:', parsedData);
-              onChunkRef.current?.(chunk, parsedData);
-              const newContent = parsedData?.content || '';
-              accumulatedContent += newContent;
-              console.log('[useSSERequest] accumulatedContent length:', accumulatedContent.length);
-              setContent(accumulatedContent as unknown as T);
-            }
-          },
-          onStop: () => {
-            console.log('[useSSERequest] onStop');
-            setStatus(SSERequestStatus.FINISH);
-          },
-        });
+                if (transformer) {
+                  const parsedData = parseSSEChunkData<IParsedData>(chunk.data);
+                  if (!parsedData) {
+                    return;
+                  }
+                  transformer(parsedData);
+                } else {
+                  const parsedData = parseSSEChunkData<IParsedData>(chunk.data);
+                  if (!parsedData) {
+                    console.log('json_parse_error');
+                    return;
+                  }
+                  console.log('[useSSERequest] parsedData:', parsedData);
+                  onChunkRef.current?.(chunk, parsedData);
+                  const newContent = parsedData?.content || '';
+                  accumulatedContent += newContent;
+                  console.log('[useSSERequest] accumulatedContent length:', accumulatedContent.length);
+                  setContent(accumulatedContent as unknown as T);
+                }
+              },
+              onStop: () => {
+                console.log('[useSSERequest] onStop');
+                setStatus(SSERequestStatus.FINISH);
+              },
+            },
+            isActiveRequest,
+          ),
+        );
+        if (!requestOwner.attach(generation, requestHandle)) {
+          return;
+        }
+        await requestHandle.done;
       } catch (error_) {
+        if (!mountedRef.current || !requestOwner.isCurrentGeneration(generation) || callbackHandledError) {
+          return;
+        }
         console.log('[useSSERequest] catch error:', error_);
         setStatus(SSERequestStatus.ERROR);
         setError(error_ instanceof Error ? error_ : new Error('Unknown error'));
+      } finally {
+        if (requestHandle) {
+          requestOwner.release(generation, requestHandle);
+        }
       }
     },
-    [instance, transformer],
+    [instance, requestOwner, setStatus, transformer],
   );
+
+  const stop = useCallback(() => {
+    if (requestOwner.stop() && mountedRef.current) {
+      setStatus(SSERequestStatus.FINISH);
+    }
+  }, [requestOwner, setStatus]);
 
   return {
     content,
     status,
     error,
     request,
-    stop: () => {
-      instance.stop();
-      setStatus(SSERequestStatus.FINISH);
-    },
+    stop,
   };
 };
 export default useSSERequest;

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/ai/ConsoleSseEmitter.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/ai/ConsoleSseEmitter.java
@@ -16,6 +16,8 @@ public class ConsoleSseEmitter extends SseEmitter {
 
     private static final String AI_SSE_MESSAGE = "ai_sse_message";
 
+    private static final String AI_STREAM_ERROR_MESSAGE = "AI stream failed";
+
     private final ConsoleResult consoleResult;
 
     public ConsoleSseEmitter(ConsoleResult consoleResult) {
@@ -50,6 +52,14 @@ public class ConsoleSseEmitter extends SseEmitter {
     @Override
     public void completeWithError(Throwable ex) {
         log.warn("ai stream error via JCEF IPC", ex);
-        complete();
+        try {
+            Map<String, Object> payload = AiChatTraceSupport.payload(AiChatTraceSupport.TYPE_ERROR);
+            payload.put("content", AI_STREAM_ERROR_MESSAGE);
+            sendData(AiChatTraceSupport.TYPE_ERROR, payload);
+        } catch (Exception sendError) {
+            log.warn("failed to send AI stream error via JCEF IPC", sendError);
+        } finally {
+            super.completeWithError(ex);
+        }
     }
 }

--- a/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/adapter/ai/ConsoleSseEmitterTest.java
+++ b/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/adapter/ai/ConsoleSseEmitterTest.java
@@ -1,0 +1,57 @@
+package ai.chat2db.community.web.api.adapter.ai;
+
+import ai.chat2db.community.tools.console.ConsoleOutboundRegistry;
+import ai.chat2db.community.tools.console.ConsoleResult;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ConsoleSseEmitterTest {
+
+    @AfterEach
+    void clearOutbound() {
+        ConsoleOutboundRegistry.register(null);
+    }
+
+    @Test
+    void completeSendsNullTerminal() {
+        List<String> messages = new ArrayList<>();
+        ConsoleOutboundRegistry.register(messages::add);
+        ConsoleSseEmitter emitter = new ConsoleSseEmitter(ConsoleResult.builder().uuid("normal-request").build());
+
+        emitter.complete();
+
+        assertEquals(1, messages.size());
+        JSONObject result = JSON.parseObject(messages.get(0));
+        assertEquals("ai_sse_message", result.getString("actionType"));
+        assertNull(result.get("message"));
+    }
+
+    @Test
+    void completeWithErrorSendsSanitizedErrorTerminal() {
+        List<String> messages = new ArrayList<>();
+        ConsoleOutboundRegistry.register(messages::add);
+        ConsoleSseEmitter emitter = new ConsoleSseEmitter(ConsoleResult.builder().uuid("failed-request").build());
+
+        emitter.completeWithError(new IllegalStateException("provider token=secret"));
+
+        assertEquals(1, messages.size());
+        JSONObject result = JSON.parseObject(messages.get(0));
+        JSONObject message = result.getJSONObject("message");
+        assertEquals("error", message.getString("event"));
+
+        JSONObject payload = JSON.parseObject(message.getString("data"));
+        assertEquals("error", payload.getString("type"));
+        assertEquals("error", payload.getString("messageType"));
+        assertEquals("AI stream failed", payload.getString("content"));
+        assertFalse(messages.get(0).contains("secret"));
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #2464

Supersedes #2465. Its fork head has maintainer edits disabled, and GitHub only permits the pull request author to change that setting, so the reviewed completion commit cannot be pushed to the original head branch.

## Summary

- Remove mutable request state from the per-URL SSE singletons. Every `create()` call now returns an independent, Promise-compatible request handle with request-scoped `stop()` and `done` semantics.
- Give each `useSSERequest` hook instance explicit ownership of one generation. Starting a replacement invalidates the old generation before stopping it, and stale, stopped, or unmounted callbacks cannot update React state.
- Scope JCEF listeners to their request UUID and add a distinguishable, sanitized error terminal from `ConsoleSseEmitter`.
- Preserve legacy `await`, `then`, `catch`, and `finally` behavior because the request handle is the original Promise extended with `stop` and `done`.
- Add request ownership and transport lifecycle contracts to Community CI.

## Affected surfaces

- [x] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:sse-request` - passed.
  - `yarn lint:eslint` - passed with zero warnings.
  - `yarn build:web:community --app_version=5.3.0` - passed; Webpack compiled successfully.
  - `mvn -B test -Dmaven.test.skip=false -DskipTests=false -f pom.xml` - passed; all 48 reactor modules succeeded.
  - Targeted TypeScript compiler diagnostics for `components/SSERequest` and `hooks/useSSERequest.ts` - zero diagnostics.
  - `git diff --check` - passed.
- Manual verification: Reviewed two-consumer replacement, stale cleanup, unmount, HTTP abort, JCEF listener isolation, normal terminal, and error terminal sequences against the production paths.
- UI evidence: N/A; no visual behavior changed.

## Risk and compatibility

- Public API or stored data: No stored-data change. `create()` remains a real Promise and adds request-scoped `stop` and `done` properties.
- Database or driver compatibility: N/A; no database or driver code changed.
- Network, privacy, or security: HTTP cancellation now aborts only the owning fetch. JCEF error terminals expose a generic message and keep the original exception in server logs.
- Community / Local / Pro boundary: Community Web and Community desktop/JCEF paths only. Enterprise source is unchanged.
- Backward compatibility: Existing Promise consumers keep `await`, `then`, `catch`, and `finally`. JCEF has no request-level backend cancel command, so `stop()` precisely detaches only the owning listener while the backend task may finish independently.

## Reviewer map

- Start here: `requestOwner.ts`, `requestHandle.ts`, and `useSSERequest.ts`; then compare the HTTP and JCEF adapters.
- Failure condition: An old consumer can stop or update a newer request, an unmounted hook receives a state update, stopped HTTP work remains attached, or a JCEF error terminal resolves as success.
- Rollback or disable path: Revert this commit; there is no feature flag or data migration.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with implementation, tests, and independent review. The maintainer inspected the source paths and ran the verification commands listed above.
