### PR TITLE
fix(community): preserve navigation and terminal layout

### DIFF
--- a/chat2db-community-client/.umirc.ts
+++ b/chat2db-community-client/.umirc.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'umi';
 import { communityProductConfig } from './product.community';
+import { createMainRootRoute } from './src/utils/mainPageNavigation';
 import { extractYarnConfig, generateBuildTime } from './src/utils/package';
 
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
@@ -263,10 +264,7 @@ export default defineConfig({
               path: '/connections',
               redirect: '/workspace',
             },
-            {
-              path: '/',
-              redirect: '/stream',
-            },
+            createMainRootRoute(buildProfile.isCommunity, MAIN_COMPONENT),
           ],
         },
       ],

--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -70,7 +70,7 @@
     "test:tree-title-highlight": "tsx src/blocks/NewTree/components/TitleRender/highlightSearchText.test.ts",
     "test:tree-data-update": "tsx src/store/tree/treeDataUpdate.test.ts",
     "test:tree-node-lookup": "tsx src/utils/treeNodeLookup.test.ts",
-    "test:terminal": "tsx src/constants/terminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendNav/quickTerminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/terminalTabPlacement.test.ts",
+    "test:terminal": "tsx src/constants/terminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendNav/quickTerminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/terminalTabPlacement.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabSelection.test.ts",
     "test:workspace-tab-drag": "tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabDrop.test.ts",
     "test:verification-code-countdown": "tsx src/utils/verificationCodeCountdown.test.ts && tsx src/utils/latestRequest.test.ts",
     "modify:package:name": "node ./scripts/modify-package-name.js",

--- a/chat2db-community-client/src/pages/main/workspace/components/LocalSQLFileTree/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/LocalSQLFileTree/index.tsx
@@ -1126,7 +1126,9 @@ const LocalSQLFileTree = forwardRef<LocalSQLFileTreeRef, LocalSQLFileTreeProps>(
         },
       ];
       setWorkspaceTabList(nextTabs);
-      setActiveConsoleId(id);
+      if (terminalOpenPosition === 'tab') {
+        setActiveConsoleId(id);
+      }
     } catch (error) {
       console.error('open sql directory terminal error', error);
       feedback.error(i18n('workspace.localSqlFileTree.openTerminalFailed'));

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendNav/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendNav/index.tsx
@@ -73,6 +73,7 @@ export default (props: IProps) => {
       });
       addWorkspaceTab(
         createQuickTerminalTab(terminal, i18n('workspace.terminal.title'), terminalOpenPosition),
+        { activate: terminalOpenPosition === 'tab' },
       );
     } catch (error) {
       console.error('create terminal error', error);

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
@@ -20,6 +20,7 @@ import {
 
 // ----- constants -----
 import { ConsoleOpenedStatus, WorkspaceTabType, workspaceTabConfig } from '@/constants';
+import { DEFAULT_TERMINAL_SETTINGS } from '@/constants/terminal';
 import {
   IWorkspaceTab,
   IWorkspaceTabPaneNode,
@@ -46,6 +47,7 @@ import TerminalTab from './TerminalTab';
 
 // ---- store -----
 import { useWorkspaceStore } from '@/store/workspace';
+import { useGlobalStore } from '@/store/global';
 import { isWorkspaceResultInspectorCode } from '@/store/workspace/utils/resultInspector';
 import { isConsoleTabNameCustomized } from '@/store/workspace/utils/consoleTabName';
 import { useTreeStore } from '@/store/tree';
@@ -75,7 +77,13 @@ import {
   getWorkspaceTabEdgeDropTarget,
   WorkspaceTabDropPosition,
 } from './workspaceTabDrop';
-import { applyTerminalTabOpenPositions } from './terminalTabPlacement';
+import {
+  applyTerminalTabOpenPositions,
+  isTerminalDockPaneId,
+  prepareTerminalTabLayout,
+  resolveLastNonTerminalActiveTabId,
+} from './terminalTabPlacement';
+import { getNextActiveWorkspaceTabIdAfterClose } from './workspaceTabSelection';
 import {
   areWorkspaceTabSplitLayoutsEqual,
   collectWorkspaceTabPaneIds,
@@ -572,7 +580,7 @@ function normalizeWorkspaceTabSplitLayout(
 
   const validPaneIds = new Set(
     paneIds.filter((paneId) => {
-      return !!nextPaneTabIds[paneId]?.length;
+      return !!nextPaneTabIds[paneId]?.length || isTerminalDockPaneId(paneId);
     }),
   );
   const normalizedRoot = pruneWorkspaceTabPaneNode(root, validPaneIds);
@@ -607,11 +615,17 @@ function normalizeWorkspaceTabSplitLayout(
           {} as Partial<Record<WorkspaceTabPaneId, number | string | null>>,
         )
       : layout.activeTabIds || {};
+  const lastNonTerminalActiveTabId = resolveLastNonTerminalActiveTabId(
+    workspaceTabList,
+    activeConsoleId,
+    layout.lastNonTerminalActiveTabId,
+  );
 
   return {
     direction: normalizedRoot.direction,
     root: normalizedRoot,
     activePane: normalizedActivePane,
+    lastNonTerminalActiveTabId,
     paneTabIds: normalizedPaneTabIds,
     activeTabIds: normalizedPaneIds.reduce(
       (result, paneId) => {
@@ -658,46 +672,6 @@ function orderSplitLayoutPaneIdsByPinned(layout: IWorkspaceTabSplitLayout | null
 function getWorkspaceTabIdsByLayout(layout: IWorkspaceTabSplitLayout) {
   const paneIds = collectWorkspaceTabPaneIds(layout.root || createDefaultSplitRoot(layout.direction || 'vertical'));
   return paneIds.flatMap((paneId) => layout.paneTabIds[paneId] || []);
-}
-
-function getNextActiveWorkspaceTabIdAfterClose(params: {
-  activeConsoleId?: string | number | null;
-  closeTabIds: Set<string | number>;
-  layout: IWorkspaceTabSplitLayout | null | undefined;
-  orderedNextWorkspaceTabList: IWorkspaceTab[];
-}) {
-  const { activeConsoleId, closeTabIds, layout, orderedNextWorkspaceTabList } = params;
-  if (activeConsoleId === undefined || activeConsoleId === null || !closeTabIds.has(activeConsoleId)) {
-    return activeConsoleId ?? null;
-  }
-
-  if (!orderedNextWorkspaceTabList.length) {
-    return null;
-  }
-
-  const workspaceTabMap = getWorkspaceTabMap(orderedNextWorkspaceTabList);
-  if (layout) {
-    const activePaneId = getPaneIdForTab(layout, activeConsoleId);
-    const paneTabIds = layout.paneTabIds[activePaneId] || [];
-    const activeIndex = paneTabIds.findIndex((id) => id === activeConsoleId);
-    const isAvailableTabId = (id: string | number) => !closeTabIds.has(id) && workspaceTabMap.has(id);
-    const previousTabId = paneTabIds.slice(0, Math.max(activeIndex, 0)).reverse()
-.find(isAvailableTabId);
-    const nextTabId = paneTabIds.slice(activeIndex + 1).find(isAvailableTabId);
-    const fallbackPaneTabId = paneTabIds.find(isAvailableTabId);
-
-    if (previousTabId !== undefined) {
-      return previousTabId;
-    }
-    if (nextTabId !== undefined) {
-      return nextTabId;
-    }
-    if (fallbackPaneTabId !== undefined) {
-      return fallbackPaneTabId;
-    }
-  }
-
-  return orderedNextWorkspaceTabList[orderedNextWorkspaceTabList.length - 1]?.id ?? null;
 }
 
 function getWorkspaceTabIdFromDndId(id: string, workspaceTabList: IWorkspaceTab[]) {
@@ -774,7 +748,7 @@ const WorkspaceTabs = memo(() => {
     activeConsoleId,
     consoleList,
     workspaceTabList,
-    workspaceTabSplitLayout,
+    workspaceTabSplitLayout: storedWorkspaceTabSplitLayout,
     recentlyClosedWorkspaceTabs,
     editorList,
     getOpenConsoleList,
@@ -795,6 +769,18 @@ const WorkspaceTabs = memo(() => {
       createConsole: state.createConsole,
     };
   });
+  const terminalOpenPosition = useGlobalStore(
+    (state) => state.terminalSettings.openPosition || DEFAULT_TERMINAL_SETTINGS.openPosition,
+  );
+  const workspaceTabSplitLayout = useMemo(() => {
+    const preparedLayout = prepareTerminalTabLayout(
+      storedWorkspaceTabSplitLayout,
+      workspaceTabList || [],
+      activeConsoleId,
+      terminalOpenPosition,
+    );
+    return normalizeWorkspaceTabSplitLayout(preparedLayout, workspaceTabList || [], activeConsoleId);
+  }, [storedWorkspaceTabSplitLayout, workspaceTabList, activeConsoleId, terminalOpenPosition]);
 
   // Get the currently selected data source.
   const { zoerBoundInfo } = useZoerStore((state) => {
@@ -859,17 +845,12 @@ const WorkspaceTabs = memo(() => {
   };
 
   useEffect(() => {
-    const normalizedLayout = normalizeWorkspaceTabSplitLayout(
-      workspaceTabSplitLayout,
-      workspaceTabList || [],
-      activeConsoleId,
-    );
-    if (!areWorkspaceTabSplitLayoutsEqual(workspaceTabSplitLayout, normalizedLayout)) {
+    if (!areWorkspaceTabSplitLayoutsEqual(storedWorkspaceTabSplitLayout, workspaceTabSplitLayout)) {
       useWorkspaceStore.setState({
-        workspaceTabSplitLayout: normalizedLayout,
+        workspaceTabSplitLayout,
       });
     }
-  }, [workspaceTabList, workspaceTabSplitLayout, activeConsoleId]);
+  }, [storedWorkspaceTabSplitLayout, workspaceTabSplitLayout]);
 
   useEffect(() => {
     const workspaceStore = useWorkspaceStore.getState();
@@ -1098,10 +1079,18 @@ const WorkspaceTabs = memo(() => {
     if (!key) {
       return;
     }
+    const selectedTab = (workspaceTabList || []).find((tab) => tab.id === key);
+    const currentActiveTab = (workspaceTabList || []).find((tab) => tab.id === activeConsoleId);
+    const lastNonTerminalActiveTabId =
+      selectedTab && selectedTab.type !== WorkspaceTabType.Terminal
+        ? key
+        : workspaceTabSplitLayout?.lastNonTerminalActiveTabId ??
+          (currentActiveTab && currentActiveTab.type !== WorkspaceTabType.Terminal ? activeConsoleId : null);
     const nextLayout = workspaceTabSplitLayout
       ? {
           ...workspaceTabSplitLayout,
           activePane: paneId,
+          lastNonTerminalActiveTabId,
           activeTabIds: {
             ...workspaceTabSplitLayout.activeTabIds,
             [paneId]: key,
@@ -1977,16 +1966,30 @@ const WorkspaceTabs = memo(() => {
       return renderWorkspaceTabPane(node.id, styles.splitPaneItem);
     }
 
+    const firstPaneHidden =
+      node.first.type === 'pane' &&
+      isTerminalDockPaneId(node.first.id) &&
+      !workspaceTabSplitLayout?.paneTabIds[node.first.id]?.length;
+    const secondPaneHidden =
+      node.second.type === 'pane' &&
+      isTerminalDockPaneId(node.second.id) &&
+      !workspaceTabSplitLayout?.paneTabIds[node.second.id]?.length;
+    const hasHiddenTerminalDock = firstPaneHidden || secondPaneHidden;
+
     return (
       <SplitPaneAny
         key={node.nodeId}
         className={styles.splitPane}
         split={node.direction}
         primary="first"
-        size={node.size ?? '50%'}
-        minSize={180}
+        size={firstPaneHidden ? 0 : secondPaneHidden ? '100%' : node.size ?? '50%'}
+        minSize={hasHiddenTerminalDock ? 0 : 180}
+        allowResize={!hasHiddenTerminalDock}
         paneClassName={styles.splitPaneInner}
+        pane1Style={firstPaneHidden ? { display: 'none' } : undefined}
+        pane2Style={secondPaneHidden ? { display: 'none' } : undefined}
         resizerClassName={WORKSPACE_TAB_RESIZER_CLASS}
+        resizerStyle={hasHiddenTerminalDock ? { display: 'none' } : undefined}
         onDragStarted={() => setWorkspaceTabResizeCursor(node.direction)}
         onDragFinished={(size: number | string) => {
           clearWorkspaceTabResizeCursor();

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/terminalTabPlacement.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/terminalTabPlacement.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { WorkspaceTabType } from '@/constants/workspace';
 import type { IWorkspaceTab, IWorkspaceTabSplitLayout } from '@/typings';
-import { applyTerminalTabOpenPositions } from './terminalTabPlacement';
+import {
+  applyTerminalTabOpenPositions,
+  prepareTerminalTabLayout,
+  resolveLastNonTerminalActiveTabId,
+} from './terminalTabPlacement';
 
 function withoutNodeIds<T>(value: T): T {
   return JSON.parse(JSON.stringify(value, (key, item) => (key === 'nodeId' ? undefined : item)));
@@ -18,6 +22,80 @@ const rightTerminal: IWorkspaceTab = {
   title: 'Terminal',
   uniqueData: { terminalOpenPosition: 'right' },
 };
+const secondEditorTab: IWorkspaceTab = {
+  id: 'editor-2',
+  type: WorkspaceTabType.CONSOLE,
+  title: 'Console 2',
+};
+
+assert.equal(
+  resolveLastNonTerminalActiveTabId(
+    [editorTab, secondEditorTab, rightTerminal],
+    secondEditorTab.id,
+    editorTab.id,
+  ),
+  secondEditorTab.id,
+  'the current editor must replace a stale remembered editor',
+);
+assert.equal(
+  resolveLastNonTerminalActiveTabId(
+    [editorTab, secondEditorTab, rightTerminal],
+    rightTerminal.id,
+    secondEditorTab.id,
+  ),
+  secondEditorTab.id,
+  'an active terminal must preserve the last active editor',
+);
+
+const emptyRightLayout = prepareTerminalTabLayout(null, [editorTab], editorTab.id, 'right');
+assert.deepEqual(withoutNodeIds(emptyRightLayout?.root), {
+  type: 'split',
+  direction: 'vertical',
+  size: '70%',
+  first: { type: 'pane', id: 'main' },
+  second: { type: 'pane', id: 'terminal-panel:right' },
+});
+assert.deepEqual(emptyRightLayout?.paneTabIds, {
+  main: ['editor-1'],
+  'terminal-panel:right': [],
+});
+assert.equal(emptyRightLayout?.activeTabIds.main, editorTab.id);
+
+const refreshedRightLayout = prepareTerminalTabLayout(
+  { ...emptyRightLayout!, lastNonTerminalActiveTabId: editorTab.id },
+  [editorTab, secondEditorTab],
+  secondEditorTab.id,
+  'right',
+);
+assert.equal(
+  refreshedRightLayout?.lastNonTerminalActiveTabId,
+  secondEditorTab.id,
+  'preparing a dock must refresh a stale remembered editor before the terminal activates',
+);
+
+const emptyRightRootId = emptyRightLayout?.root?.type === 'split' ? emptyRightLayout.root.nodeId : undefined;
+const populatedRightLayout = prepareTerminalTabLayout(
+  emptyRightLayout,
+  [editorTab, rightTerminal],
+  editorTab.id,
+  'right',
+);
+assert.equal(
+  populatedRightLayout?.root?.type === 'split' ? populatedRightLayout.root.nodeId : undefined,
+  emptyRightRootId,
+  'opening a docked terminal must keep the existing split root mounted',
+);
+assert.deepEqual(populatedRightLayout?.paneTabIds['terminal-panel:right'], ['terminal-1']);
+assert.equal(populatedRightLayout?.activeTabIds.main, editorTab.id);
+
+const emptyBottomLayout = prepareTerminalTabLayout(null, [editorTab], editorTab.id, 'bottom');
+assert.deepEqual(withoutNodeIds(emptyBottomLayout?.root), {
+  type: 'split',
+  direction: 'horizontal',
+  size: '65%',
+  first: { type: 'pane', id: 'main' },
+  second: { type: 'pane', id: 'terminal-panel:bottom' },
+});
 
 const rightLayout = applyTerminalTabOpenPositions(null, [editorTab, rightTerminal], rightTerminal.id);
 assert.match(rightLayout?.root?.type === 'split' ? rightLayout.root.nodeId || '' : '', /^split_/);

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/terminalTabPlacement.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/terminalTabPlacement.ts
@@ -15,8 +15,14 @@ const TERMINAL_PANE_IDS: Record<Exclude<TerminalOpenPosition, 'tab'>, WorkspaceT
   right: 'terminal-panel:right',
 };
 
-function isDockPosition(value?: TerminalOpenPosition): value is Exclude<TerminalOpenPosition, 'tab'> {
+export function isTerminalDockPosition(
+  value?: TerminalOpenPosition,
+): value is Exclude<TerminalOpenPosition, 'tab'> {
   return value === 'bottom' || value === 'right';
+}
+
+export function isTerminalDockPaneId(paneId: WorkspaceTabPaneId) {
+  return Object.values(TERMINAL_PANE_IDS).includes(paneId);
 }
 
 function createRootFromLayout(layout: IWorkspaceTabSplitLayout): IWorkspaceTabPaneNode {
@@ -37,6 +43,22 @@ function getActiveTabId(tabIds: Array<string | number>, activeTabId?: string | n
     : tabIds[0] ?? null;
 }
 
+export function resolveLastNonTerminalActiveTabId(
+  workspaceTabs: IWorkspaceTab[],
+  activeTabId?: string | number | null,
+  fallbackTabId?: string | number | null,
+) {
+  const activeTab = workspaceTabs.find((tab) => tab.id === activeTabId);
+  if (activeTab && activeTab.type !== WorkspaceTabType.Terminal) {
+    return activeTab.id;
+  }
+
+  const fallbackTab = workspaceTabs.find((tab) => tab.id === fallbackTabId);
+  return fallbackTab && fallbackTab.type !== WorkspaceTabType.Terminal
+    ? fallbackTab.id
+    : workspaceTabs.find((tab) => tab.type !== WorkspaceTabType.Terminal)?.id ?? null;
+}
+
 export function applyTerminalTabOpenPositions(
   layout: IWorkspaceTabSplitLayout | null | undefined,
   workspaceTabs: IWorkspaceTab[],
@@ -46,7 +68,7 @@ export function applyTerminalTabOpenPositions(
   const pendingTerminalTabs = workspaceTabs.filter(
     (tab) =>
       tab.type === WorkspaceTabType.Terminal &&
-      isDockPosition(tab.uniqueData?.terminalOpenPosition) &&
+      isTerminalDockPosition(tab.uniqueData?.terminalOpenPosition) &&
       !assignedTabIds.has(tab.id),
   );
 
@@ -74,6 +96,7 @@ export function applyTerminalTabOpenPositions(
     nextLayout = {
       direction: 'vertical',
       activePane: MAIN_WORKSPACE_TAB_PANE,
+      lastNonTerminalActiveTabId: resolveLastNonTerminalActiveTabId(workspaceTabs, activeTabId),
       root: { type: 'pane', id: MAIN_WORKSPACE_TAB_PANE },
       paneTabIds: { [MAIN_WORKSPACE_TAB_PANE]: mainTabIds },
       activeTabIds: {
@@ -122,4 +145,87 @@ export function applyTerminalTabOpenPositions(
   }
 
   return nextLayout;
+}
+
+export function prepareTerminalTabLayout(
+  layout: IWorkspaceTabSplitLayout | null | undefined,
+  workspaceTabs: IWorkspaceTab[],
+  activeTabId: string | number | null | undefined,
+  preferredOpenPosition: TerminalOpenPosition,
+): IWorkspaceTabSplitLayout | null {
+  let preparedLayout = layout
+    ? {
+        ...layout,
+        lastNonTerminalActiveTabId: resolveLastNonTerminalActiveTabId(
+          workspaceTabs,
+          activeTabId,
+          layout.lastNonTerminalActiveTabId,
+        ),
+      }
+    : null;
+
+  if (isTerminalDockPosition(preferredOpenPosition)) {
+    const dockedTerminalIds = new Set(
+      workspaceTabs
+        .filter(
+          (tab) =>
+            tab.type === WorkspaceTabType.Terminal &&
+            isTerminalDockPosition(tab.uniqueData?.terminalOpenPosition),
+        )
+        .map((tab) => tab.id),
+    );
+    const mainTabIds = workspaceTabs.filter((tab) => !dockedTerminalIds.has(tab.id)).map((tab) => tab.id);
+
+    if (mainTabIds.length) {
+      const paneId = TERMINAL_PANE_IDS[preferredOpenPosition];
+      const direction: WorkspaceTabSplitDirection = preferredOpenPosition === 'right' ? 'vertical' : 'horizontal';
+      const dockSize = preferredOpenPosition === 'right' ? '70%' : '65%';
+
+      if (!preparedLayout) {
+        preparedLayout = {
+          direction,
+          activePane: MAIN_WORKSPACE_TAB_PANE,
+          lastNonTerminalActiveTabId: resolveLastNonTerminalActiveTabId(workspaceTabs, activeTabId),
+          root: createWorkspaceTabSplitNode(
+            direction,
+            { type: 'pane', id: MAIN_WORKSPACE_TAB_PANE },
+            { type: 'pane', id: paneId },
+            dockSize,
+          ),
+          paneTabIds: {
+            [MAIN_WORKSPACE_TAB_PANE]: mainTabIds,
+            [paneId]: [],
+          },
+          activeTabIds: {
+            [MAIN_WORKSPACE_TAB_PANE]: getActiveTabId(mainTabIds, activeTabId),
+            [paneId]: null,
+          },
+        };
+      } else {
+        const root = createRootFromLayout(preparedLayout);
+        if (!collectWorkspaceTabPaneIds(root).includes(paneId)) {
+          preparedLayout = {
+            ...preparedLayout,
+            direction,
+            root: createWorkspaceTabSplitNode(
+              direction,
+              root,
+              { type: 'pane', id: paneId },
+              dockSize,
+            ),
+            paneTabIds: {
+              ...preparedLayout.paneTabIds,
+              [paneId]: [],
+            },
+            activeTabIds: {
+              ...preparedLayout.activeTabIds,
+              [paneId]: null,
+            },
+          };
+        }
+      }
+    }
+  }
+
+  return applyTerminalTabOpenPositions(preparedLayout, workspaceTabs, activeTabId);
 }

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabLayout.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabLayout.ts
@@ -155,6 +155,7 @@ export function areWorkspaceTabSplitLayoutsEqual(
   return (
     left.direction === right.direction &&
     left.activePane === right.activePane &&
+    left.lastNonTerminalActiveTabId === right.lastNonTerminalActiveTabId &&
     paneNodesEqual(left.root, right.root) &&
     recordOfIdsEqual(left.paneTabIds, right.paneTabIds) &&
     leftActiveKeys.length === rightActiveKeys.length &&

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabSelection.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabSelection.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { WorkspaceTabType } from '@/constants/workspace';
+import type { IWorkspaceTab, IWorkspaceTabSplitLayout } from '@/typings';
+import { getNextActiveWorkspaceTabIdAfterClose } from './workspaceTabSelection';
+
+const editorOne: IWorkspaceTab = { id: 'editor-1', type: WorkspaceTabType.CONSOLE, title: 'Editor 1' };
+const editorTwo: IWorkspaceTab = { id: 'editor-2', type: WorkspaceTabType.CONSOLE, title: 'Editor 2' };
+const terminal: IWorkspaceTab = { id: 'terminal-1', type: WorkspaceTabType.Terminal, title: 'Terminal' };
+const splitLayout: IWorkspaceTabSplitLayout = {
+  direction: 'horizontal',
+  activePane: 'terminal-panel:bottom',
+  root: {
+    type: 'split',
+    direction: 'horizontal',
+    first: { type: 'pane', id: 'main' },
+    second: { type: 'pane', id: 'terminal-panel:bottom' },
+  },
+  paneTabIds: {
+    main: [editorOne.id, editorTwo.id],
+    'terminal-panel:bottom': [terminal.id],
+  },
+  activeTabIds: {
+    main: editorOne.id,
+    'terminal-panel:bottom': terminal.id,
+  },
+};
+
+assert.equal(
+  getNextActiveWorkspaceTabIdAfterClose({
+    activeConsoleId: terminal.id,
+    closeTabIds: new Set([terminal.id]),
+    layout: splitLayout,
+    orderedNextWorkspaceTabList: [editorOne, editorTwo],
+  }),
+  editorOne.id,
+  'closing a docked terminal should restore the editor that was active in the main pane',
+);
+
+assert.equal(
+  getNextActiveWorkspaceTabIdAfterClose({
+    activeConsoleId: editorOne.id,
+    closeTabIds: new Set([terminal.id]),
+    layout: splitLayout,
+    orderedNextWorkspaceTabList: [editorOne, editorTwo],
+  }),
+  editorOne.id,
+  'closing a background terminal must not change the active editor',
+);
+
+assert.equal(
+  getNextActiveWorkspaceTabIdAfterClose({
+    activeConsoleId: editorTwo.id,
+    closeTabIds: new Set([editorTwo.id]),
+    layout: splitLayout,
+    orderedNextWorkspaceTabList: [editorOne, terminal],
+  }),
+  editorOne.id,
+  'closing an editor should keep the existing same-pane neighbor behavior',
+);
+
+const multiEditorPaneLayout: IWorkspaceTabSplitLayout = {
+  ...splitLayout,
+  lastNonTerminalActiveTabId: editorTwo.id,
+  root: {
+    type: 'split',
+    direction: 'horizontal',
+    first: {
+      type: 'split',
+      direction: 'vertical',
+      first: { type: 'pane', id: 'main' },
+      second: { type: 'pane', id: 'editor-split' },
+    },
+    second: { type: 'pane', id: 'terminal-panel:bottom' },
+  },
+  paneTabIds: {
+    main: [editorOne.id],
+    'editor-split': [editorTwo.id],
+    'terminal-panel:bottom': [terminal.id],
+  },
+  activeTabIds: {
+    main: editorOne.id,
+    'editor-split': editorTwo.id,
+    'terminal-panel:bottom': terminal.id,
+  },
+};
+
+assert.equal(
+  getNextActiveWorkspaceTabIdAfterClose({
+    activeConsoleId: terminal.id,
+    closeTabIds: new Set([terminal.id]),
+    layout: multiEditorPaneLayout,
+    orderedNextWorkspaceTabList: [editorOne, editorTwo],
+  }),
+  editorTwo.id,
+  'closing a docked terminal should restore the last active editor across multiple panes',
+);
+
+console.log('Workspace tab selection tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabSelection.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabSelection.ts
@@ -1,0 +1,68 @@
+import type { IWorkspaceTab, IWorkspaceTabSplitLayout } from '@/typings';
+
+export function getNextActiveWorkspaceTabIdAfterClose(params: {
+  activeConsoleId?: string | number | null;
+  closeTabIds: Set<string | number>;
+  layout: IWorkspaceTabSplitLayout | null | undefined;
+  orderedNextWorkspaceTabList: IWorkspaceTab[];
+}) {
+  const { activeConsoleId, closeTabIds, layout, orderedNextWorkspaceTabList } = params;
+  if (activeConsoleId === undefined || activeConsoleId === null || !closeTabIds.has(activeConsoleId)) {
+    return activeConsoleId ?? null;
+  }
+  if (!orderedNextWorkspaceTabList.length) {
+    return null;
+  }
+
+  const availableTabIds = new Set(orderedNextWorkspaceTabList.map((tab) => tab.id));
+  const isAvailableTabId = (id: string | number | null | undefined): id is string | number =>
+    id !== undefined && id !== null && !closeTabIds.has(id) && availableTabIds.has(id);
+
+  if (layout) {
+    const activePaneId = Object.keys(layout.paneTabIds).find((paneId) =>
+      layout.paneTabIds[paneId]?.includes(activeConsoleId),
+    );
+    if (activePaneId) {
+      const paneTabIds = layout.paneTabIds[activePaneId] || [];
+      const activeIndex = paneTabIds.findIndex((id) => id === activeConsoleId);
+      const previousTabId = paneTabIds
+        .slice(0, Math.max(activeIndex, 0))
+        .reverse()
+        .find(isAvailableTabId);
+      const nextTabId = paneTabIds.slice(activeIndex + 1).find(isAvailableTabId);
+      const fallbackPaneTabId = paneTabIds.find(isAvailableTabId);
+
+      if (previousTabId !== undefined) {
+        return previousTabId;
+      }
+      if (nextTabId !== undefined) {
+        return nextTabId;
+      }
+      if (fallbackPaneTabId !== undefined) {
+        return fallbackPaneTabId;
+      }
+
+      if (isAvailableTabId(layout.lastNonTerminalActiveTabId)) {
+        return layout.lastNonTerminalActiveTabId;
+      }
+
+      const otherPaneActiveTabId = Object.entries(layout.activeTabIds)
+        .filter(([paneId]) => paneId !== activePaneId)
+        .map(([, tabId]) => tabId)
+        .find(isAvailableTabId);
+      if (otherPaneActiveTabId !== undefined) {
+        return otherPaneActiveTabId;
+      }
+
+      const otherPaneTabId = Object.entries(layout.paneTabIds)
+        .filter(([paneId]) => paneId !== activePaneId)
+        .flatMap(([, tabIds]) => tabIds)
+        .find(isAvailableTabId);
+      if (otherPaneTabId !== undefined) {
+        return otherPaneTabId;
+      }
+    }
+  }
+
+  return orderedNextWorkspaceTabList[orderedNextWorkspaceTabList.length - 1]?.id ?? null;
+}

--- a/chat2db-community-client/src/store/workspace/slices/console/action.ts
+++ b/chat2db-community-client/src/store/workspace/slices/console/action.ts
@@ -82,7 +82,7 @@ export interface ConsoleAction {
     nameCustomized?: boolean;
   }) => void;
   createConsole: (params: ICreateConsoleParams) => Promise<any>;
-  addWorkspaceTab: (params: any) => void;
+  addWorkspaceTab: (params: any, options?: { activate?: boolean }) => void;
   setEditorToList: (id: number | string, editorIns: any) => void;
   deleteEditor: (id: number | string) => void;
   appendConsole: (params: { id: number | string; content: string; type?: EditorSetValueType; space?: boolean }) => void;
@@ -196,16 +196,21 @@ export const createConsoleAction: StateCreator<WorkspaceStore, [['zustand/devtoo
         });
     });
   },
-  addWorkspaceTab: (params) => {
+  addWorkspaceTab: (params, options) => {
     const workspaceTabList = get().workspaceTabList;
+    const activate = options?.activate ?? true;
     if (workspaceTabList?.length && workspaceTabList.findIndex((item) => item?.id === params?.id) !== -1) {
-      get().setActiveConsoleId(params.id);
+      if (activate) {
+        get().setActiveConsoleId(params.id);
+      }
       return;
     }
 
     const newList = [...(workspaceTabList || []), params];
     get().setWorkspaceTabList(newList);
-    get().setActiveConsoleId(params.id);
+    if (activate) {
+      get().setActiveConsoleId(params.id);
+    }
   },
   setEditorToList: (id, editorIns) => {
     const editorList = get().editorList;

--- a/chat2db-community-client/src/typings/workspace.ts
+++ b/chat2db-community-client/src/typings/workspace.ts
@@ -36,6 +36,7 @@ export type IWorkspaceTabPaneNode =
 export interface IWorkspaceTabSplitLayout {
   direction: WorkspaceTabSplitDirection;
   activePane: WorkspaceTabPaneId;
+  lastNonTerminalActiveTabId?: number | string | null;
   paneTabIds: Record<WorkspaceTabPaneId, Array<number | string>>;
   activeTabIds: Partial<Record<WorkspaceTabPaneId, number | string | null>>;
   root?: IWorkspaceTabPaneNode;

--- a/chat2db-community-client/src/utils/mainPageNavigation.test.ts
+++ b/chat2db-community-client/src/utils/mainPageNavigation.test.ts
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
-import { DEFAULT_MAIN_PAGE_ACTIVE_TAB, resolveInitialMainPage } from './mainPageNavigation';
+import {
+  createMainRootRoute,
+  DEFAULT_MAIN_PAGE_ACTIVE_TAB,
+  resolveInitialMainPage,
+} from './mainPageNavigation';
 
 assert.equal(DEFAULT_MAIN_PAGE_ACTIVE_TAB, 'workspace', 'a new user should start on the workspace entry');
 assert.equal(
@@ -16,6 +20,16 @@ assert.equal(
   resolveInitialMainPage('', ''),
   'workspace',
   'workspace should be used when neither a route nor a persisted entry exists',
+);
+assert.deepEqual(
+  createMainRootRoute(true, '@/pages/main/CommunityMainPage'),
+  { path: '/', component: '@/pages/main/CommunityMainPage' },
+  'the Community root route must let persisted navigation choose the initial page',
+);
+assert.deepEqual(
+  createMainRootRoute(false, 'main'),
+  { path: '/', redirect: '/stream' },
+  'commercial routing should keep its existing root redirect',
 );
 
 console.log('Main page navigation tests passed.');

--- a/chat2db-community-client/src/utils/mainPageNavigation.ts
+++ b/chat2db-community-client/src/utils/mainPageNavigation.ts
@@ -2,3 +2,8 @@ export const DEFAULT_MAIN_PAGE_ACTIVE_TAB = 'workspace';
 
 export const resolveInitialMainPage = (routePage?: string, persistedPage?: string) =>
   routePage || persistedPage || DEFAULT_MAIN_PAGE_ACTIVE_TAB;
+
+export const createMainRootRoute = (preserveLastSelection: boolean, component: string) =>
+  preserveLastSelection
+    ? { path: '/', component }
+    : { path: '/', redirect: '/stream' };

--- a/docs/guides/community-jcef-development.md
+++ b/docs/guides/community-jcef-development.md
@@ -67,6 +67,8 @@ with `-Dchat2db.jcef.web-frontend=true`. That parameter tells JCEF to load the
 Web frontend instead of packaged frontend files. The script does not start a
 separate Web backend. It waits up to another 120 seconds for the embedded
 backend's `/api/system` health check to succeed on `127.0.0.1:10825`.
+On macOS, the launcher also starts Java on the AppKit first thread as required
+by AWT and JCEF.
 
 Press `Ctrl+C` to stop both processes. If either child exits, the launcher stops
 the other one. It prints the checkout, JBR, backend jar, child PIDs, listener

--- a/script/dev-community-jcef.sh
+++ b/script/dev-community-jcef.sh
@@ -22,6 +22,7 @@ BACKEND_PID=""
 case "$(uname -s)" in
     Darwin)
         JAVA_OPTIONS+=(
+            -XstartOnFirstThread
             --add-opens=java.desktop/sun.awt=ALL-UNNAMED
             --add-opens=java.desktop/sun.lwawt=ALL-UNNAMED
             --add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED


### PR DESCRIPTION
## Summary

- default Community navigation to Workspace and persist the last selected main section
- keep docked terminals mounted while hidden so opening and closing does not flash or replace the active editor tab
- restore the last valid non-terminal tab and cover multi-pane/stale-selection fallbacks
- start macOS Community JCEF development on the JVM first thread

## Testing

- yarn test:terminal
- yarn test:main-page-navigation
- targeted ESLint
- yarn build:web:community --app_version=5.3.3
- bash -n script/dev-community-jcef.sh
- git diff --check