### PR TITLE
fix(community): restore last selected main page

### DIFF
--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -32,7 +32,11 @@ import aiStreamService, { IChatSession } from '@/service/aiStream';
 import { useChatStore } from '@/store/chat';
 import { useWorkspaceStore } from '@/store/workspace';
 import { isDesktop, isHashHistoryEnv } from '@/utils/env';
-import { resolveInitialMainPage } from '@/utils/mainPageNavigation';
+import {
+  readPersistedMainPageActiveTab,
+  resolveDesktopInitialMainPage,
+  resolveInitialMainPage,
+} from '@/utils/mainPageNavigation';
 import { checkIsSharePage } from '@/utils/url';
 
 function CommunityMainPage() {
@@ -207,8 +211,20 @@ function CommunityMainPage() {
       const hashPath = window.location.hash.replace(/^#/, '');
       const normalizedHashPath = hashPath.startsWith('/') ? hashPath : `/${hashPath}`;
       const hashPage = normalizedHashPath.split('/')[1];
-      page = resolveInitialMainPage(hashPage, mainPageActiveTab);
-      pathName = hashPage ? normalizedHashPath : '';
+      if (isDesktop) {
+        let persistedPage: string | undefined;
+        try {
+          persistedPage = readPersistedMainPageActiveTab(localStorage.getItem(runtimeEditionConfig.globalStoreName));
+        } catch {
+          persistedPage = undefined;
+        }
+        const initialLocation = resolveDesktopInitialMainPage(normalizedHashPath, persistedPage);
+        page = initialLocation.page;
+        pathName = initialLocation.pathName;
+      } else {
+        page = resolveInitialMainPage(hashPage, mainPageActiveTab);
+        pathName = hashPage ? normalizedHashPath : '';
+      }
     } else {
       page = resolveInitialMainPage(window.location.pathname.split('/')[1], mainPageActiveTab);
       pathName = window.location.pathname;

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -218,7 +218,11 @@ function CommunityMainPage() {
         } catch {
           persistedPage = undefined;
         }
-        const initialLocation = resolveDesktopInitialMainPage(normalizedHashPath, persistedPage);
+        const initialLocation = resolveDesktopInitialMainPage(
+          normalizedHashPath,
+          persistedPage,
+          nextNavConfig.map((item) => `${item.key}`),
+        );
         page = initialLocation.page;
         pathName = initialLocation.pathName;
       } else {

--- a/chat2db-community-client/src/utils/mainPageNavigation.test.ts
+++ b/chat2db-community-client/src/utils/mainPageNavigation.test.ts
@@ -54,6 +54,16 @@ assert.deepEqual(
   'a shallow route should still initialize a desktop profile without persisted state',
 );
 assert.deepEqual(
+  resolveDesktopInitialMainPage('/', 'dashboard', ['workspace']),
+  { page: 'workspace', pathName: '/workspace' },
+  'an unavailable persisted page should fall back to an available main page',
+);
+assert.deepEqual(
+  resolveDesktopInitialMainPage('/dashboard', undefined, ['stream', 'workspace']),
+  { page: 'workspace', pathName: '/workspace' },
+  'an unavailable shallow route should fall back to the default available main page',
+);
+assert.deepEqual(
   resolveDesktopInitialMainPage('/stream/session-1', 'dashboard'),
   { page: 'stream', pathName: '/stream/session-1' },
   'a chat-session deep link should take precedence over the last selected page',

--- a/chat2db-community-client/src/utils/mainPageNavigation.test.ts
+++ b/chat2db-community-client/src/utils/mainPageNavigation.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import {
   createMainRootRoute,
   DEFAULT_MAIN_PAGE_ACTIVE_TAB,
+  readPersistedMainPageActiveTab,
+  resolveDesktopInitialMainPage,
   resolveInitialMainPage,
 } from './mainPageNavigation';
 
@@ -20,6 +22,51 @@ assert.equal(
   resolveInitialMainPage('', ''),
   'workspace',
   'workspace should be used when neither a route nor a persisted entry exists',
+);
+assert.equal(
+  readPersistedMainPageActiveTab('{"state":{"mainPageActiveTab":"dashboard"}}'),
+  'dashboard',
+  'the persisted main page should be read from the Zustand storage payload',
+);
+assert.equal(
+  readPersistedMainPageActiveTab('{"state":{"mainPageActiveTab":"settings"}}'),
+  undefined,
+  'non-navigation values should not be restored as a main page',
+);
+assert.equal(
+  readPersistedMainPageActiveTab('{invalid-json'),
+  undefined,
+  'invalid persisted state should fall back without blocking startup',
+);
+assert.deepEqual(
+  resolveDesktopInitialMainPage('/', 'dashboard'),
+  { page: 'dashboard', pathName: '/dashboard' },
+  'desktop root startup should restore the last selected main page',
+);
+assert.deepEqual(
+  resolveDesktopInitialMainPage('/workspace', 'dashboard'),
+  { page: 'dashboard', pathName: '/dashboard' },
+  'a shallow desktop main route should not override the last selected page',
+);
+assert.deepEqual(
+  resolveDesktopInitialMainPage('/dashboard', undefined),
+  { page: 'dashboard', pathName: '/dashboard' },
+  'a shallow route should still initialize a desktop profile without persisted state',
+);
+assert.deepEqual(
+  resolveDesktopInitialMainPage('/stream/session-1', 'dashboard'),
+  { page: 'stream', pathName: '/stream/session-1' },
+  'a chat-session deep link should take precedence over the last selected page',
+);
+assert.deepEqual(
+  resolveDesktopInitialMainPage('/dashboard/share/dashboard-1', 'workspace'),
+  { page: 'dashboard', pathName: '/dashboard/share/dashboard-1' },
+  'a dashboard deep link should take precedence over the last selected page',
+);
+assert.deepEqual(
+  resolveDesktopInitialMainPage('/settings/terminal', 'dashboard'),
+  { page: 'settings', pathName: '/settings/terminal' },
+  'a non-main explicit route should keep its full deep-link path',
 );
 assert.deepEqual(
   createMainRootRoute(true, '@/pages/main/CommunityMainPage'),

--- a/chat2db-community-client/src/utils/mainPageNavigation.ts
+++ b/chat2db-community-client/src/utils/mainPageNavigation.ts
@@ -1,9 +1,46 @@
 export const DEFAULT_MAIN_PAGE_ACTIVE_TAB = 'workspace';
 
+const RESTORABLE_MAIN_PAGE_TABS = new Set(['stream', 'workspace', 'dashboard']);
+
+const normalizeMainPagePath = (routePath?: string) => {
+  const hashlessPath = (routePath || '').replace(/^#/, '');
+  if (!hashlessPath) {
+    return '/';
+  }
+  return hashlessPath.startsWith('/') ? hashlessPath : `/${hashlessPath}`;
+};
+
 export const resolveInitialMainPage = (routePage?: string, persistedPage?: string) =>
   routePage || persistedPage || DEFAULT_MAIN_PAGE_ACTIVE_TAB;
 
+export const readPersistedMainPageActiveTab = (serializedStore?: string | null) => {
+  if (!serializedStore) {
+    return undefined;
+  }
+
+  try {
+    const page = JSON.parse(serializedStore)?.state?.mainPageActiveTab;
+    return typeof page === 'string' && RESTORABLE_MAIN_PAGE_TABS.has(page) ? page : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const resolveDesktopInitialMainPage = (routePath?: string, persistedPage?: string) => {
+  const normalizedPath = normalizeMainPagePath(routePath);
+  const routeSegments = normalizedPath.split('/').filter(Boolean);
+  const routePage = routeSegments[0] || '';
+  const restoresLastSelection =
+    routeSegments.length === 0 || (routeSegments.length === 1 && RESTORABLE_MAIN_PAGE_TABS.has(routePage));
+  const page = restoresLastSelection
+    ? persistedPage || routePage || DEFAULT_MAIN_PAGE_ACTIVE_TAB
+    : routePage || persistedPage || DEFAULT_MAIN_PAGE_ACTIVE_TAB;
+
+  return {
+    page,
+    pathName: restoresLastSelection ? `/${page}` : normalizedPath,
+  };
+};
+
 export const createMainRootRoute = (preserveLastSelection: boolean, component: string) =>
-  preserveLastSelection
-    ? { path: '/', component }
-    : { path: '/', redirect: '/stream' };
+  preserveLastSelection ? { path: '/', component } : { path: '/', redirect: '/stream' };

--- a/chat2db-community-client/src/utils/mainPageNavigation.ts
+++ b/chat2db-community-client/src/utils/mainPageNavigation.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_MAIN_PAGE_ACTIVE_TAB = 'workspace';
 
-const RESTORABLE_MAIN_PAGE_TABS = new Set(['stream', 'workspace', 'dashboard']);
+const RESTORABLE_MAIN_PAGE_TABS = ['stream', 'workspace', 'dashboard'] as const;
+const RESTORABLE_MAIN_PAGE_TAB_SET = new Set<string>(RESTORABLE_MAIN_PAGE_TABS);
 
 const normalizeMainPagePath = (routePath?: string) => {
   const hashlessPath = (routePath || '').replace(/^#/, '');
@@ -20,20 +21,28 @@ export const readPersistedMainPageActiveTab = (serializedStore?: string | null) 
 
   try {
     const page = JSON.parse(serializedStore)?.state?.mainPageActiveTab;
-    return typeof page === 'string' && RESTORABLE_MAIN_PAGE_TABS.has(page) ? page : undefined;
+    return typeof page === 'string' && RESTORABLE_MAIN_PAGE_TAB_SET.has(page) ? page : undefined;
   } catch {
     return undefined;
   }
 };
 
-export const resolveDesktopInitialMainPage = (routePath?: string, persistedPage?: string) => {
+export const resolveDesktopInitialMainPage = (
+  routePath?: string,
+  persistedPage?: string,
+  availablePages: readonly string[] = RESTORABLE_MAIN_PAGE_TABS,
+) => {
   const normalizedPath = normalizeMainPagePath(routePath);
   const routeSegments = normalizedPath.split('/').filter(Boolean);
   const routePage = routeSegments[0] || '';
   const restoresLastSelection =
-    routeSegments.length === 0 || (routeSegments.length === 1 && RESTORABLE_MAIN_PAGE_TABS.has(routePage));
+    routeSegments.length === 0 || (routeSegments.length === 1 && RESTORABLE_MAIN_PAGE_TAB_SET.has(routePage));
+  const availablePageSet = new Set(availablePages);
+  const restoredPage = [persistedPage, routePage, DEFAULT_MAIN_PAGE_ACTIVE_TAB, ...availablePages].find(
+    (candidate) => candidate && availablePageSet.has(candidate),
+  );
   const page = restoresLastSelection
-    ? persistedPage || routePage || DEFAULT_MAIN_PAGE_ACTIVE_TAB
+    ? restoredPage || DEFAULT_MAIN_PAGE_ACTIVE_TAB
     : routePage || persistedPage || DEFAULT_MAIN_PAGE_ACTIVE_TAB;
 
   return {


### PR DESCRIPTION
## Summary

- restore the last selected Stream, Workspace, or Dashboard page on Community desktop startup
- read persisted Zustand state directly to avoid startup initialization order overwriting the selection
- preserve explicit deep-link paths and normalize the restored hash

## Validation

- yarn test:main-page-navigation
- targeted ESLint and Prettier
- git diff --check
- yarn build:web:community --app_version=5.3.3
- temporary packaged App dist replacement and manual cold-start verification