### PR TITLE
fix(client): share updated main navigation icons

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -63,7 +63,7 @@
     "test:local-file-tab-title": "tsx src/pages/main/workspace/utils/localTextFile.test.ts",
     "test:local-file-tab-refresh": "tsx src/store/workspace/utils/localFileWorkspaceTab.test.ts",
     "test:local-file-encoding": "tsx src/utils/localFileEncoding.test.ts && yarn test:local-file-tab-refresh && tsx src/store/workspace/utils/workspaceTabPersistence.test.ts",
-    "test:main-page-navigation": "tsx src/utils/mainPageNavigation.test.ts",
+    "test:main-page-navigation": "tsx src/utils/mainPageNavigation.test.ts && tsx src/pages/main/navigationItems.test.ts",
     "test:sql-completion-context": "tsx src/components/SQLEditor/core/sqlCompletionContext.test.ts",
     "test:sql-in-clipboard": "tsx src/utils/sqlInClipboard.test.ts && tsx src/components/SQLEditor/helper/sqlInsertValueDefaults.test.ts",
     "test:console-tab-name": "tsx src/store/workspace/utils/consoleTabName.test.ts",

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -1,6 +1,5 @@
 import { Confetti, IconButton, IconfontSvg } from '@chat2db/ui';
 import { Tooltip, type InputRef } from 'antd';
-import { Layers, LayoutDashboard, MessageSquarePlus } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import i18n from '@/i18n';
@@ -21,6 +20,7 @@ import StreamSidebar from './components/StreamSidebar';
 
 import Dashboard from './dashboard';
 import DashboardMenuList from './dashboard/DashboardMenuList';
+import { createCoreMainNavItems } from './navigationItems';
 import Workspace from './workspace';
 import Stream from '../stream';
 
@@ -43,29 +43,12 @@ function CommunityMainPage() {
   const [navConfig, setNavConfig] = useState<INavItem[]>([]);
 
   const initNavConfig: INavItem[] = useMemo(
-    () => [
-      {
-        key: 'stream',
-        icon: MessageSquarePlus,
-        isLoad: false,
-        component: <Stream />,
-        name: i18n('stream.nav.title'),
-      },
-      {
-        key: 'workspace',
-        icon: Layers,
-        isLoad: false,
-        component: <Workspace />,
-        name: i18n('workspace.title'),
-      },
-      {
-        key: 'dashboard',
-        icon: LayoutDashboard,
-        isLoad: false,
-        component: <Dashboard />,
-        name: i18n('dashboard.title'),
-      },
-    ],
+    () =>
+      createCoreMainNavItems({
+        stream: { component: <Stream />, name: i18n('stream.nav.title') },
+        workspace: { component: <Workspace />, name: i18n('workspace.title') },
+        dashboard: { component: <Dashboard />, name: i18n('dashboard.title') },
+      }),
     [],
   );
 

--- a/chat2db-community-client/src/pages/main/index.tsx
+++ b/chat2db-community-client/src/pages/main/index.tsx
@@ -27,6 +27,7 @@ import StreamSidebar from './components/StreamSidebar';
 // ----- block -----
 import Dashboard from './dashboard';
 import DashboardMenuList from './dashboard/DashboardMenuList';
+import { createCoreMainNavItems } from './navigationItems';
 import Workspace from './workspace';
 // import KnowledgeManagement from './knowledgeManagement';
 import Stream from '../stream';
@@ -55,27 +56,11 @@ function MainPage() {
 
   const initNavConfig: INavItem[] = useMemo(() => {
     return [
-      {
-        key: 'stream',
-        icon: 'icon-chat-alt-21',
-        isLoad: false,
-        component: <Stream />,
-        name: i18n('stream.nav.title'),
-      },
-      {
-        key: 'workspace',
-        icon: 'icon-gongxiang-',
-        isLoad: false,
-        component: <Workspace />,
-        name: i18n('workspace.title'),
-      },
-      {
-        key: 'dashboard',
-        icon: 'icon-chart-square-bar',
-        isLoad: false,
-        component: <Dashboard />,
-        name: i18n('dashboard.title'),
-      },
+      ...createCoreMainNavItems({
+        stream: { component: <Stream />, name: i18n('stream.nav.title') },
+        workspace: { component: <Workspace />, name: i18n('workspace.title') },
+        dashboard: { component: <Dashboard />, name: i18n('dashboard.title') },
+      }),
       // {
       //   key: 'knowledge-management',
       //   icon: 'icon-knowledge-management',
@@ -523,6 +508,7 @@ function MainPage() {
               return null;
             }
             const isActive = item.key === mainPageActiveTab && settingPageActiveTab === false;
+            const NavIcon = typeof item.icon === 'string' ? null : item.icon;
 
             if (!sidebarExpanded) {
               return (
@@ -532,10 +518,11 @@ function MainPage() {
                   key={item.key}
                   size={{
                     boxSize: 34,
-                    iconSize: 22,
+                    iconSize: NavIcon ? 18 : 22,
                   }}
                   title={item.name}
-                  code={item.icon}
+                  code={NavIcon ? undefined : item.icon}
+                  icon={NavIcon || undefined}
                   tooltipPlacement="right"
                   onClick={() => handleNavItemClick(item)}
                 />
@@ -548,7 +535,11 @@ function MainPage() {
                 className={cx(styles.navItem, isActive && styles.navItemActive)}
                 onClick={() => handleNavItemClick(item)}
               >
-                <IconfontSvg code={item.icon} className={styles.navItemIcon} size={20} />
+                {NavIcon ? (
+                  <NavIcon className={styles.navItemIcon} size={18} />
+                ) : (
+                  <IconfontSvg code={item.icon} className={styles.navItemIcon} size={20} />
+                )}
                 <span className={styles.navItemLabel}>{item.name}</span>
               </div>
             );

--- a/chat2db-community-client/src/pages/main/navigationItems.test.ts
+++ b/chat2db-community-client/src/pages/main/navigationItems.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { Layers, LayoutDashboard, MessageSquarePlus } from 'lucide-react';
+
+import { CORE_MAIN_NAV_KEYS, createCoreMainNavItems } from './navigationItems';
+
+const items = createCoreMainNavItems({
+  stream: { component: 'stream-component', name: 'Stream' },
+  workspace: { component: 'workspace-component', name: 'Workspace' },
+  dashboard: { component: 'dashboard-component', name: 'Dashboard' },
+});
+
+assert.deepEqual(
+  items.map((item) => item.key),
+  CORE_MAIN_NAV_KEYS,
+  'shared main navigation should keep the Stream, Workspace, Dashboard order',
+);
+assert.strictEqual(items[0].icon, MessageSquarePlus, 'Stream should use the semantic Lucide icon');
+assert.strictEqual(items[1].icon, Layers, 'Workspace should use the semantic Lucide icon');
+assert.strictEqual(items[2].icon, LayoutDashboard, 'Dashboard should use the semantic Lucide icon');
+assert.ok(
+  items.every((item) => item.isLoad === false),
+  'shared navigation items should remain lazy by default',
+);
+
+for (const page of ['src/pages/main/CommunityMainPage.tsx', 'src/pages/main/index.tsx']) {
+  assert.match(
+    readFileSync(page, 'utf8'),
+    /createCoreMainNavItems/,
+    `${page} should consume the shared core navigation definition`,
+  );
+}
+
+const commercialMainPage = readFileSync('src/pages/main/index.tsx', 'utf8');
+assert.match(commercialMainPage, /icon: 'icon-a-xunwen1'/, 'Team should keep its existing iconfont icon');
+for (const retiredIconCode of ['icon-chat-alt-21', 'icon-gongxiang-', 'icon-chart-square-bar']) {
+  assert.doesNotMatch(
+    commercialMainPage,
+    new RegExp(retiredIconCode),
+    `commercial main navigation should not use ${retiredIconCode}`,
+  );
+}
+
+console.log('Main navigation item tests passed.');

--- a/chat2db-community-client/src/pages/main/navigationItems.ts
+++ b/chat2db-community-client/src/pages/main/navigationItems.ts
@@ -1,0 +1,32 @@
+import { Layers, LayoutDashboard, MessageSquarePlus } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import type { INavItem } from '@/typings/main';
+
+export const CORE_MAIN_NAV_KEYS = ['stream', 'workspace', 'dashboard'] as const;
+
+type CoreMainNavKey = (typeof CORE_MAIN_NAV_KEYS)[number];
+
+type CoreMainNavContent = Record<
+  CoreMainNavKey,
+  {
+    component: ReactNode;
+    name: string;
+  }
+>;
+
+export const CORE_MAIN_NAV_ICONS = {
+  stream: MessageSquarePlus,
+  workspace: Layers,
+  dashboard: LayoutDashboard,
+} as const;
+
+export function createCoreMainNavItems(content: CoreMainNavContent): INavItem[] {
+  return CORE_MAIN_NAV_KEYS.map((key) => ({
+    key,
+    icon: CORE_MAIN_NAV_ICONS[key],
+    isLoad: false,
+    component: content[key].component,
+    name: content[key].name,
+  }));
+}


### PR DESCRIPTION
Updates Stream, Workspace, and Dashboard to use the shared Lucide navigation icons in both Community and commercial main pages.\n\nTests: yarn test:main-page-navigation; targeted Prettier and ESLint checks.