### PR TITLE
fix(client): sync value inspector with record field

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -9,7 +9,7 @@ import useSqlExecutor from '@/hooks/useSqlExecutor';
 import executeSql from '@/service/executeSql';
 import SQLPreviewExecute, { SQLPreviewExecuteRef } from '../SQLPreviewExecute';
 import ViewData, { ViewDataRef } from '../ViewData';
-import RowDetail, { IChangeDataParams, RowDetailRef } from '../RowDetail';
+import RowDetail, { IChangeDataParams, IViewDataParams, RowDetailRef } from '../RowDetail';
 import SelectionAggregates from '../SelectionAggregates';
 import { IManageResultData } from '@/typings';
 import { Button, Spin, Tabs, Tooltip } from 'antd';
@@ -529,6 +529,16 @@ export default memo<IProps>(
       });
     }, [isResultFieldFrozen]);
 
+    const handleRowDetailActiveFieldChange = useCallback((params: IViewDataParams) => {
+      setLastActiveCell({
+        tableInstance: params.tableInstance,
+        col: params.col,
+        row: params.row,
+        rowId: params.rowId,
+        field: params.field,
+      });
+    }, []);
+
     const handleSelectionChange = useCallback(
       (selection: IResultSetSelection) => {
         setSelectedValues(selection.values);
@@ -636,6 +646,7 @@ export default memo<IProps>(
               ref={mode === 'sidebar' ? sidebarRowDetailRef : modalRowDetailRef}
               resultData={resultData}
               isFieldReadOnly={isResultFieldFrozen}
+              onActiveFieldChange={handleRowDetailActiveFieldChange}
               onChangeData={handleRowDetailChangeData}
               onViewData={openValueInspector}
             />

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
@@ -45,6 +45,14 @@ const resultTableStyleSource = readFileSync(
   'src/blocks/SearchResult/components/ResultSetTable/style.ts',
   'utf8',
 );
+const rowDetailSource = readFileSync(
+  'src/blocks/SearchResult/components/RowDetail/index.tsx',
+  'utf8',
+);
+const resultSetSource = readFileSync(
+  'src/blocks/SearchResult/components/ResultSet/index.tsx',
+  'utf8',
+);
 
 test('more-tabs and export chevrons share one aligned trailing slot', () => {
   assert.match(exportBarSource, /<DropdownChevronTrigger>\{i18n\('common\.text\.export'\)\}/);
@@ -101,6 +109,12 @@ test('result search escape and close action use the same close lifecycle', () =>
   });
 
   assert.deepEqual(calls, ['close']);
+});
+
+test('record field focus updates the cell used by the value inspector', () => {
+  assert.match(rowDetailSource, /onFocus=\{\(\) => handleFieldActivate\(item\)\}/);
+  assert.match(rowDetailSource, /onActiveFieldChange\?\.\(\{[\s\S]*?field: item\.field,[\s\S]*?\}\);/);
+  assert.match(resultSetSource, /onActiveFieldChange=\{handleRowDetailActiveFieldChange\}/);
 });
 
 test('column metadata contains each available name, type, and comment row', () => {

--- a/chat2db-community-client/src/blocks/SearchResult/components/RowDetail/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/RowDetail/index.tsx
@@ -49,6 +49,7 @@ interface IRowDetailState {
 interface IProps {
   resultData: IManageResultData;
   isFieldReadOnly?: (field: string) => boolean;
+  onActiveFieldChange?: (params: IViewDataParams) => void;
   onViewData?: (params: IViewDataParams) => void;
   onChangeData?: (params: IChangeDataParams) => void;
 }
@@ -72,7 +73,7 @@ const formatValue = (value: any, cellMeta?: IResultCell) => {
 };
 
 const RowDetail = forwardRef((props: IProps, ref: ForwardedRef<RowDetailRef>) => {
-  const { resultData, isFieldReadOnly, onViewData, onChangeData } = props;
+  const { resultData, isFieldReadOnly, onActiveFieldChange, onViewData, onChangeData } = props;
   const { styles, cx } = useStyles();
   const [rowDetail, setRowDetail] = useState<IRowDetailState | null>(null);
   const activeItemRef = useRef<HTMLDivElement>(null);
@@ -141,6 +142,21 @@ const RowDetail = forwardRef((props: IProps, ref: ForwardedRef<RowDetailRef>) =>
     });
   };
 
+  const handleFieldActivate = (item: IRowDetailItem) => {
+    if (!rowDetail) {
+      return;
+    }
+    setRowDetail((current) => (current ? { ...current, activeField: item.field } : current));
+    onActiveFieldChange?.({
+      tableInstance: rowDetail.tableInstance,
+      col: item.col,
+      row: rowDetail.row,
+      rowId: rowDetail.rowId,
+      field: item.field,
+      cellMeta: item.cellMeta,
+    });
+  };
+
   const handleValueChange = (field: string, value: string) => {
     setRowDetail((current) => {
       if (!current) {
@@ -189,6 +205,7 @@ const RowDetail = forwardRef((props: IProps, ref: ForwardedRef<RowDetailRef>) =>
                     placeholder={isNull ? '<null>' : undefined}
                     readOnly={!resultData.canEdit || item.largeValue || item.readOnly || !onChangeData}
                     className={cx(styles.valueInput, isActive && styles.activeValueInput, isNull && styles.nullValue)}
+                    onFocus={() => handleFieldActivate(item)}
                     onChange={(event) => handleValueChange(item.field, event.target.value)}
                     onBlur={() => handleValueBlur(item)}
                   />


### PR DESCRIPTION
## Summary

- Treat the focused Record input as the active result field.
- Keep Value and inspector mode switches aligned with that field instead of the original grid cell.
- Add a regression assertion for the Record-to-Value handoff.

## Verification

- yarn test:result-set-ui
- yarn test:result-inspector
- targeted ESLint
- git diff --check