### PR TITLE
fix: preserve result inspector field and mode

### DIFF
--- a/chat2db-community-client/src/blocks/CanvasTable/index.tsx
+++ b/chat2db-community-client/src/blocks/CanvasTable/index.tsx
@@ -42,6 +42,7 @@ interface IProps {
   onInit?: (tableInstance: ITableInstance) => void;
   onCopy?: () => void;
   onPaste?: () => void;
+  onPointerDown?: React.PointerEventHandler<HTMLDivElement>;
 }
 
 export interface CanvasTableRef {
@@ -83,7 +84,18 @@ function isEditableElement(target: EventTarget | null): boolean {
 }
 
 const CanvasTable = forwardRef((props: IProps, ref: ForwardedRef<CanvasTableRef>) => {
-  const { className, records, columns, onInit, tooltip, options = null, customOptions, onCopy, onPaste } = props;
+  const {
+    className,
+    records,
+    columns,
+    onInit,
+    tooltip,
+    options = null,
+    customOptions,
+    onCopy,
+    onPaste,
+    onPointerDown,
+  } = props;
   const { styles, theme, cx } = useStyles();
   const [tableInstance, setTableInstance] = useState<ITableInstance | null>(null);
   const tableRef = useRef<HTMLDivElement>(null);
@@ -275,7 +287,11 @@ const CanvasTable = forwardRef((props: IProps, ref: ForwardedRef<CanvasTableRef>
   }));
 
   return (
-    <div className={cx(className, styles.container)} ref={containerRef}>
+    <div
+      className={cx(className, styles.container)}
+      ref={containerRef}
+      onPointerDown={onPointerDown}
+    >
       <div ref={tableRef} className={styles.table} />
       <ContextMenu ref={contextMenuRef} />
       {tooltipTongs}

--- a/chat2db-community-client/src/blocks/CanvasTable/index.tsx
+++ b/chat2db-community-client/src/blocks/CanvasTable/index.tsx
@@ -42,6 +42,7 @@ interface IProps {
   onInit?: (tableInstance: ITableInstance) => void;
   onCopy?: () => void;
   onPaste?: () => void;
+  onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
   onPointerDown?: React.PointerEventHandler<HTMLDivElement>;
 }
 
@@ -94,6 +95,7 @@ const CanvasTable = forwardRef((props: IProps, ref: ForwardedRef<CanvasTableRef>
     customOptions,
     onCopy,
     onPaste,
+    onKeyDown,
     onPointerDown,
   } = props;
   const { styles, theme, cx } = useStyles();
@@ -290,6 +292,7 @@ const CanvasTable = forwardRef((props: IProps, ref: ForwardedRef<CanvasTableRef>
     <div
       className={cx(className, styles.container)}
       ref={containerRef}
+      onKeyDown={onKeyDown}
       onPointerDown={onPointerDown}
     >
       <div ref={tableRef} className={styles.table} />

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -30,12 +30,16 @@ import { useGlobalStore } from '@/store/global';
 import { useAIStore } from '@/store/ai';
 import { useWorkspaceStore } from '@/store/workspace';
 import {
-  DEFAULT_RESULT_INSPECTOR_MODE,
+  createResultInspectorModeStorageKey,
   getResultInspectorTabs,
+  getResultInspectorPreferenceStorage,
   getWorkspaceResultInspectorCode,
+  persistResultInspectorMode,
+  readResultInspectorMode,
   ResultInspectorMode,
   ResultInspectorTab,
   shouldClearInactiveResultInspector,
+  subscribeResultInspectorMode,
   toggleResultInspectorMode,
   WORKSPACE_RESULT_INSPECTOR_PORTAL_ID,
 } from '@/store/workspace/utils/resultInspector';
@@ -50,12 +54,19 @@ import {
   getResultCellMetaAtTableColumn,
   getResultFieldAtTableColumn,
 } from '../ResultSetTable/columnState';
+import { resolveResultInspectorActiveCell } from '../ResultSetTable/selectionState';
+import { areResultCellValuesEquivalent } from './inspectorState';
 
 interface IProps {
   resultData: IManageResultData;
   active: boolean;
   viewTable?: boolean;
 }
+
+const RESULT_INSPECTOR_MODE_STORAGE_KEY = createResultInspectorModeStorageKey(
+  'community',
+  __RUNTIME_ENV__,
+);
 
 export default memo<IProps>(
   (props) => {
@@ -82,13 +93,20 @@ export default memo<IProps>(
     const feSearchRef = useRef<FESearchRef>(null);
     const [orderByText, setOrderByText] = useState<string>('');
     const [submitLoading, setSubmitLoading] = useState(false);
-    const [inspectorMode, setInspectorMode] = useState<ResultInspectorMode>(DEFAULT_RESULT_INSPECTOR_MODE);
+    const [inspectorMode, setInspectorMode] = useState<ResultInspectorMode>(() =>
+      readResultInspectorMode(
+        getResultInspectorPreferenceStorage(),
+        RESULT_INSPECTOR_MODE_STORAGE_KEY,
+      ),
+    );
     const [inspectorTab, setInspectorTab] = useState<ResultInspectorTab>('row');
     const [inspectorModalOpen, setInspectorModalOpen] = useState(false);
     const [inspectorPortalTarget, setInspectorPortalTarget] = useState<HTMLElement | null>(null);
     const [selectedValues, setSelectedValues] = useState<unknown[]>([]);
     const [selectedRowCount, setSelectedRowCount] = useState(0);
-    const [lastActiveCell, setLastActiveCell] = useState<IResultSetSelection['activeCell']>();
+    const lastActiveCellRef = useRef<IResultSetSelection['activeCell']>();
+    const inspectorActiveCellRef = useRef<IResultSetSelection['activeCell']>();
+    const inspectorOpenInteractionRevisionRef = useRef(0);
     const currentWorkspaceExtend = useWorkspaceStore((state) => state.currentWorkspaceExtend);
     const inspectorExtendCode = useMemo(() => getWorkspaceResultInspectorCode(searchAreaId), [searchAreaId]);
     const inspectorSidebarOpen = currentWorkspaceExtend === inspectorExtendCode;
@@ -99,6 +117,21 @@ export default memo<IProps>(
       [shortcutOverrides],
     );
 
+    const setLastActiveCell = useCallback((activeCell: IResultSetSelection['activeCell']) => {
+      lastActiveCellRef.current = activeCell;
+    }, []);
+
+    const setInspectorActiveCell = useCallback((activeCell: IResultSetSelection['activeCell']) => {
+      inspectorActiveCellRef.current = activeCell;
+      lastActiveCellRef.current = activeCell;
+    }, []);
+
+    const clearActiveCell = useCallback(() => {
+      inspectorActiveCellRef.current = undefined;
+      lastActiveCellRef.current = undefined;
+      inspectorOpenInteractionRevisionRef.current = 0;
+    }, []);
+
     useEffect(() => {
       setResultData(props.resultData);
     }, [props.resultData]);
@@ -106,21 +139,32 @@ export default memo<IProps>(
     useEffect(() => {
       setSelectedValues([]);
       setSelectedRowCount(0);
-      setLastActiveCell(undefined);
+      clearActiveCell();
       setInspectorModalOpen(false);
       const workspaceStore = useWorkspaceStore.getState();
       if (workspaceStore.currentWorkspaceExtend === inspectorExtendCode) {
         workspaceStore.setCurrentWorkspaceExtend(null);
       }
-    }, [inspectorExtendCode, resultData]);
+    }, [clearActiveCell, inspectorExtendCode, resultData]);
 
     const closeInspector = useCallback(() => {
+      clearActiveCell();
       setInspectorModalOpen(false);
       const workspaceStore = useWorkspaceStore.getState();
       if (workspaceStore.currentWorkspaceExtend === inspectorExtendCode) {
         workspaceStore.setCurrentWorkspaceExtend(null);
       }
-    }, [inspectorExtendCode]);
+    }, [clearActiveCell, inspectorExtendCode]);
+
+    useEffect(
+      () =>
+        subscribeResultInspectorMode((storageKey, mode) => {
+          if (storageKey === RESULT_INSPECTOR_MODE_STORAGE_KEY) {
+            setInspectorMode(mode);
+          }
+        }),
+      [],
+    );
 
     useEffect(() => {
       const workspaceStore = useWorkspaceStore.getState();
@@ -396,7 +440,9 @@ export default memo<IProps>(
               ? record?.__CHAT2DB_CELL_META__?.[Number(field)]
               : getResultCellMetaAtTableColumn(params.tableInstance, record, recordCol, params.row)),
         };
-        setLastActiveCell({
+        inspectorOpenInteractionRevisionRef.current =
+          resultSetTableRef.current?.getInteractionRevision() ?? 0;
+        setInspectorActiveCell({
           tableInstance: params.tableInstance,
           col: tableCol,
           row: params.row,
@@ -414,7 +460,7 @@ export default memo<IProps>(
           });
         }, 0);
       },
-      [activateInspector, inspectorMode, isResultFieldFrozen, resultData?.canEdit],
+      [activateInspector, inspectorMode, isResultFieldFrozen, resultData?.canEdit, setInspectorActiveCell],
     );
 
     const openRowInspector = useCallback((params) => {
@@ -424,7 +470,9 @@ export default memo<IProps>(
       const field = params.field || getResultFieldAtTableColumn(params.tableInstance, params.col, params.row);
       const tableCol = field ? params.tableInstance.getTableIndexByField(field) : params.col;
       const record = params.tableInstance.getRecordByCell(tableCol >= 1 ? tableCol : 1, params.row);
-      setLastActiveCell({
+      inspectorOpenInteractionRevisionRef.current =
+        resultSetTableRef.current?.getInteractionRevision() ?? 0;
+      setInspectorActiveCell({
         tableInstance: params.tableInstance,
         col: tableCol,
         row: params.row,
@@ -437,7 +485,7 @@ export default memo<IProps>(
         const targetRef = targetMode === 'sidebar' ? sidebarRowDetailRef : modalRowDetailRef;
         targetRef.current?.openPanel(params);
       }, 0);
-    }, [activateInspector, inspectorMode]);
+    }, [activateInspector, inspectorMode, setInspectorActiveCell]);
 
     const onTableOperationUtils = useMemo(() => {
       return {
@@ -509,7 +557,7 @@ export default memo<IProps>(
       if (
         !originData ||
         originData.__CHAT2DB_CELL_META__?.[Number(sourceField)]?.largeValue ||
-        currentValue === value
+        areResultCellValuesEquivalent(currentValue, value)
       ) {
         return;
       }
@@ -530,45 +578,76 @@ export default memo<IProps>(
     }, [isResultFieldFrozen]);
 
     const handleRowDetailActiveFieldChange = useCallback((params: IViewDataParams) => {
-      setLastActiveCell({
+      setInspectorActiveCell({
         tableInstance: params.tableInstance,
         col: params.col,
         row: params.row,
         rowId: params.rowId,
         field: params.field,
       });
-    }, []);
+    }, [setInspectorActiveCell]);
 
     const handleSelectionChange = useCallback(
       (selection: IResultSetSelection) => {
         setSelectedValues(selection.values);
         setSelectedRowCount(selection.rowCount);
-        if (!selection.activeCell) {
-          setLastActiveCell(undefined);
+        const preserveInspectorForTableSelection =
+          selection.cause === 'table-selection' &&
+          !!inspectorActiveCellRef.current &&
+          selection.interactionRevision <= inspectorOpenInteractionRevisionRef.current;
+        const activeCell = resolveResultInspectorActiveCell(
+          inspectorActiveCellRef.current,
+          selection.activeCell,
+          selection.cause,
+          preserveInspectorForTableSelection,
+        );
+        if (selection.cause === 'table-selection' && !preserveInspectorForTableSelection) {
+          inspectorActiveCellRef.current = undefined;
+        }
+        if (!activeCell) {
+          clearActiveCell();
           closeInspector();
           return;
         }
-        setLastActiveCell(selection.activeCell);
+        setLastActiveCell(activeCell);
+        if (
+          inspectorActiveCellRef.current &&
+          (selection.cause === 'value-change' || preserveInspectorForTableSelection)
+        ) {
+          return;
+        }
         if (inspectorOpen) {
           if (inspectorTab === 'row') {
             const targetRef = inspectorMode === 'sidebar' ? sidebarRowDetailRef : modalRowDetailRef;
-            targetRef.current?.openPanel(selection.activeCell);
+            targetRef.current?.openPanel(activeCell);
           } else if (inspectorTab === 'value') {
-            openValueInspector(selection.activeCell);
+            openValueInspector(activeCell);
           }
         }
       },
-      [closeInspector, inspectorMode, inspectorOpen, inspectorTab, openValueInspector],
+      [
+        clearActiveCell,
+        closeInspector,
+        inspectorMode,
+        inspectorOpen,
+        inspectorTab,
+        openValueInspector,
+        setLastActiveCell,
+      ],
     );
 
     const handleInspectorTabChange = useCallback(
       (key: string, targetMode: ResultInspectorMode = inspectorMode) => {
         const nextTab = key as ResultInspectorTab;
         setInspectorTab(nextTab);
-        if (nextTab === 'aggregates' || !lastActiveCell) {
+        if (nextTab === 'aggregates') {
           return;
         }
         setTimeout(() => {
+          const lastActiveCell = lastActiveCellRef.current;
+          if (!lastActiveCell) {
+            return;
+          }
           const field =
             lastActiveCell.field ||
             getResultFieldAtTableColumn(lastActiveCell.tableInstance, lastActiveCell.col, lastActiveCell.row);
@@ -583,7 +662,7 @@ export default memo<IProps>(
             lastActiveCell.rowId !== undefined &&
             String(record?.CHAT2DB_ROW_NUMBER) !== String(lastActiveCell.rowId)
           ) {
-            setLastActiveCell(undefined);
+            clearActiveCell();
             closeInspector();
             return;
           }
@@ -603,11 +682,16 @@ export default memo<IProps>(
           });
         }, 0);
       },
-      [closeInspector, inspectorMode, isResultFieldFrozen, lastActiveCell, resultData?.canEdit],
+      [clearActiveCell, closeInspector, inspectorMode, isResultFieldFrozen, resultData?.canEdit],
     );
 
     const handleInspectorModeSwitch = useCallback(() => {
       const nextMode = toggleResultInspectorMode(inspectorMode);
+      persistResultInspectorMode(
+        getResultInspectorPreferenceStorage(),
+        RESULT_INSPECTOR_MODE_STORAGE_KEY,
+        nextMode,
+      );
       activateInspector(inspectorTab, nextMode);
       handleInspectorTabChange(inspectorTab, nextMode);
     }, [activateInspector, handleInspectorTabChange, inspectorMode, inspectorTab]);

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/inspectorState.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/inspectorState.ts
@@ -1,0 +1,6 @@
+export function areResultCellValuesEquivalent(currentValue: unknown, nextValue: string | null) {
+  if (currentValue === null || currentValue === undefined || nextValue === null) {
+    return (currentValue === null || currentValue === undefined) && nextValue === null;
+  }
+  return String(currentValue) === nextValue;
+}

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
@@ -23,7 +23,11 @@ import {
   orderResultColumns,
   updateHiddenResultColumnFields,
 } from '../ResultSetTable/columnState';
-import { resolveResultSelectionActiveCell } from '../ResultSetTable/selectionState';
+import {
+  resolveResultInspectorActiveCell,
+  resolveResultSelectionActiveCell,
+} from '../ResultSetTable/selectionState';
+import { areResultCellValuesEquivalent } from './inspectorState';
 import {
   isResultHeaderContext,
   joinContextMenuGroups,
@@ -115,6 +119,40 @@ test('record field focus updates the cell used by the value inspector', () => {
   assert.match(rowDetailSource, /onFocus=\{\(\) => handleFieldActivate\(item\)\}/);
   assert.match(rowDetailSource, /onActiveFieldChange\?\.\(\{[\s\S]*?field: item\.field,[\s\S]*?\}\);/);
   assert.match(resultSetSource, /onActiveFieldChange=\{handleRowDetailActiveFieldChange\}/);
+  assert.match(resultSetSource, /const lastActiveCell = lastActiveCellRef\.current;/);
+});
+
+test('unchanged typed values do not produce a row-detail cell update', () => {
+  assert.equal(areResultCellValuesEquivalent(42, '42'), true);
+  assert.equal(areResultCellValuesEquivalent(true, 'true'), true);
+  assert.equal(areResultCellValuesEquivalent(false, 'false'), true);
+  assert.equal(areResultCellValuesEquivalent(null, null), true);
+  assert.equal(areResultCellValuesEquivalent(undefined, null), true);
+  assert.equal(areResultCellValuesEquivalent(42, '43'), false);
+  assert.equal(areResultCellValuesEquivalent(null, ''), false);
+});
+
+test('value refresh preserves the inspector field while real table selection replaces it', () => {
+  const inspectorField = { row: 1, field: '2' };
+  const oldTableField = { row: 1, field: '1' };
+  const newTableField = { row: 2, field: '3' };
+
+  assert.equal(
+    resolveResultInspectorActiveCell(inspectorField, oldTableField, 'value-change'),
+    inspectorField,
+  );
+  assert.equal(
+    resolveResultInspectorActiveCell(inspectorField, newTableField, 'table-selection'),
+    newTableField,
+  );
+  assert.equal(
+    resolveResultInspectorActiveCell(inspectorField, oldTableField, 'table-selection', true),
+    inspectorField,
+  );
+  assert.equal(
+    resolveResultInspectorActiveCell(undefined, newTableField, 'value-change'),
+    newTableField,
+  );
 });
 
 test('column metadata contains each available name, type, and comment row', () => {

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
@@ -155,6 +155,15 @@ test('value refresh preserves the inspector field while real table selection rep
   );
 });
 
+test('result table advances inspector interaction revisions for pointer and keyboard input', () => {
+  const resultSetTableSource = readFileSync(
+    'src/blocks/SearchResult/components/ResultSetTable/index.tsx',
+    'utf8',
+  );
+  assert.match(resultSetTableSource, /onPointerDown=\{handleTablePointerDown\}/);
+  assert.match(resultSetTableSource, /onKeyDown=\{handleTableKeyDown\}/);
+});
+
 test('column metadata contains each available name, type, and comment row', () => {
   assert.deepEqual(
     getHeaderMetadataRows({

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/index.tsx
@@ -388,6 +388,10 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
     interactionRevisionRef.current += 1;
   }, []);
 
+  const handleTableKeyDown = useCallback(() => {
+    interactionRevisionRef.current += 1;
+  }, []);
+
   return (
     <>
       <CanvasTable
@@ -397,6 +401,7 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
         className={styles.canvasTable}
         onCopy={onCopy}
         onPaste={onPaste}
+        onKeyDown={handleTableKeyDown}
         onPointerDown={handleTablePointerDown}
         customOptions={{ showFrozenColumnDivider: frozenColumnFields.length > 0 }}
         options={{

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/index.tsx
@@ -1,4 +1,14 @@
-import { memo, useEffect, useMemo, forwardRef, useImperativeHandle, ForwardedRef, useCallback, useState } from 'react';
+import {
+  memo,
+  useEffect,
+  useMemo,
+  forwardRef,
+  useImperativeHandle,
+  ForwardedRef,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
 import { useStyles } from './style';
 import CanvasTable from '@/blocks/CanvasTable';
 import { ITableInstance } from '@/blocks/CanvasTable/typings';
@@ -24,7 +34,7 @@ import {
   reconcileHiddenResultColumnFields,
   getResultFieldAtTableColumn,
 } from './columnState';
-import { resolveResultSelectionActiveCell } from './selectionState';
+import { resolveResultSelectionActiveCell, ResultSelectionCause } from './selectionState';
 
 interface IProps {
   className?: string;
@@ -43,6 +53,8 @@ interface IProps {
 export interface IResultSetSelection {
   values: unknown[];
   rowCount: number;
+  cause: ResultSelectionCause;
+  interactionRevision: number;
   activeCell?: {
     tableInstance: ITableInstance;
     col: number;
@@ -59,6 +71,7 @@ export interface ResultSetTableRef {
   clearAllFilters: () => void;
   isFieldFrozen: (field: string | number) => boolean;
   openColumnVisibility: () => void;
+  getInteractionRevision: () => number;
 }
 
 const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTableRef>) => {
@@ -68,6 +81,7 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
   const [frozenColumnFields, setFrozenColumnFields] = useState<string[]>([]);
   const [columnOrder, setColumnOrder] = useState<string[]>([]);
   const [columnVisibilityOpen, setColumnVisibilityOpen] = useState(false);
+  const interactionRevisionRef = useRef(0);
   const { customFontSize, showFieldType, showFieldComment } = useGlobalStore((state) => ({
     customFontSize: state.baseSetting.customFontSize ?? 13,
     showFieldType: state.dataTableSettings.showFieldType ?? true,
@@ -143,8 +157,14 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
   const records = useMemo(() => buildResultRecords(resultData), [resultData]);
 
   const clearColumnSensitiveSelection = useCallback(() => {
+    interactionRevisionRef.current += 1;
     tableInstance?.clearSelected();
-    props.onSelectionChange?.({ values: [], rowCount: 0 });
+    props.onSelectionChange?.({
+      values: [],
+      rowCount: 0,
+      cause: 'table-selection',
+      interactionRevision: interactionRevisionRef.current,
+    });
   }, [props.onSelectionChange, tableInstance]);
 
   const handleColumnVisibilityConfirm = useCallback(
@@ -271,6 +291,7 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
 
     let frameId: number | null = null;
     let latestActiveCell: { col: number; row: number } | undefined;
+    let pendingCause: ResultSelectionCause = 'table-selection';
     const emitSelection = () => {
       frameId = null;
       const cells = (tableInstance.getSelectedCellInfos() || [])
@@ -282,6 +303,8 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
       props.onSelectionChange?.({
         values: cells.map((cell) => (cell.dataValue !== undefined ? cell.dataValue : cell.value)),
         rowCount: new Set(cells.map((cell) => cell.row)).size,
+        cause: pendingCause,
+        interactionRevision: interactionRevisionRef.current,
         activeCell: activeCell
           ? {
               tableInstance,
@@ -293,7 +316,13 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
           : undefined,
       });
     };
-    const scheduleSelection = (event?: { col?: number; row?: number }) => {
+    const scheduleSelection = (
+      cause: ResultSelectionCause,
+      event?: { col?: number; row?: number },
+    ) => {
+      if (cause === 'table-selection' || frameId === null) {
+        pendingCause = cause;
+      }
       if (
         event?.col !== undefined &&
         event?.row !== undefined &&
@@ -309,16 +338,16 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
     };
     const clearSelection = () => {
       latestActiveCell = undefined;
-      scheduleSelection();
+      scheduleSelection('table-selection');
     };
 
     const eventIds = [
-      tableInstance.on('selected_cell', scheduleSelection),
-      tableInstance.on('drag_select_end', scheduleSelection),
+      tableInstance.on('selected_cell', (event) => scheduleSelection('table-selection', event)),
+      tableInstance.on('drag_select_end', (event) => scheduleSelection('table-selection', event)),
       tableInstance.on('selected_clear', clearSelection),
-      tableInstance.on('change_cell_value', scheduleSelection),
+      tableInstance.on('change_cell_value', (event) => scheduleSelection('value-change', event)),
     ];
-    scheduleSelection();
+    scheduleSelection('table-selection');
 
     return () => {
       if (frameId !== null) {
@@ -341,6 +370,7 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
       clearAllFilters,
       isFieldFrozen: (field) => frozenColumnFields.includes(String(field)),
       openColumnVisibility: () => setColumnVisibilityOpen(true),
+      getInteractionRevision: () => interactionRevisionRef.current,
     };
   }, [operationRecordUtils, tableInstance, activeFilterCount, clearAllFilters, frozenColumnFields]);
 
@@ -354,6 +384,10 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
     onPasteData(tableInstance, operationRecordUtils, new Set(frozenColumnFields));
   }, [frozenColumnFields, tableInstance, operationRecordUtils]);
 
+  const handleTablePointerDown = useCallback(() => {
+    interactionRevisionRef.current += 1;
+  }, []);
+
   return (
     <>
       <CanvasTable
@@ -363,6 +397,7 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
         className={styles.canvasTable}
         onCopy={onCopy}
         onPaste={onPaste}
+        onPointerDown={handleTablePointerDown}
         customOptions={{ showFrozenColumnDivider: frozenColumnFields.length > 0 }}
         options={{
           rowSeriesNumber: {

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/selectionState.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/selectionState.ts
@@ -3,6 +3,8 @@ export interface ResultSelectionCellPosition {
   row: number;
 }
 
+export type ResultSelectionCause = 'table-selection' | 'value-change';
+
 export function resolveResultSelectionActiveCell(
   cells: readonly ResultSelectionCellPosition[],
   latestActiveCell?: ResultSelectionCellPosition,
@@ -15,4 +17,15 @@ export function resolveResultSelectionActiveCell(
   }
   const fallbackCell = cells[cells.length - 1];
   return fallbackCell ? { col: fallbackCell.col, row: fallbackCell.row } : undefined;
+}
+
+export function resolveResultInspectorActiveCell<T>(
+  inspectorActiveCell: T | undefined,
+  tableActiveCell: T | undefined,
+  cause: ResultSelectionCause,
+  preserveInspectorForTableSelection = false,
+): T | undefined {
+  return (cause === 'value-change' || preserveInspectorForTableSelection) && inspectorActiveCell
+    ? inspectorActiveCell
+    : tableActiveCell;
 }

--- a/chat2db-community-client/src/store/workspace/utils/resultInspector.test.ts
+++ b/chat2db-community-client/src/store/workspace/utils/resultInspector.test.ts
@@ -1,12 +1,17 @@
 import assert from 'node:assert/strict';
 import {
   DEFAULT_RESULT_INSPECTOR_MODE,
+  createResultInspectorModeStorageKey,
   getResultInspectorPanelSize,
+  getResultInspectorPreferenceStorage,
   getResultInspectorTabs,
   getWorkspaceResultInspectorCode,
   isWorkspaceResultInspectorCode,
   RESULT_INSPECTOR_MAX_PANEL_RATIO,
+  persistResultInspectorMode,
+  readResultInspectorMode,
   shouldClearInactiveResultInspector,
+  subscribeResultInspectorMode,
   toggleResultInspectorMode,
   WORKSPACE_RESULT_INSPECTOR_PORTAL_ID,
 } from './resultInspector';
@@ -30,5 +35,44 @@ assert.equal(toggleResultInspectorMode('sidebar'), 'modal');
 assert.equal(toggleResultInspectorMode('modal'), 'sidebar');
 assert.deepEqual(getResultInspectorTabs('sidebar'), ['row', 'value', 'aggregates']);
 assert.deepEqual(getResultInspectorTabs('modal'), ['row', 'value', 'aggregates']);
+
+const modeStorageKey = createResultInspectorModeStorageKey('community', 'desktop');
+assert.equal(modeStorageKey, 'chat2db.community.desktop.result-inspector.mode.v1');
+
+const values = new Map<string, string>();
+const storage = {
+  getItem: (key: string) => values.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    values.set(key, value);
+  },
+};
+assert.equal(readResultInspectorMode(storage, modeStorageKey), DEFAULT_RESULT_INSPECTOR_MODE);
+values.set(modeStorageKey, 'modal');
+assert.equal(readResultInspectorMode(storage, modeStorageKey), 'modal');
+values.set(modeStorageKey, 'invalid');
+assert.equal(readResultInspectorMode(storage, modeStorageKey), DEFAULT_RESULT_INSPECTOR_MODE);
+
+let notifiedMode: string | undefined;
+const unsubscribe = subscribeResultInspectorMode((storageKey, mode) => {
+  if (storageKey === modeStorageKey) {
+    notifiedMode = mode;
+  }
+});
+persistResultInspectorMode(storage, modeStorageKey, 'sidebar');
+unsubscribe();
+assert.equal(values.get(modeStorageKey), 'sidebar');
+assert.equal(notifiedMode, 'sidebar');
+
+const throwingStorage = {
+  getItem: () => {
+    throw new Error('unavailable');
+  },
+  setItem: () => {
+    throw new Error('unavailable');
+  },
+};
+assert.equal(readResultInspectorMode(throwingStorage, modeStorageKey), DEFAULT_RESULT_INSPECTOR_MODE);
+assert.doesNotThrow(() => persistResultInspectorMode(throwingStorage, modeStorageKey, 'modal'));
+assert.equal(getResultInspectorPreferenceStorage(), undefined);
 
 console.log('Workspace result inspector tests passed');

--- a/chat2db-community-client/src/store/workspace/utils/resultInspector.ts
+++ b/chat2db-community-client/src/store/workspace/utils/resultInspector.ts
@@ -5,11 +5,66 @@ export const RESULT_INSPECTOR_MAX_PANEL_RATIO = 0.5;
 export type ResultInspectorMode = 'sidebar' | 'modal';
 export type ResultInspectorTab = 'row' | 'value' | 'aggregates';
 
+export interface ResultInspectorPreferenceStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+type ResultInspectorModeListener = (storageKey: string, mode: ResultInspectorMode) => void;
+
 export const DEFAULT_RESULT_INSPECTOR_MODE: ResultInspectorMode = 'sidebar';
 
 const RESULT_INSPECTOR_TABS: ResultInspectorTab[] = ['row', 'value', 'aggregates'];
 
 const WORKSPACE_RESULT_INSPECTOR_PREFIX = 'resultInspector:';
+
+const modeListeners = new Set<ResultInspectorModeListener>();
+
+export function createResultInspectorModeStorageKey(clientEdition: string, runtimeEnv: string) {
+  return `chat2db.${clientEdition}.${runtimeEnv}.result-inspector.mode.v1`;
+}
+
+export function getResultInspectorPreferenceStorage(): ResultInspectorPreferenceStorage | undefined {
+  try {
+    return typeof window === 'undefined' ? undefined : window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readResultInspectorMode(
+  storage: ResultInspectorPreferenceStorage | undefined,
+  storageKey: string,
+): ResultInspectorMode {
+  try {
+    const storedValue = storage?.getItem(storageKey);
+    return storedValue === 'sidebar' || storedValue === 'modal'
+      ? storedValue
+      : DEFAULT_RESULT_INSPECTOR_MODE;
+  } catch {
+    return DEFAULT_RESULT_INSPECTOR_MODE;
+  }
+}
+
+export function persistResultInspectorMode(
+  storage: ResultInspectorPreferenceStorage | undefined,
+  storageKey: string,
+  mode: ResultInspectorMode,
+) {
+  try {
+    storage?.setItem(storageKey, mode);
+  } catch {
+    // Storage can be unavailable in restricted browser contexts.
+  }
+  modeListeners.forEach((listener) => listener(storageKey, mode));
+}
+
+export function subscribeResultInspectorMode(listener: ResultInspectorModeListener) {
+  modeListeners.add(listener);
+  return () => {
+    modeListeners.delete(listener);
+  };
+}
 
 export function getWorkspaceResultInspectorCode(ownerId: string) {
   return `${WORKSPACE_RESULT_INSPECTOR_PREFIX}${ownerId}`;


### PR DESCRIPTION
## Summary
- keep the Record field authoritative across delayed VTable selection and value refresh events
- avoid unchanged numeric and boolean blur writes
- persist the Community sidebar or dialog inspector preference per runtime

## Root cause
The original right-click selection could remain queued until the next animation frame. After a user focused another Record field, that stale table selection restored the original cell. Numeric and boolean values were also compared to submitted strings with strict equality, producing false cell-change events.

## Verification
- yarn test:result-set-ui (30 passed)
- yarn test:result-inspector
- targeted ESLint
- git diff --check
- hot webpack compilation
- Playwright: Record 202 -> Value 202 -> Record 202
- Playwright: a later real grid click moved focus to third
- Playwright: dialog and sidebar preferences survived reload and reopen