### PR TITLE
feat(mysql): expose DESC table targets to editor

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/parser/visitor/MysqlParserVisitor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/parser/visitor/MysqlParserVisitor.java
@@ -405,6 +405,18 @@ public class MysqlParserVisitor extends MySqlParserBaseVisitor<Void> {
 
 
     @Override
+    public Void visitSimpleDescribeStatement(MySqlParser.SimpleDescribeStatementContext ctx) {
+        Token command = ctx.command;
+        if (command == null || (command.getType() != MySqlParser.DESC && command.getType() != MySqlParser.DESCRIBE)) {
+            return super.visitSimpleDescribeStatement(ctx);
+        }
+        context.setStatementType(SqlTypeEnum.DESCRIBE);
+        visitTableNameContext(ctx.tableReferenceName().tableName());
+        return null;
+    }
+
+
+    @Override
     public Void visitUseStatement(MySqlParser.UseStatementContext ctx) {
         context.setStatementType(SqlTypeEnum.USE_DATABASE);
         MySqlParser.UidContext uid = ctx.databaseReferenceName().uid();

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/parser/MysqlDescribeStatementParserTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/parser/MysqlDescribeStatementParserTest.java
@@ -1,0 +1,81 @@
+package ai.chat2db.plugin.mysql.parser;
+
+import ai.chat2db.community.domain.api.enums.parser.IdentifierTypeEnum;
+import ai.chat2db.community.domain.api.enums.parser.SqlTypeEnum;
+import ai.chat2db.community.domain.api.model.parser.result.SqlParserResponse;
+import ai.chat2db.community.domain.api.model.parser.statement.Statement;
+import ai.chat2db.community.domain.api.model.parser.token.Identifier;
+import org.antlr.v4.runtime.Token;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MysqlDescribeStatementParserTest {
+
+    @Test
+    void parsesDescribeTargetsWithSourceRanges() {
+        assertDescribeTable("DESC user_info;", null, "user_info", "user_info");
+        assertDescribeTable("DESCRIBE user_info;", null, "user_info", "user_info");
+        assertDescribeTable("DESC user_info column_name;", null, "user_info", "user_info");
+        assertDescribeTable("DESC database_name.user_info;", "database_name", "user_info", ".user_info");
+        assertDescribeTable("DESCRIBE `database_name`.`user_info`;", "database_name", "user_info", "`user_info`");
+    }
+
+    @Test
+    void doesNotCreateTableIdentifiersForIncompleteDescribeStatements() {
+        assertNoTableIdentifier("DESC");
+        assertNoTableIdentifier("DESCRIBE;");
+    }
+
+    @Test
+    void preservesExplainTableBehavior() {
+        Statement statement = parseSingleStatement("EXPLAIN database_name.user_info;");
+
+        assertNull(statement.getType());
+        assertTrue(statement.getIdentifiers().isEmpty());
+    }
+
+    private void assertDescribeTable(String sql, String databaseName, String tableName, String sourceToken) {
+        Statement statement = parseSingleStatement(sql);
+        assertEquals(SqlTypeEnum.DESCRIBE.name(), statement.getType());
+
+        List<Identifier> tableIdentifiers = statement.getIdentifiers().stream()
+                .filter(identifier -> IdentifierTypeEnum.TABLE.name().equals(identifier.getIdentifierType()))
+                .toList();
+        assertEquals(1, tableIdentifiers.size());
+
+        Identifier tableIdentifier = tableIdentifiers.get(0);
+        assertEquals(tableName, tableIdentifier.getIdentifierName());
+        assertEquals(databaseName, tableIdentifier.getIdentifierDatabase());
+
+        Token token = tableIdentifier.getFirstToken();
+        assertEquals(sourceToken, token.getText());
+        assertEquals(sql.indexOf(sourceToken), token.getStartIndex());
+        assertEquals(sourceToken, sql.substring(token.getStartIndex(), token.getStopIndex() + 1));
+
+        if (databaseName == null) {
+            assertNull(tableIdentifier.getIdentifierDatabase());
+        } else {
+            assertTrue(statement.getIdentifiers().stream().anyMatch(identifier ->
+                    IdentifierTypeEnum.DATABASE.name().equals(identifier.getIdentifierType())
+                            && databaseName.equals(identifier.getIdentifierName())));
+        }
+    }
+
+    private void assertNoTableIdentifier(String sql) {
+        SqlParserResponse response = new MysqlSqlParser().parserStatements(sql);
+        assertFalse(response.getStatements().stream().flatMap(statement -> statement.getIdentifiers().stream())
+                .anyMatch(identifier -> IdentifierTypeEnum.TABLE.name().equals(identifier.getIdentifierType())));
+    }
+
+    private Statement parseSingleStatement(String sql) {
+        SqlParserResponse response = new MysqlSqlParser().parserStatements(sql);
+        assertEquals(1, response.getStatements().size());
+        return response.getStatements().get(0);
+    }
+}


### PR DESCRIPTION
Closes #2662. Adds MySQL DESC/DESCRIBE table identifiers to the existing SQL-editor hover and Ctrl/Cmd-click DDL path, without changing normal execution. Preserves EXPLAIN behavior and adds parser coverage for unqualified, qualified, quoted, optional-column, malformed, and EXPLAIN inputs. Validated locally with the MySQL parser test and on HandSonic/Chat2DB#23: frontend, backend, Java/JS CodeQL, SBOM, license, and repository checks are green.