### PR TITLE
fix: restore Local AI and dashboard behavior

### DIFF
--- a/chat2db-community-client/src/blocks/AI/components/AIModelSelect/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelSelect/index.tsx
@@ -9,7 +9,9 @@ import { SelectedModelOption } from '@/store/ai/slices/model/initialState';
 import {
   appendCustomModelEntryOption,
   isCustomModelEntryOption,
+  isModelOptionAvailable,
   ModelSelectOption,
+  shouldOpenCustomModelDirectly,
 } from './modelSelectOptions';
 
 interface AIModelSelectProps {
@@ -44,6 +46,10 @@ const AIModelSelect = ({
     }
   }, [options, modelList?.length]);
 
+  const selectOptions = options !== undefined ? options : modelList;
+  const openCustomModelDirectly =
+    !!onCustomModelClick && shouldOpenCustomModelDirectly(selectOptions, showCustomModelEntry);
+
   // Handle select change
   const handleChange = (selectedValue: { value: string; label: React.ReactNode }) => {
     if (isCustomModelEntryOption(selectedValue.value)) {
@@ -63,6 +69,9 @@ const AIModelSelect = ({
 
   // handles the drop-down box opening event
   const handleDropdownVisibleChange = (open: boolean) => {
+    if (open && openCustomModelDirectly) {
+      return;
+    }
     if (open && (!modelList || modelList.length === 0)) {
       if (options !== undefined) {
         return;
@@ -71,7 +80,24 @@ const AIModelSelect = ({
     }
   };
 
-  const selectOptions = options !== undefined ? options : modelList;
+  const handleDirectCustomModelMouseDown = (event: React.MouseEvent<HTMLElement>) => {
+    if (!openCustomModelDirectly) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    onCustomModelClick?.();
+  };
+
+  const handleDirectCustomModelKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!openCustomModelDirectly || !['Enter', ' ', 'ArrowDown'].includes(event.key)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    onCustomModelClick?.();
+  };
+
   const customModelEntry =
     showCustomModelEntry && onCustomModelClick ? (
       <div className={styles.customModelEntry}>
@@ -90,19 +116,27 @@ const AIModelSelect = ({
     customModelEntry,
     selectOptions?.length ? styles.customModelOption : undefined,
   );
+  const visibleSelectedModel =
+    options === undefined || isModelOptionAvailable(selectOptions, selectedModel) ? selectedModel : undefined;
+  const placeholder = showCustomModelEntry
+    ? customModelText || i18n('setting.modelConfig.entry')
+    : i18n('ai.select.model');
 
   return (
     <Select
       popupMatchSelectWidth={false}
       className={styles.modelSelect}
       popupClassName={styles.popupSelect}
+      open={openCustomModelDirectly ? false : undefined}
+      onMouseDown={handleDirectCustomModelMouseDown}
+      onKeyDown={handleDirectCustomModelKeyDown}
       variant="borderless"
       labelInValue
-      value={selectedModel && selectedModel.label ? selectedModel : undefined}
+      value={visibleSelectedModel?.label ? visibleSelectedModel : undefined}
       onChange={handleChange}
       options={optionsWithCustomModelEntry}
       size="small"
-      placeholder={i18n('ai.select.model')}
+      placeholder={placeholder}
       suffixIcon={<ChevronDown size={14} />}
       onDropdownVisibleChange={handleDropdownVisibleChange}
     />

--- a/chat2db-community-client/src/blocks/AI/components/AIModelSelect/modelSelectOptions.test.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelSelect/modelSelectOptions.test.ts
@@ -3,6 +3,9 @@ import {
   appendCustomModelEntryOption,
   CUSTOM_MODEL_ENTRY_OPTION_VALUE,
   isCustomModelEntryOption,
+  isModelOptionAvailable,
+  resolveSelectedModel,
+  shouldOpenCustomModelDirectly,
 } from './modelSelectOptions';
 
 const emptyOptions = appendCustomModelEntryOption([], 'Custom model');
@@ -26,5 +29,27 @@ assert.deepEqual(appendCustomModelEntryOption(configuredOptions, 'Custom model',
 assert.deepEqual(appendCustomModelEntryOption(configuredOptions, null, 'custom-option'), configuredOptions);
 assert.equal(isCustomModelEntryOption(CUSTOM_MODEL_ENTRY_OPTION_VALUE), true);
 assert.equal(isCustomModelEntryOption('gpt-4o'), false);
+
+const staleSelection = { label: 'GPT-5.2', value: 'preset:OPENAI:gpt-5.2' };
+assert.equal(isModelOptionAvailable([], staleSelection), false);
+assert.equal(isModelOptionAvailable(configuredOptions, configuredOptions[0]), true);
+assert.equal(resolveSelectedModel([], staleSelection), null);
+assert.equal(shouldOpenCustomModelDirectly([], true), true);
+assert.equal(shouldOpenCustomModelDirectly(configuredOptions, true), false);
+assert.equal(shouldOpenCustomModelDirectly(undefined, true), false);
+assert.equal(shouldOpenCustomModelDirectly([], false), false);
+
+const availableOptions = [
+  { label: 'Custom Claude', value: 'config:claude', isDefault: false },
+  { label: 'Custom OpenAI', value: 'config:openai', isDefault: true },
+];
+assert.deepEqual(resolveSelectedModel(availableOptions, staleSelection), {
+  label: 'Custom OpenAI',
+  value: 'config:openai',
+});
+assert.deepEqual(resolveSelectedModel(availableOptions, { label: 'Old label', value: 'config:claude' }), {
+  label: 'Custom Claude',
+  value: 'config:claude',
+});
 
 console.log('AI model select option tests passed.');

--- a/chat2db-community-client/src/blocks/AI/components/AIModelSelect/modelSelectOptions.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelSelect/modelSelectOptions.ts
@@ -7,9 +7,46 @@ export interface ModelSelectOption {
   className?: string;
 }
 
+export interface SelectedModelValue {
+  label: string;
+  value: string;
+}
+
 export const CUSTOM_MODEL_ENTRY_OPTION_VALUE = 'chat2db://action/custom-model';
 
 export const isCustomModelEntryOption = (value: unknown): boolean => value === CUSTOM_MODEL_ENTRY_OPTION_VALUE;
+
+export const isModelOptionAvailable = (
+  options: readonly Pick<ModelSelectOption, 'value'>[] | undefined,
+  selectedModel: Pick<SelectedModelValue, 'value'> | null,
+): boolean => !!selectedModel && !!options?.some((option) => option.value === selectedModel.value);
+
+export const shouldOpenCustomModelDirectly = (
+  options: readonly ModelSelectOption[] | undefined,
+  showCustomModelEntry: boolean,
+): boolean => showCustomModelEntry && options !== undefined && options.length === 0;
+
+export const resolveSelectedModel = (
+  options: readonly (Pick<ModelSelectOption, 'value' | 'isDefault'> & { label: string })[],
+  selectedModel: SelectedModelValue | null,
+): SelectedModelValue | null => {
+  const currentOption = selectedModel ? options.find((option) => option.value === selectedModel.value) : undefined;
+  if (currentOption) {
+    return {
+      value: currentOption.value,
+      label: currentOption.label,
+    };
+  }
+
+  const fallbackOption = options.find((option) => option.isDefault) || options[0];
+  if (!fallbackOption) {
+    return null;
+  }
+  return {
+    value: fallbackOption.value,
+    label: fallbackOption.label,
+  };
+};
 
 export const appendCustomModelEntryOption = (
   options: readonly ModelSelectOption[] | undefined,

--- a/chat2db-community-client/src/blocks/AI/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/index.tsx
@@ -35,6 +35,7 @@ import i18n from '@/i18n';
 import { keyboardKey } from '@/utils';
 import { cx } from 'antd-style';
 import AIModelConfigModal from './components/AIModelConfigModal';
+import { resolveSelectedModel } from './components/AIModelSelect/modelSelectOptions';
 import { listAvailableModelOptions, resolveModelRequestPayload } from '@/service/aiModelConfig';
 import { isDesktop } from '@/utils/env';
 
@@ -827,26 +828,21 @@ export default function AI({ variant = 'page', onTableClick, onPinSql, onSession
           isDefault: !!item.defaultOption,
         })),
       );
-      const currentValue = selectedModel?.value;
-      const currentOption = currentValue ? result.find((item) => item.value === currentValue) : undefined;
-      const hasCurrent = !!currentOption;
-      if (currentOption && currentOption.label !== selectedModel?.label) {
-        setSelectedModel({
-          value: currentOption.value,
-          label: currentOption.label,
-        });
-        return;
-      }
-      if (!hasCurrent && result.length > 0) {
-        const defaultOption = result.find((item) => item.defaultOption) || result[0];
-        setSelectedModel({
-          value: defaultOption.value,
-          label: defaultOption.label,
-        });
+      const nextSelectedModel = resolveSelectedModel(
+        result.map((item) => ({
+          value: item.value,
+          label: item.label,
+          isDefault: !!item.defaultOption,
+        })),
+        selectedModel,
+      );
+      if (nextSelectedModel?.value !== selectedModel?.value || nextSelectedModel?.label !== selectedModel?.label) {
+        setSelectedModel(nextSelectedModel);
       }
     } catch {
       setModelOptions([]);
       setModelOptionMap({});
+      setSelectedModel(null);
       feedback.error(i18n('stream.error.loadModelList'));
     }
   }, [selectedModel?.label, selectedModel?.value, setSelectedModel]);

--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/LocalDashboardService.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/LocalDashboardService.java
@@ -14,7 +14,7 @@ import ai.chat2db.community.domain.api.service.db.IDbDlTemplateService;
 import ai.chat2db.community.domain.api.service.ops.IOpsSqlOperationLogService;
 import ai.chat2db.community.storage.small.ChartStorage;
 import ai.chat2db.community.storage.small.DashboardStorage;
-import ai.chat2db.community.tools.annotation.CommunityRuntimeOnly;
+import ai.chat2db.community.tools.annotation.LocalPersistenceRuntimeOnly;
 import ai.chat2db.community.tools.exception.BusinessException;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 
 @Service
-@CommunityRuntimeOnly
+@LocalPersistenceRuntimeOnly
 public class LocalDashboardService implements IDashboardService {
 
     private static final int DEFAULT_CHART_REFRESH_PAGE_SIZE = 200;

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/LocalDashboardServiceRuntimeBoundaryTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/LocalDashboardServiceRuntimeBoundaryTest.java
@@ -1,0 +1,69 @@
+package ai.chat2db.community.storage;
+
+import ai.chat2db.community.domain.api.service.dashboard.IDashboardService;
+import ai.chat2db.community.domain.api.service.db.IDbConnectionContextService;
+import ai.chat2db.community.domain.api.service.db.IDbDlTemplateService;
+import ai.chat2db.community.domain.api.service.ops.IOpsSqlOperationLogService;
+import ai.chat2db.community.tools.annotation.LocalPersistenceRuntimeOnly;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+import java.lang.reflect.Proxy;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalDashboardServiceRuntimeBoundaryTest {
+
+    @Test
+    void localDashboardIsAvailableToCommunityAndLocalEditions() {
+        assertTrue(LocalDashboardService.class.isAnnotationPresent(LocalPersistenceRuntimeOnly.class));
+
+        ConditionalOnExpression condition = LocalPersistenceRuntimeOnly.class
+                .getAnnotation(ConditionalOnExpression.class);
+        assertEquals("'${chat2db.runtime.mode:pro}'.equalsIgnoreCase('community')"
+                + " || '${chat2db.runtime.mode:pro}'.equalsIgnoreCase('local')", condition.value());
+    }
+
+    @Test
+    void springLoadsLocalDashboardForLocalAndCommunityButNotPro() {
+        for (String runtimeMode : new String[]{"community", "local"}) {
+            try (AnnotationConfigApplicationContext context = context(runtimeMode, true)) {
+                assertInstanceOf(LocalDashboardService.class, context.getBean(IDashboardService.class));
+            }
+        }
+
+        try (AnnotationConfigApplicationContext context = context("pro", false)) {
+            assertTrue(context.getBeansOfType(IDashboardService.class).isEmpty());
+        }
+    }
+
+    private static AnnotationConfigApplicationContext context(String runtimeMode, boolean registerDependencies) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getEnvironment().getPropertySources().addFirst(new MapPropertySource(
+                "test-runtime",
+                Map.of("chat2db.runtime.mode", runtimeMode)));
+        if (registerDependencies) {
+            context.registerBean(IDbConnectionContextService.class,
+                    () -> proxy(IDbConnectionContextService.class));
+            context.registerBean(IDbDlTemplateService.class,
+                    () -> proxy(IDbDlTemplateService.class));
+            context.registerBean(IOpsSqlOperationLogService.class,
+                    () -> proxy(IOpsSqlOperationLogService.class));
+        }
+        context.register(LocalDashboardService.class);
+        context.refresh();
+        return context;
+    }
+
+    private static <T> T proxy(Class<T> type) {
+        return type.cast(Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[]{type},
+                (proxy, method, args) -> null));
+    }
+}

--- a/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/annotation/LocalPersistenceRuntimeOnly.java
+++ b/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/annotation/LocalPersistenceRuntimeOnly.java
@@ -1,0 +1,17 @@
+package ai.chat2db.community.tools.annotation;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ConditionalOnExpression("'${chat2db.runtime.mode:pro}'.equalsIgnoreCase('community')"
+        + " || '${chat2db.runtime.mode:pro}'.equalsIgnoreCase('local')")
+public @interface LocalPersistenceRuntimeOnly {
+}


### PR DESCRIPTION
Restore the existing Local product behavior needed by the Enterprise overlay.\n\n- clear stale AI model selections and open custom-model configuration directly when no models are available\n- register LocalDashboardService for Community and Local runtimes, but not Pro\n- add focused selector and Spring runtime-boundary tests\n\nVerification:\n- Local production frontend build and API contract passed\n- Community Maven reactor compiled and installed successfully\n- focused selector and LocalDashboardService runtime-boundary tests passed