### PR TITLE
fix(client): wrap long DDL previews

### DIFF
--- a/chat2db-community-client/src/components/SQLPreview/index.tsx
+++ b/chat2db-community-client/src/components/SQLPreview/index.tsx
@@ -54,7 +54,11 @@ const SQLPreview = memo<SQLPreviewProps>((props) => {
       data-sql-preview-source={source}
     >
       <CodeHighlighter
-        className={cx(styles.highlighter, surface === 'transparent' && styles.transparentHighlighter)}
+        className={cx(
+          styles.highlighter,
+          wrap && styles.wrappedHighlighter,
+          surface === 'transparent' && styles.transparentHighlighter,
+        )}
         code={sql || ''}
         language={language}
         type={type}

--- a/chat2db-community-client/src/components/SQLPreview/style.ts
+++ b/chat2db-community-client/src/components/SQLPreview/style.ts
@@ -16,6 +16,12 @@ export const useStyles = createStyles(({ css }) => {
         margin: 0;
       }
     `,
+    wrappedHighlighter: css`
+      && pre code {
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+      }
+    `,
     transparentHighlighter: css`
       background-color: transparent !important;
       border-radius: 0 !important;


### PR DESCRIPTION
## Summary
- Apply the requested `SQLPreview` wrapping behavior with enough specificity to override the UI library `white-space: pre` rule.
- Use `pre-wrap` plus `overflow-wrap: anywhere` only when `wrap=true`.
- Preserve the explicit `wrap=false` behavior used by chat code blocks.

## Verification
- Prettier and targeted ESLint passed.
- `yarn build:web` passed.
- Independent adversarial CSS review passed.
- Chromium DOM/CSS smoke at 480px: wrapped preview had no horizontal overflow and rendered multiple lines; `wrap=false` remained a single horizontally scrollable line.
- Fork CI: backend, frontend, Java/JavaScript CodeQL, repository/docs, licenses, and SBOM passed.
- `git diff --check` passed.

Fixes #2247