### PR TITLE
fix(sqlserver): preserve index sort direction

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/SqlServerMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/SqlServerMetaData.java
@@ -725,11 +725,11 @@ public class SqlServerMetaData extends DefaultMetaService implements IDbMetaData
         TableIndexColumn tableIndexColumn = new TableIndexColumn();
         tableIndexColumn.setColumnName(resultSet.getString("COLUMN_NAME"));
         tableIndexColumn.setOrdinalPosition(resultSet.getShort("COLUMN_POSITION"));
-        int collation = resultSet.getInt("DESCEND");
-        if (collation == 1) {
-            tableIndexColumn.setAscOrDesc("ASC");
-        } else {
+        int isDescending = resultSet.getInt("DESCEND");
+        if (isDescending == 1) {
             tableIndexColumn.setAscOrDesc("DESC");
+        } else {
+            tableIndexColumn.setAscOrDesc("ASC");
         }
         return tableIndexColumn;
     }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/SqlServerMetaDataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/SqlServerMetaDataTest.java
@@ -1,8 +1,15 @@
 package ai.chat2db.plugin.sqlserver;
 
+import ai.chat2db.community.domain.api.model.metadata.TableIndex;
+import ai.chat2db.community.domain.api.model.metadata.TableIndexColumn;
+import ai.chat2db.plugin.sqlserver.enums.type.SqlServerIndexTypeEnum;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,5 +56,70 @@ class SqlServerMetaDataTest {
                 SqlServerMetaData.buildForeignKeyDefinition(
                         "FK orders]owner", List.of("order id", "line]id"),
                         "sales archive", "order]history", List.of("id"), 0, 2));
+    }
+
+    @Test
+    void shouldPreserveIndexColumnSortDirectionFromSqlServerMetadata() {
+        List<TableIndex> indexes = new SqlServerMetaData().indexes(
+                indexMetadataConnection(), "catalog", "dbo", "orders");
+
+        assertEquals(1, indexes.size());
+        TableIndex index = indexes.get(0);
+        assertEquals(List.of("DESC", "ASC"), index.getColumnList().stream()
+                .map(TableIndexColumn::getAscOrDesc)
+                .toList());
+
+        String script = SqlServerIndexTypeEnum.NONCLUSTERED.buildIndexScript(index);
+        assertTrue(script.contains("([created_at] DESC,[id] ASC)"), script);
+    }
+
+    private static Connection indexMetadataConnection() {
+        ResultSet resultSet = indexMetadataResultSet();
+        PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                SqlServerMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "execute" -> true;
+                    case "getResultSet" -> resultSet;
+                    default -> defaultValue(method.getReturnType());
+                });
+        return (Connection) Proxy.newProxyInstance(
+                SqlServerMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> "prepareStatement".equals(method.getName())
+                        ? statement : defaultValue(method.getReturnType()));
+    }
+
+    private static ResultSet indexMetadataResultSet() {
+        int[] row = {-1};
+        return (ResultSet) Proxy.newProxyInstance(
+                SqlServerMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{ResultSet.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "next" -> ++row[0] < 2;
+                    case "getString" -> switch ((String) args[0]) {
+                        case "INDEX_NAME" -> "IX_orders_sort";
+                        case "COLUMN_NAME" -> row[0] == 0 ? "created_at" : "id";
+                        case "INDEX_TYPE" -> "NONCLUSTERED";
+                        default -> null;
+                    };
+                    case "getInt" -> "DESCEND".equals(args[0]) && row[0] == 0 ? 1 : 0;
+                    case "getShort" -> (short) (row[0] + 1);
+                    case "getBoolean" -> false;
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
     }
 }


### PR DESCRIPTION
## Summary

- Map SQL Server is_descending_key values to the correct ASC/DESC direction.
- Cover both index metadata and generated DDL with regression tests.

## Validation

- Focused tests: 5/5
- SQL Server module tests: 80/80
- Maven package

Fixes #2683

## Latest-main verification (2026-09-04)
- Rebased onto `144a04ee2`; full SQL Server plugin suite passed (80 tests).`n- `git diff --check` and pairwise integration analysis passed.