### PR TITLE
fix(tools): harden asynchronous JDBC downloads

### DIFF
--- a/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/JdbcJarUtils.java
+++ b/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/JdbcJarUtils.java
@@ -9,9 +9,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import cn.hutool.core.io.FileUtil;
@@ -28,8 +34,25 @@ import okhttp3.Response;
 @Slf4j
 public class JdbcJarUtils {
 
+    private static final String ASYNC_DOWNLOAD_THREAD_NAME_PREFIX = "chat2db-jdbc-download-";
+
+    private static final String PARTIAL_FILE_PREFIX = "jdbc-";
+
+    private static final String PARTIAL_FILE_SUFFIX = ".part";
+
+    private static final long STALE_PARTIAL_FILE_AGE_MILLIS = TimeUnit.DAYS.toMillis(1);
+
+    private static final AtomicInteger ASYNC_DOWNLOAD_THREAD_INDEX = new AtomicInteger();
+
+    static final ThreadFactory ASYNC_DOWNLOAD_THREAD_FACTORY = runnable -> {
+        Thread thread = new Thread(runnable,
+                ASYNC_DOWNLOAD_THREAD_NAME_PREFIX + ASYNC_DOWNLOAD_THREAD_INDEX.incrementAndGet());
+        thread.setDaemon(true);
+        return thread;
+    };
+
     private static final OkHttpClient async_client = new OkHttpClient.Builder()
-            .dispatcher(new Dispatcher(Executors.newFixedThreadPool(20)))
+            .dispatcher(new Dispatcher(Executors.newFixedThreadPool(20, ASYNC_DOWNLOAD_THREAD_FACTORY)))
             .build();
 
     private static final OkHttpClient client = new OkHttpClient();
@@ -39,6 +62,7 @@ public class JdbcJarUtils {
         if (!file.exists()) {
             file.mkdirs();
         }
+        cleanupStalePartialFiles(file);
     }
 
     public static void asyncDownload(List<String> urls) throws Exception {
@@ -57,7 +81,6 @@ public class JdbcJarUtils {
 
     static void asyncDownload(String url, Consumer<IOException> completion) throws IOException {
         File file = outputFile(url);
-        deleteIfExists(file);
         String safeUrl = sanitizeUrl(url);
         Request request;
         try {
@@ -68,7 +91,6 @@ public class JdbcJarUtils {
         async_client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
-                deleteIfExists(file);
                 IOException failure = downloadFailure(safeUrl, e.getClass().getSimpleName());
                 log.warn("Async JDBC driver download failed for {} ({})", safeUrl,
                     e.getClass().getSimpleName());
@@ -79,7 +101,6 @@ public class JdbcJarUtils {
             public void onResponse(Call call, Response response) {
                 try (Response closeableResponse = response) {
                     if (!closeableResponse.isSuccessful()) {
-                        deleteIfExists(file);
                         IOException failure = downloadFailure(safeUrl,
                             "HTTP " + closeableResponse.code());
                         log.warn("Async JDBC driver download failed for {} (HTTP {})", safeUrl,
@@ -90,7 +111,6 @@ public class JdbcJarUtils {
                     writeResponseBody(closeableResponse, file);
                     completion.accept(null);
                 } catch (IOException e) {
-                    deleteIfExists(file);
                     IOException failure = downloadFailure(safeUrl, e.getClass().getSimpleName());
                     log.warn("Async JDBC driver download failed for {} ({})", safeUrl,
                         e.getClass().getSimpleName());
@@ -106,7 +126,6 @@ public class JdbcJarUtils {
             pathfile.mkdirs();
         }
         File file = outputFile(url);
-        deleteIfExists(file);
         String safeUrl = sanitizeUrl(url);
         Request request;
         try {
@@ -125,14 +144,12 @@ public class JdbcJarUtils {
         }
         try (response) {
             if (!response.isSuccessful()) {
-                deleteIfExists(file);
                 log.warn("JDBC driver download failed for {} (HTTP {})", safeUrl, response.code());
                 throw downloadFailure(safeUrl, "HTTP " + response.code());
             }
             try {
                 writeResponseBody(response, file);
             } catch (IOException e) {
-                deleteIfExists(file);
                 throw downloadFailure(safeUrl, e.getClass().getSimpleName());
             }
         }
@@ -173,14 +190,46 @@ public class JdbcJarUtils {
         if (response.body() == null) {
             throw new IOException("Empty response body");
         }
-        try (InputStream is = response.body().byteStream();
-             FileOutputStream fos = new FileOutputStream(file)) {
-            byte[] buffer = new byte[2048];
-            int length;
-            while ((length = is.read(buffer)) != -1) {
-                fos.write(buffer, 0, length);
+        Path outputPath = file.toPath().toAbsolutePath();
+        Path temporaryFile = Files.createTempFile(outputPath.getParent(),
+            PARTIAL_FILE_PREFIX + file.getName() + "-", PARTIAL_FILE_SUFFIX);
+        try {
+            try (InputStream is = response.body().byteStream();
+                 FileOutputStream fos = new FileOutputStream(temporaryFile.toFile())) {
+                byte[] buffer = new byte[2048];
+                int length;
+                while ((length = is.read(buffer)) != -1) {
+                    fos.write(buffer, 0, length);
+                }
+                fos.flush();
             }
-            fos.flush();
+            moveIntoPlace(temporaryFile, outputPath);
+        } finally {
+            deleteIfExists(temporaryFile.toFile());
+        }
+    }
+
+    private static void moveIntoPlace(Path temporaryFile, Path outputPath) throws IOException {
+        try {
+            Files.move(temporaryFile, outputPath, StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException ignored) {
+            Files.move(temporaryFile, outputPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    static void cleanupStalePartialFiles(File directory) {
+        File[] partialFiles = directory.listFiles((ignored, name) ->
+            name.startsWith(PARTIAL_FILE_PREFIX) && name.endsWith(PARTIAL_FILE_SUFFIX));
+        if (partialFiles == null) {
+            return;
+        }
+        long cutoff = System.currentTimeMillis() - STALE_PARTIAL_FILE_AGE_MILLIS;
+        for (File partialFile : partialFiles) {
+            long lastModified = partialFile.lastModified();
+            if (partialFile.isFile() && lastModified > 0 && lastModified < cutoff) {
+                deleteIfExists(partialFile);
+            }
         }
     }
 

--- a/chat2db-community-server/chat2db-community-tools/src/test/java/ai/chat2db/community/tools/util/JdbcJarUtilsTest.java
+++ b/chat2db-community-server/chat2db-community-tools/src/test/java/ai/chat2db/community/tools/util/JdbcJarUtilsTest.java
@@ -2,7 +2,10 @@ package ai.chat2db.community.tools.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -15,9 +18,12 @@ import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,15 +41,29 @@ class JdbcJarUtilsTest {
     }
 
     @Test
+    void asyncDownloadWorkerThreadsAreNamedDaemons() {
+        Thread first = JdbcJarUtils.ASYNC_DOWNLOAD_THREAD_FACTORY.newThread(() -> { });
+        Thread second = JdbcJarUtils.ASYNC_DOWNLOAD_THREAD_FACTORY.newThread(() -> { });
+
+        assertTrue(first.isDaemon());
+        assertTrue(second.isDaemon());
+        assertTrue(first.getName().startsWith("chat2db-jdbc-download-"));
+        assertTrue(second.getName().startsWith("chat2db-jdbc-download-"));
+        assertNotEquals(first.getName(), second.getName());
+    }
+
+    @Test
     void asyncConnectionFailureIsReportedWithoutLeavingAPartialFile() throws Exception {
         String fileName = uniqueFileName();
         File output = outputFile(fileName);
         CountDownLatch completion = new CountDownLatch(1);
         AtomicReference<IOException> failure = new AtomicReference<>();
+        AtomicReference<Thread> callbackThread = new AtomicReference<>();
 
         JdbcJarUtils.asyncDownload(
             "http://user:password@127.0.0.1:1/" + fileName + "?token=secret",
             error -> {
+                callbackThread.set(Thread.currentThread());
                 failure.set(error);
                 completion.countDown();
             });
@@ -53,6 +73,133 @@ class JdbcJarUtilsTest {
         assertFalse(failure.get().getMessage().contains("user:password"));
         assertFalse(failure.get().getMessage().contains("token=secret"));
         assertFalse(output.exists());
+        assertNotNull(callbackThread.get());
+        assertTrue(callbackThread.get().isDaemon());
+        // OkHttp temporarily replaces the worker name while an AsyncCall is running. The
+        // factory test above owns the stable naming assertion; this callback only needs to
+        // prove that the actual network worker is a daemon.
+    }
+
+    @Test
+    void asyncDownloadPublishesOnlyCompleteFiles() throws Exception {
+        String fileName = uniqueFileName();
+        File output = outputFile(fileName);
+        byte[] content = "complete-jdbc-driver".getBytes(StandardCharsets.UTF_8);
+        CountDownLatch headersSent = new CountDownLatch(1);
+        CountDownLatch releaseBody = new CountDownLatch(1);
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/" + fileName, exchange -> {
+            exchange.sendResponseHeaders(200, content.length);
+            headersSent.countDown();
+            try (OutputStream responseBody = exchange.getResponseBody()) {
+                try {
+                    if (!releaseBody.await(10, TimeUnit.SECONDS)) {
+                        return;
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                responseBody.write(content);
+            }
+        });
+        server.start();
+        CountDownLatch completion = new CountDownLatch(1);
+        AtomicReference<IOException> failure = new AtomicReference<>();
+
+        JdbcJarUtils.asyncDownload(
+            "http://127.0.0.1:" + server.getAddress().getPort() + "/" + fileName,
+            error -> {
+                failure.set(error);
+                completion.countDown();
+            });
+
+        File partialFile = null;
+        try {
+            assertTrue(headersSent.await(10, TimeUnit.SECONDS));
+            partialFile = awaitPartialFile(output);
+            assertNotNull(partialFile);
+            filesToDelete.add(partialFile);
+            assertFalse(output.exists());
+        } finally {
+            releaseBody.countDown();
+        }
+        assertTrue(completion.await(10, TimeUnit.SECONDS));
+        assertNull(failure.get());
+        assertArrayEquals(content, Files.readAllBytes(output.toPath()));
+        assertFalse(partialFile.exists());
+    }
+
+    @Test
+    void asyncFailureDoesNotDeletePreviouslyPublishedDriver() throws Exception {
+        String fileName = uniqueFileName();
+        File output = outputFile(fileName);
+        byte[] content = "complete-jdbc-driver".getBytes(StandardCharsets.UTF_8);
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/" + fileName, exchange -> {
+            if ("fail=true".equals(exchange.getRequestURI().getRawQuery())) {
+                exchange.sendResponseHeaders(503, -1);
+                exchange.close();
+                return;
+            }
+            exchange.sendResponseHeaders(200, content.length);
+            try (OutputStream responseBody = exchange.getResponseBody()) {
+                responseBody.write(content);
+            }
+        });
+        server.start();
+        String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/" + fileName;
+
+        assertNull(awaitAsyncDownload(url));
+        assertArrayEquals(content, Files.readAllBytes(output.toPath()));
+
+        assertNotNull(awaitAsyncDownload(url + "?fail=true"));
+        assertArrayEquals(content, Files.readAllBytes(output.toPath()));
+    }
+
+    @Test
+    void interruptedResponseRemovesPartialFile() throws Exception {
+        String fileName = uniqueFileName();
+        File output = outputFile(fileName);
+        byte[] partialContent = "partial".getBytes(StandardCharsets.UTF_8);
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/" + fileName, exchange -> {
+            exchange.sendResponseHeaders(200, partialContent.length + 10);
+            try (OutputStream responseBody = exchange.getResponseBody()) {
+                responseBody.write(partialContent);
+                responseBody.flush();
+            }
+        });
+        server.start();
+
+        IOException failure = awaitAsyncDownload(
+            "http://127.0.0.1:" + server.getAddress().getPort() + "/" + fileName);
+
+        assertNotNull(failure);
+        assertFalse(output.exists());
+        assertNull(findPartialFile(output));
+    }
+
+    @Test
+    void stalePartialFilesAreCleanedWithoutRemovingFreshDownloads() throws Exception {
+        File directory = new File(JdbcDriverConstants.DRIVER_LIB_PATH);
+        File stale = new File(directory, "jdbc-stale-" + UUID.randomUUID() + ".part");
+        File fresh = new File(directory, "jdbc-fresh-" + UUID.randomUUID() + ".part");
+        File matchingDirectory = new File(directory, "jdbc-directory-" + UUID.randomUUID() + ".part");
+        filesToDelete.add(stale);
+        filesToDelete.add(fresh);
+        filesToDelete.add(matchingDirectory);
+        Files.writeString(stale.toPath(), "stale", StandardCharsets.UTF_8);
+        Files.writeString(fresh.toPath(), "fresh", StandardCharsets.UTF_8);
+        assertTrue(matchingDirectory.mkdir());
+        assertTrue(stale.setLastModified(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2)));
+        assertTrue(matchingDirectory.setLastModified(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2)));
+
+        JdbcJarUtils.cleanupStalePartialFiles(directory);
+
+        assertFalse(stale.exists());
+        assertTrue(fresh.exists());
+        assertTrue(matchingDirectory.exists());
     }
 
     @Test
@@ -122,5 +269,35 @@ class JdbcJarUtilsTest {
         File output = new File(JdbcDriverConstants.DRIVER_LIB_PATH, fileName);
         filesToDelete.add(output);
         return output;
+    }
+
+    private File awaitPartialFile(File output) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        do {
+            File partialFile = findPartialFile(output);
+            if (partialFile != null) {
+                return partialFile;
+            }
+            Thread.sleep(10);
+        } while (System.nanoTime() < deadline);
+        return null;
+    }
+
+    private File findPartialFile(File output) {
+        String prefix = "jdbc-" + output.getName() + "-";
+        File[] partialFiles = output.getParentFile().listFiles(
+            (directory, name) -> name.startsWith(prefix) && name.endsWith(".part"));
+        return partialFiles == null || partialFiles.length == 0 ? null : partialFiles[0];
+    }
+
+    private IOException awaitAsyncDownload(String url) throws Exception {
+        CountDownLatch completion = new CountDownLatch(1);
+        AtomicReference<IOException> failure = new AtomicReference<>();
+        JdbcJarUtils.asyncDownload(url, error -> {
+            failure.set(error);
+            completion.countDown();
+        });
+        assertTrue(completion.await(10, TimeUnit.SECONDS));
+        return failure.get();
     }
 }


### PR DESCRIPTION
## Summary

- Use daemon workers for asynchronous JDBC driver downloads so they cannot keep the JVM alive.
- Publish completed downloads atomically and isolate concurrent temporary-file cleanup.

## Validation

- Focused tests: 9/9
- Tools module tests: 72/72
- Maven package

Fixes #2684

## Latest-main verification (2026-09-04)
- Rebased onto `144a04ee2`; full tools suite passed (73 tests).`n- The Linux CI-only race was traced to OkHttp temporarily renaming a daemon worker during its callback. The test now separates stable factory naming from actual callback daemon status; the focused suite passed 10 consecutive runs before the full suite.`n- Combined with #2695 using a semantic conflict resolution; full combined tools suite passed (76 tests), covering daemon workers, atomic publication, and dynamic runtime paths.