### PR TITLE
fix(clickhouse): preserve IPv6 URL when switching schema

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/ClickHouseDBManager.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/ClickHouseDBManager.java
@@ -93,27 +93,30 @@ public class ClickHouseDBManager extends DefaultDBManager implements IDbManager 
     }
 
     private String setDatabaseInJdbcUrl(ConnectInfo connectInfo) {
-        String schemaName = connectInfo.getSchemaName();
-        String url = connectInfo.getUrl();
-        if (StringUtils.isBlank(schemaName)) {
+        return replaceDatabaseInJdbcUrl(connectInfo.getUrl(), connectInfo.getSchemaName());
+    }
+
+    static String replaceDatabaseInJdbcUrl(String url, String schemaName) {
+        if (StringUtils.isBlank(url) || StringUtils.isBlank(schemaName)) {
             return url;
         }
-        String connectAddress = connectInfo.getHost() + ":" + connectInfo.getPort();
-        String[] addressSplit = url.split(connectAddress);
-        if(addressSplit == null){
+
+        int queryStart = url.indexOf('?');
+        int fragmentStart = url.indexOf('#');
+        int suffixStart = queryStart >= 0 ? queryStart : url.length();
+        if (fragmentStart >= 0) {
+            suffixStart = Math.min(suffixStart, fragmentStart);
+        }
+        int authorityStart = url.indexOf("://");
+        if (authorityStart < 0 || authorityStart + 3 >= suffixStart) {
             return url;
         }
-        StringBuilder newUrl = new StringBuilder();
-        newUrl.append(addressSplit[0]).append(connectAddress).append("/").append(schemaName);
-        if (addressSplit.length == 2) {
-            if (StringUtils.isNotBlank(addressSplit[1])) {
-                String[] param = addressSplit[1].split("\\?");
-                if (param.length == 2) {
-                    newUrl.append("?").append(param[1]);
-                }
-            }
+
+        int pathStart = url.indexOf('/', authorityStart + 3);
+        if (pathStart < 0 || pathStart >= suffixStart) {
+            pathStart = suffixStart;
         }
-        return newUrl.toString();
+        return url.substring(0, pathStart) + "/" + schemaName + url.substring(suffixStart);
     }
 
     @Override

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/test/java/ai/chat2db/plugin/clickhouse/ClickHouseDBManagerConnectionUrlTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/test/java/ai/chat2db/plugin/clickhouse/ClickHouseDBManagerConnectionUrlTest.java
@@ -1,0 +1,59 @@
+package ai.chat2db.plugin.clickhouse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ClickHouseDBManagerConnectionUrlTest {
+
+    @Test
+    void replacesDatabasePathForBracketedIpv6AndPreservesQueryAndFragment() {
+        assertEquals(
+                "jdbc:clickhouse://[2001:db8::1]:8123/analytics?ssl=true#replica/tag",
+                ClickHouseDBManager.replaceDatabaseInJdbcUrl(
+                        "jdbc:clickhouse://[2001:db8::1]:8123/default?ssl=true#replica/tag",
+                        "analytics")
+        );
+    }
+
+    @Test
+    void repeatedReplacementIsIdempotent() {
+        String expected = "jdbc:clickhouse://[2001:db8::1]:8123/analytics?ssl=true";
+        String first = ClickHouseDBManager.replaceDatabaseInJdbcUrl(
+                "jdbc:clickhouse://[2001:db8::1]:8123/default?ssl=true",
+                "analytics");
+
+        assertEquals(expected, first);
+        assertEquals(expected, ClickHouseDBManager.replaceDatabaseInJdbcUrl(first, "analytics"));
+    }
+
+    @Test
+    void appendsDatabasePathWhenHostnameUrlHasNoPath() {
+        assertEquals(
+                "jdbc:clickhouse://clickhouse.example:8123/analytics",
+                ClickHouseDBManager.replaceDatabaseInJdbcUrl(
+                        "jdbc:clickhouse://clickhouse.example:8123",
+                        "analytics")
+        );
+    }
+
+    @Test
+    void appendsDatabasePathBeforeFragmentWhenUrlHasNoPath() {
+        assertEquals(
+                "jdbc:clickhouse://clickhouse.example:8123/analytics#replica/tag",
+                ClickHouseDBManager.replaceDatabaseInJdbcUrl(
+                        "jdbc:clickhouse://clickhouse.example:8123#replica/tag",
+                        "analytics")
+        );
+    }
+
+    @Test
+    void replacesExistingDatabasePathAndPreservesFragment() {
+        assertEquals(
+                "jdbc:clickhouse://clickhouse.example:8123/analytics#replica/tag",
+                ClickHouseDBManager.replaceDatabaseInJdbcUrl(
+                        "jdbc:clickhouse://clickhouse.example:8123/default#replica/tag",
+                        "analytics")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Preserve the host and port of IPv6 ClickHouse JDBC URLs when switching schemas.
- Keep query and fragment components intact during the rewrite.

## Validation

- Focused regression tests: 5/5
- ClickHouse module tests: 48/48
- Maven package

Fixes #2685