### PR TITLE
fix(sqlserver): detect top-level pagination ordering

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
@@ -7,6 +7,7 @@ import ai.chat2db.plugin.sqlserver.enums.type.SqlServerColumnTypeEnum;
 import ai.chat2db.plugin.sqlserver.enums.type.SqlServerIndexTypeEnum;
 import ai.chat2db.plugin.sqlserver.SqlServerSqlGuards;
 import ai.chat2db.plugin.sqlserver.identifier.SqlServerIdentifierProcessor;
+import ai.chat2db.plugin.sqlserver.parser.base.TSqlLexer;
 import ai.chat2db.spi.DefaultSqlBuilder;
 import ai.chat2db.spi.model.request.PageLimitRequest;
 import ai.chat2db.spi.model.request.UpdateSqlRequest;
@@ -25,10 +26,11 @@ import ai.chat2db.spi.sql.Chat2DBContext;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.Token;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static ai.chat2db.plugin.sqlserver.constant.SqlServerSqlBuilderConstants.*;
@@ -285,7 +287,7 @@ public class SqlServerSqlBuilder extends DefaultSqlBuilder {
             if (versions.length > 0 && Integer.parseInt(versions[0]) >= 11) {
                 StringBuilder sqlBuilder = new StringBuilder(sql.length() + 14);
                 sqlBuilder.append(sql);
-                if (!sql.toLowerCase(Locale.ROOT).contains(ORDER_BY_KEYWORD_LOWER)) {
+                if (!hasTopLevelOrderBy(sql)) {
                     sqlBuilder.append(SQL_ORDER_BY_OPEN_PAREN_SELECT_NULL_CLOSE_PAREN);
                 }
                 sqlBuilder.append(SQLConstants.LINE_SEPARATOR_OFFSET_SQL);
@@ -308,6 +310,37 @@ public class SqlServerSqlBuilder extends DefaultSqlBuilder {
         sqlBuilder.append(SQL_AND);
         sqlBuilder.append(endRow);
         return sqlBuilder.toString();
+    }
+
+    private static boolean hasTopLevelOrderBy(String sql) {
+        TSqlLexer lexer = new TSqlLexer(CharStreams.fromString(sql));
+        int parenthesisDepth = 0;
+        boolean previousTokenWasOrder = false;
+        Token token;
+        while ((token = lexer.nextToken()).getType() != Token.EOF) {
+            if (token.getChannel() != Token.DEFAULT_CHANNEL) {
+                continue;
+            }
+            int tokenType = token.getType();
+            if (tokenType == TSqlLexer.LR_BRACKET) {
+                parenthesisDepth++;
+                previousTokenWasOrder = false;
+                continue;
+            }
+            if (tokenType == TSqlLexer.RR_BRACKET) {
+                parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+                previousTokenWasOrder = false;
+                continue;
+            }
+            if (parenthesisDepth != 0) {
+                continue;
+            }
+            if (previousTokenWasOrder && tokenType == TSqlLexer.BY) {
+                return true;
+            }
+            previousTokenWasOrder = tokenType == TSqlLexer.ORDER;
+        }
+        return false;
     }
 
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerSqlBuilderConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/constant/SqlServerSqlBuilderConstants.java
@@ -33,7 +33,6 @@ public final class SqlServerSqlBuilderConstants {
     public static final String VALUE_CLOSE_PAREN_GO = "\n)\ngo\n";
     public static final String VALUE_GO = "\ngo\n";
     public static final String VALUE_BACKSLASH_DOT = "\\.";
-    public static final String ORDER_BY_KEYWORD_LOWER = "order by";
     public static final String SQL_ORDER_BY_OPEN_PAREN_SELECT_NULL_CLOSE_PAREN = "\n ORDER BY (SELECT NULL)";
     public static final String SQL_COLLATE = " COLLATE ";
     public static final String SQL_EXEC_OPEN_BRACKET = "exec [";

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
@@ -9,6 +9,7 @@ import ai.chat2db.plugin.sqlserver.SqlServerPlugin;
 import ai.chat2db.spi.IPlugin;
 import ai.chat2db.spi.constant.SQLConstants;
 import ai.chat2db.spi.model.datasource.ConnectInfo;
+import ai.chat2db.spi.model.request.PageLimitRequest;
 import ai.chat2db.spi.sql.Chat2DBContext;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +49,37 @@ class SqlServerSqlBuilderTest {
 
         assertEquals("[dbo].[orders]", builder.tableName(null, "dbo", "orders"));
         assertEquals("[analytics].[dbo].[orders]", builder.tableName("analytics", "dbo", "orders"));
+    }
+
+    @Test
+    void shouldAddOuterOrderByWhenOnlyWindowFunctionIsOrdered() {
+        String sql = "SELECT ROW_NUMBER() OVER (ORDER BY id) AS row_no, id FROM users";
+
+        assertEquals(sql + "\n ORDER BY (SELECT NULL)\n OFFSET 0 ROWS  FETCH NEXT 10 ROWS ONLY",
+                buildPageLimit(sql));
+    }
+
+    @Test
+    void shouldAddOuterOrderByWhenOnlyNestedQueryIsOrdered() {
+        String sql = "SELECT id FROM (SELECT TOP 10 id FROM users ORDER BY id) recent_users";
+
+        assertEquals(sql + "\n ORDER BY (SELECT NULL)\n OFFSET 0 ROWS  FETCH NEXT 10 ROWS ONLY",
+                buildPageLimit(sql));
+    }
+
+    @Test
+    void shouldIgnoreOrderByInStringAndCommentWhenPaginating() {
+        String sql = "SELECT 'order by' AS label FROM users -- order by is not an outer clause";
+
+        assertEquals(sql + "\n ORDER BY (SELECT NULL)\n OFFSET 0 ROWS  FETCH NEXT 10 ROWS ONLY",
+                buildPageLimit(sql));
+    }
+
+    @Test
+    void shouldKeepExistingOuterOrderByWhenPaginating() {
+        String sql = "SELECT id FROM users ORDER /* keep deterministic */\n BY id";
+
+        assertEquals(sql + "\n OFFSET 0 ROWS  FETCH NEXT 10 ROWS ONLY", buildPageLimit(sql));
     }
 
     @Test
@@ -122,6 +154,24 @@ class SqlServerSqlBuilderTest {
 
     private static String buildCopyWhere(String columnType, String value) {
         return buildCopyWhere(columnType, Collections.singletonList(value));
+    }
+
+    private static String buildPageLimit(String sql) {
+        ConnectInfo connectInfo = new ConnectInfo();
+        connectInfo.setDbType("SQLSERVER");
+        connectInfo.setDbVersion("15.0");
+        connectInfo.setDriverConfig(new DriverConfig());
+        Chat2DBContext.putContext(connectInfo);
+        try {
+            return new SqlServerSqlBuilder().buildPageLimit(PageLimitRequest.builder()
+                    .sql(sql)
+                    .offset(0)
+                    .pageNo(1)
+                    .pageSize(10)
+                    .build());
+        } finally {
+            Chat2DBContext.removeContext();
+        }
     }
 
     private static String buildCopyWhere(String columnType, List<String> values) {


### PR DESCRIPTION
## Summary

- Detect ORDER BY at the top SQL level with the T-SQL lexer before adding SQL Server OFFSET/FETCH pagination.
- Add the fallback ORDER BY (SELECT NULL) when ordering appears only inside a window expression, nested query, string literal, or comment.
- Preserve a real outer ORDER BY, including one split by a comment.

## Validation

- SqlServerSqlBuilderTest regression coverage for window, nested query, string/comment, and outer-order cases.
- Fork CI: Backend tests and package, Frontend lint/test/build, repository checks, JavaScript CodeQL, Java CodeQL, SBOM, and license summary passed.

## Latest-main verification (2026-09-04)
- Rebased onto `144a04ee2`; full SQL Server plugin suite passed (83 tests).`n- `git diff --check` and pairwise integration analysis passed.