### PR TITLE
Add MiniMax global and China endpoint presets

### DIFF
--- a/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Button, Form, Input, InputNumber, Modal, Popconfirm, Select, Switch, Tag } from 'antd';
+import { AutoComplete, Button, Form, Input, InputNumber, Modal, Popconfirm, Select, Switch, Tag } from 'antd';
 import i18n from '@/i18n';
 import feedback from '@/utils/feedback';
 import {
@@ -11,7 +11,11 @@ import {
   saveAIModelConfig,
   testAIModelConfig,
 } from '@/service/aiModelConfig';
-import { resolveBaseUrlOnProviderChange, resolveProviderBaseUrl } from './modelConfigDefaults';
+import {
+  MINIMAX_BASE_URL_PRESETS,
+  resolveBaseUrlOnProviderChange,
+  resolveProviderBaseUrl,
+} from './modelConfigDefaults';
 import { useStyles } from './style';
 
 interface AIModelConfigModalProps {
@@ -309,7 +313,14 @@ export default function AIModelConfigModal({ open, onClose, onChanged }: AIModel
               />
             </Form.Item>
             <Form.Item name="baseUrl" label={i18n('setting.modelConfig.baseUrl')}>
-              <Input autoComplete="off" placeholder={i18n('setting.modelConfig.placeholder.baseUrl')} />
+              {currentProvider === 'MINIMAX' ? (
+                <AutoComplete
+                  options={MINIMAX_BASE_URL_PRESETS}
+                  placeholder={i18n('setting.modelConfig.placeholder.baseUrl')}
+                />
+              ) : (
+                <Input autoComplete="off" placeholder={i18n('setting.modelConfig.placeholder.baseUrl')} />
+              )}
             </Form.Item>
             <Form.Item name="projectId" label={i18n('setting.modelConfig.projectId')}>
               <Input autoComplete="off" placeholder={i18n('setting.modelConfig.placeholder.projectId')} />

--- a/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/modelConfigDefaults.test.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/modelConfigDefaults.test.ts
@@ -1,9 +1,21 @@
 import assert from 'node:assert/strict';
 import {
   DEFAULT_MINIMAX_BASE_URL,
+  MINIMAX_BASE_URL_PRESETS,
   resolveBaseUrlOnProviderChange,
   resolveProviderBaseUrl,
 } from './modelConfigDefaults';
+
+assert.deepEqual(
+  MINIMAX_BASE_URL_PRESETS.map(({ value }) => value),
+  [
+    'https://api.minimax.io/v1',
+    'https://api.minimaxi.com/v1',
+    'https://api.minimax.io/anthropic',
+    'https://api.minimaxi.com/anthropic',
+  ],
+);
+assert.equal(DEFAULT_MINIMAX_BASE_URL, 'https://api.minimax.io/v1');
 
 assert.equal(resolveProviderBaseUrl('MINIMAX', ''), DEFAULT_MINIMAX_BASE_URL);
 assert.equal(resolveProviderBaseUrl('MINIMAX', '   '), DEFAULT_MINIMAX_BASE_URL);
@@ -11,7 +23,9 @@ assert.equal(resolveProviderBaseUrl('MINIMAX', 'https://api.minimax.chat/v1'), '
 assert.equal(resolveProviderBaseUrl('OPENAI', ''), '');
 
 assert.equal(resolveBaseUrlOnProviderChange('MINIMAX', ''), DEFAULT_MINIMAX_BASE_URL);
-assert.equal(resolveBaseUrlOnProviderChange('OPENAI', DEFAULT_MINIMAX_BASE_URL), '');
+MINIMAX_BASE_URL_PRESETS.forEach(({ value }) => {
+  assert.equal(resolveBaseUrlOnProviderChange('OPENAI', value), '');
+});
 assert.equal(
   resolveBaseUrlOnProviderChange('OPENAI', 'https://proxy.example.com/v1'),
   'https://proxy.example.com/v1',

--- a/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/modelConfigDefaults.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/modelConfigDefaults.ts
@@ -1,6 +1,15 @@
 import type { AIProvider } from '@/service/aiModelConfig';
 
-export const DEFAULT_MINIMAX_BASE_URL = 'https://api.minimax.io/v1';
+export const MINIMAX_BASE_URL_PRESETS: Array<{ label: string; value: string }> = [
+  { label: 'Global (OpenAI compatible)', value: 'https://api.minimax.io/v1' },
+  { label: 'China (OpenAI compatible)', value: 'https://api.minimaxi.com/v1' },
+  { label: 'Global (Anthropic compatible)', value: 'https://api.minimax.io/anthropic' },
+  { label: 'China (Anthropic compatible)', value: 'https://api.minimaxi.com/anthropic' },
+];
+
+export const DEFAULT_MINIMAX_BASE_URL = MINIMAX_BASE_URL_PRESETS[0].value;
+
+const MINIMAX_BASE_URLS = new Set(MINIMAX_BASE_URL_PRESETS.map(({ value }) => value));
 
 export const resolveProviderBaseUrl = (provider: AIProvider, baseUrl?: string): string => {
   if (provider === 'MINIMAX' && !baseUrl?.trim()) {
@@ -13,7 +22,7 @@ export const resolveBaseUrlOnProviderChange = (provider: AIProvider, baseUrl?: s
   if (provider === 'MINIMAX') {
     return resolveProviderBaseUrl(provider, baseUrl);
   }
-  if (baseUrl?.trim() === DEFAULT_MINIMAX_BASE_URL) {
+  if (baseUrl && MINIMAX_BASE_URLS.has(baseUrl.trim())) {
     return '';
   }
   return baseUrl || '';


### PR DESCRIPTION
Reason: MiniMax configuration needs first-class global and China endpoint presets for both supported compatibility modes.

This change adds editable presets for the global and China OpenAI-compatible and Anthropic-compatible endpoints while preserving custom base URLs. It also clears any known MiniMax preset when users switch providers, avoiding an invalid inherited base URL.

The focused test now verifies the exact endpoint catalog, the default endpoint, and provider-switch behavior for every preset.

Checks:

- `npx --yes --package=node@20 -- yarn test:ai-model-config`
- `npx --yes --package=node@20 -- yarn lint`
- `npx --yes --package=node@20 -- yarn build:web:community --app_version=0.0.0`
