### PR TITLE
fix(local): preserve storage compatibility and runtime search capability

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -13,7 +13,7 @@
     "build:desktop": "npm run build:web:desktop",
     "build:prod": "npm run build:web:prod",
     "build:web": "umi build",
-    "prebuild:web:community": "yarn test:chat-answer-update && yarn test:tree-title-highlight && yarn test:tree-data-update && yarn test:tree-node-lookup && yarn test:data-source-authorization && yarn test:data-source-mutation-refresh && yarn test:ai-model-config && yarn test:ai-model-select && yarn test:export-connections && yarn test:main-page-navigation && yarn test:console-tab-name && yarn test:file-manager-label && yarn test:local-file-encoding && yarn test:editor-close && yarn test:invoice-routing && yarn test:result-set-ui && yarn test:result-status && yarn test:hot-update",
+    "prebuild:web:community": "yarn test:runtime-edition-storage && yarn test:chat-answer-update && yarn test:tree-title-highlight && yarn test:tree-data-update && yarn test:tree-node-lookup && yarn test:data-source-authorization && yarn test:data-source-mutation-refresh && yarn test:ai-model-config && yarn test:ai-model-select && yarn test:export-connections && yarn test:main-page-navigation && yarn test:console-tab-name && yarn test:file-manager-label && yarn test:local-file-encoding && yarn test:editor-close && yarn test:invoice-routing && yarn test:result-set-ui && yarn test:result-status && yarn test:hot-update",
     "postbuild:web:community": "node ./scripts/verify-production-bundles.cjs",
     "build:web:2java": "yarn run build:web:prod && rm -rf ../chat2db-community-server/chat2db-community-start/src/main/resources/thymeleaf/* && cp -r dist/index.html ../chat2db-community-server/chat2db-community-start/src/main/resources/thymeleaf/",
     "build:web:desktop": "cross-env UMI_ENV=desktop cross-env APP_NAME=chat2db-pro cross-env APP_VERSION=${npm_config_app_version} cross-env PRINT_LOGS=${npm_config_print_logs} cross-env APP_PORT=${npm_config_app_port} umi build",
@@ -53,6 +53,7 @@
     "test:result-markdown": "tsx src/blocks/SearchResult/components/ResultSetTable/event/onContextmenuCell/handleCopyAsMarkdown.test.ts",
     "test:result-set-ui": "tsx src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts",
     "test:result-status": "tsx src/blocks/SearchResult/components/StatusBar/resultSummary.test.ts",
+    "test:runtime-edition-storage": "tsx src/constants/runtimeEdition.test.ts && tsx src/store/indexDB/storageKey.test.ts",
     "test:runtime-capabilities": "tsx src/edition-ui/runtimeCapabilities.test.ts && tsx src/pages/main/workspace/components/WorkspaceLeft/desktopBridge.test.ts",
     "test:result-tab-preferences": "tsx src/blocks/SearchResult/resultTabPreferences.test.ts && tsx src/service/resultTabShortcut.test.ts",
     "test:result-inspector": "tsx src/store/workspace/utils/resultInspector.test.ts && yarn test:search-result-tab-selection",
@@ -196,4 +197,3 @@
     "node": ">=18.17.0"
   }
 }
-

--- a/chat2db-community-client/src/blocks/RedisAllData/index.tsx
+++ b/chat2db-community-client/src/blocks/RedisAllData/index.tsx
@@ -33,9 +33,13 @@ import {
   type RedisRowIdentity,
 } from './redisRowIdentity';
 import { RedisEditSessionRegistry, type RedisEditSessionToken } from './redisEditSession';
+import { runtimeEditionConfig } from '@/constants/runtimeEdition';
 
 const REDIS_SCAN_COUNT = 1000;
-const REDIS_KEY_VIEW_MODE_STORAGE_KEY = createRedisKeyViewModeStorageKey('community', __RUNTIME_ENV__);
+const REDIS_KEY_VIEW_MODE_STORAGE_KEY = createRedisKeyViewModeStorageKey(
+  runtimeEditionConfig.clientStorageEdition,
+  __RUNTIME_ENV__,
+);
 const INITIAL_SCAN_CURSOR = '0';
 const EDIT_PANE_COLLAPSED_SIZE = 0;
 const EDIT_PANE_DEFAULT_SIZE = 320;

--- a/chat2db-community-client/src/blocks/RedisAllData/redisViewMode.test.ts
+++ b/chat2db-community-client/src/blocks/RedisAllData/redisViewMode.test.ts
@@ -22,6 +22,10 @@ assert.equal(
   createRedisKeyViewModeStorageKey('community', 'community'),
   'chat2db.community.community.redis.key-view-mode.v1',
 );
+assert.equal(
+  createRedisKeyViewModeStorageKey('enterprise', 'offline'),
+  'chat2db.enterprise.offline.redis.key-view-mode.v1',
+);
 
 assert.equal(readRedisKeyViewMode(undefined, storageKey), 'list');
 assert.equal(readRedisKeyViewMode(storage, storageKey), 'list');

--- a/chat2db-community-client/src/constants/runtimeEdition.test.ts
+++ b/chat2db-community-client/src/constants/runtimeEdition.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+
+Object.assign(globalThis, {
+  __RUNTIME_ENV__: 'offline',
+  __ENV__: 'test',
+  __APP_VERSION__: '5.3.0',
+  __APP_NAME__: 'chat2db-local',
+  window: { javaQuery: {} },
+});
+
+async function main() {
+  const runtimeEditionModule = await import('./runtimeEdition');
+  const runtimeEditionConfig =
+    runtimeEditionModule.runtimeEditionConfig ||
+    (
+      runtimeEditionModule as typeof runtimeEditionModule & {
+        default?: typeof runtimeEditionModule;
+      }
+    ).default?.runtimeEditionConfig;
+
+  assert.ok(runtimeEditionConfig);
+  assert.deepEqual(
+    {
+      clientStorageEdition: runtimeEditionConfig.clientStorageEdition,
+      globalStoreName: runtimeEditionConfig.globalStoreName,
+      userStoreName: runtimeEditionConfig.userStoreName,
+      orgStoreName: runtimeEditionConfig.orgStoreName,
+      workspaceStoreName: runtimeEditionConfig.workspaceStoreName,
+      aiStoreName: runtimeEditionConfig.aiStoreName,
+      treeStoreName: runtimeEditionConfig.treeStoreName,
+      localStorageVersionKey: runtimeEditionConfig.localStorageVersionKey,
+      aiModelConfigStorageKey: runtimeEditionConfig.aiModelConfigStorageKey,
+      loginRedirectStorageKey: runtimeEditionConfig.loginRedirectStorageKey,
+      desktopResponseHeaderStorageKey: runtimeEditionConfig.desktopResponseHeaderStorageKey,
+      sidebarExpandedStorageKey: runtimeEditionConfig.sidebarExpandedStorageKey,
+      notificationPopupStorageKey: runtimeEditionConfig.notificationPopupStorageKey,
+      contentDiffDisabledSurfacesStorageKey: runtimeEditionConfig.contentDiffDisabledSurfacesStorageKey,
+      googleAdsSignupPendingStorageKey: runtimeEditionConfig.googleAdsSignupPendingStorageKey,
+      googleAdsSignupOnceStorageKeyPrefix: runtimeEditionConfig.googleAdsSignupOnceStorageKeyPrefix,
+      googleAdsPurchaseOnceStorageKeyPrefix: runtimeEditionConfig.googleAdsPurchaseOnceStorageKeyPrefix,
+      pricingAutoPopupStorageKey: runtimeEditionConfig.pricingAutoPopupStorageKey,
+      dailyPopupStorageKeyPrefix: runtimeEditionConfig.dailyPopupStorageKeyPrefix,
+      currentWorkspaceDatabaseStorageKey: runtimeEditionConfig.currentWorkspaceDatabaseStorageKey,
+      currentConnectionStorageKey: runtimeEditionConfig.currentConnectionStorageKey,
+      activeConsoleIdStorageKey: runtimeEditionConfig.activeConsoleIdStorageKey,
+      currentPageStorageKey: runtimeEditionConfig.currentPageStorageKey,
+      indexedDbKeyPrefix: runtimeEditionConfig.indexedDbKeyPrefix,
+      dexieDatabaseName: runtimeEditionConfig.dexieDatabaseName,
+      localSqlDirectoryPathStorageKey: runtimeEditionConfig.localSqlDirectoryPathStorageKey,
+      localSqlDirectoryPathsStorageKey: runtimeEditionConfig.localSqlDirectoryPathsStorageKey,
+    },
+    {
+      clientStorageEdition: 'enterprise',
+      globalStoreName: 'Chat2DB_Global_Store',
+      userStoreName: 'Chat2DB_User_Store',
+      orgStoreName: 'Chat2DB_Org_Store',
+      workspaceStoreName: 'Chat2DB_Workspace_Store',
+      aiStoreName: 'Chat2DB_AI_Store',
+      treeStoreName: 'Chat2DB_Tree_Store',
+      localStorageVersionKey: 'app-local-storage-versions',
+      aiModelConfigStorageKey: 'chat2db_v3_model_configs',
+      loginRedirectStorageKey: 'loginRedirectUrl',
+      desktopResponseHeaderStorageKey: 'Chat2db',
+      sidebarExpandedStorageKey: 'chat2db_sidebar_expanded',
+      notificationPopupStorageKey: 'popedNotification',
+      contentDiffDisabledSurfacesStorageKey: 'chat2db.contentDiff.disabledSurfaces',
+      googleAdsSignupPendingStorageKey: 'gads_signup_pending',
+      googleAdsSignupOnceStorageKeyPrefix: 'gads_signup',
+      googleAdsPurchaseOnceStorageKeyPrefix: 'gads_purchase',
+      pricingAutoPopupStorageKey: 'pricing-auto-popup-dismissed-at',
+      dailyPopupStorageKeyPrefix: '',
+      currentWorkspaceDatabaseStorageKey: 'current-workspace-database',
+      currentConnectionStorageKey: 'cur-connection',
+      activeConsoleIdStorageKey: 'active-console-id',
+      currentPageStorageKey: 'curPage',
+      indexedDbKeyPrefix: '',
+      dexieDatabaseName: 'chat2db_database',
+      localSqlDirectoryPathStorageKey: 'chat2db.localSqlFileTree.rootPath',
+      localSqlDirectoryPathsStorageKey: 'chat2db.localSqlFileTree.rootPaths',
+    },
+  );
+
+  console.log('Runtime edition storage contract tests passed');
+}
+
+void main();

--- a/chat2db-community-client/src/constants/runtimeEdition.ts
+++ b/chat2db-community-client/src/constants/runtimeEdition.ts
@@ -6,6 +6,7 @@ import type { GlobalAppConfig } from '@/typings/settings';
 import { RUNTIME_ENV, isCommunityEnv, isDesktop, isDesktopEnv, isOfflineEnv } from '@/utils/env';
 
 export type SettingMenuProfile = 'commercial' | 'local' | 'community';
+export type ClientStorageEdition = 'enterprise' | 'community';
 
 export interface RuntimeEditionConfig {
   mode: string;
@@ -33,6 +34,7 @@ export interface RuntimeEditionConfig {
   feedbackEntry: boolean;
   languageRegionRestricted: boolean;
   settingMenuProfile: SettingMenuProfile;
+  clientStorageEdition: ClientStorageEdition;
   globalStoreName: string;
   userStoreName: string;
   orgStoreName: string;
@@ -91,6 +93,7 @@ const commonConfig: RuntimeEditionConfig = {
   feedbackEntry: true,
   languageRegionRestricted: true,
   settingMenuProfile: 'commercial',
+  clientStorageEdition: 'enterprise',
   globalStoreName: 'Chat2DB_Global_Store',
   userStoreName: 'Chat2DB_User_Store',
   orgStoreName: 'Chat2DB_Org_Store',
@@ -138,32 +141,9 @@ const localConfig: RuntimeEditionConfig = {
   dashboardHostedAiGenerate: true,
   feedbackEntry: false,
   settingMenuProfile: 'local',
-  globalStoreName: 'Chat2DB_Local_Global_Store',
-  userStoreName: 'Chat2DB_Local_User_Store',
-  orgStoreName: 'Chat2DB_Local_Org_Store',
-  workspaceStoreName: 'Chat2DB_Local_Workspace_Store',
-  aiStoreName: 'Chat2DB_Local_AI_Store',
-  treeStoreName: 'Chat2DB_Local_Tree_Store',
-  localStorageVersionKey: 'app-local-storage-versions-local',
-  aiModelConfigStorageKey: 'chat2db_ai_model_configs',
-  loginRedirectStorageKey: 'chat2db-local-login-redirect-url',
-  desktopResponseHeaderStorageKey: 'Chat2db_Local',
-  sidebarExpandedStorageKey: 'chat2db_local_sidebar_expanded',
-  notificationPopupStorageKey: 'chat2db-local-popedNotification',
-  contentDiffDisabledSurfacesStorageKey: 'chat2db.local.contentDiff.disabledSurfaces',
-  googleAdsSignupPendingStorageKey: 'gads_signup_pending_local',
-  googleAdsSignupOnceStorageKeyPrefix: 'gads_signup_local',
-  googleAdsPurchaseOnceStorageKeyPrefix: 'gads_purchase_local',
-  pricingAutoPopupStorageKey: 'pricing-auto-popup-dismissed-at-local',
-  dailyPopupStorageKeyPrefix: 'chat2db-local-popup',
-  currentWorkspaceDatabaseStorageKey: 'chat2db-local-current-workspace-database',
-  currentConnectionStorageKey: 'chat2db-local-cur-connection',
-  activeConsoleIdStorageKey: 'chat2db-local-active-console-id',
-  currentPageStorageKey: 'chat2db-local-curPage',
-  indexedDbKeyPrefix: 'chat2db_local',
-  dexieDatabaseName: 'chat2db_local_database',
-  localSqlDirectoryPathStorageKey: 'chat2db.local.localSqlFileTree.rootPath',
-  localSqlDirectoryPathsStorageKey: 'chat2db.local.localSqlFileTree.rootPaths',
+  aiModelConfigStorageKey: 'chat2db_v3_model_configs',
+  loginRedirectStorageKey: 'loginRedirectUrl',
+  indexedDbKeyPrefix: '',
 };
 
 const communityConfig: RuntimeEditionConfig = {
@@ -193,6 +173,7 @@ const communityConfig: RuntimeEditionConfig = {
   feedbackEntry: false,
   languageRegionRestricted: false,
   settingMenuProfile: 'community',
+  clientStorageEdition: 'community',
   globalStoreName: 'Chat2DB_Community_Global_Store',
   userStoreName: 'Chat2DB_Community_User_Store',
   orgStoreName: 'Chat2DB_Community_Org_Store',

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeftActionBar/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeftActionBar/index.tsx
@@ -12,6 +12,7 @@ import i18n from '@/i18n';
 import { searchTreeNodes } from '@/utils';
 import { filterTreeNodesForDisplay } from '@/utils/filterTreeNodes';
 import { runtimeEditionConfig } from '@/constants/runtimeEdition';
+import useRuntimeEditionCapabilities from '@/hooks/useRuntimeEditionCapabilities';
 import createRequest from '@/service/base';
 import { useUpdateEffect } from 'ahooks';
 import { debounce } from 'lodash';
@@ -71,6 +72,7 @@ const WorkspaceLeftActionBar = memo<WorkspaceLeftActionBarProps>(
     );
 
     const { styles } = useStyles();
+    const { aiDataCollection } = useRuntimeEditionCapabilities();
     const showStorageMigration = !isEmbedIframe && runtimeEditionConfig.settingMenuProfile !== 'community';
     const [migrationPending, setMigrationPending] = useState(false);
 
@@ -106,14 +108,14 @@ const WorkspaceLeftActionBar = memo<WorkspaceLeftActionBarProps>(
         }
         const visibleTreeData = filterTreeNodesForDisplay(treeStore.treeData || [], {
           hiddenTreeNodeIds: treeStore.hiddenTreeNodeIds,
-          aiDataCollectionEnabled: runtimeEditionConfig.aiDataCollection,
+          aiDataCollectionEnabled: aiDataCollection,
         });
         const { matchedNodes, matchedKeys, parentIdsWithMatches } = searchTreeNodes(visibleTreeData, value);
         treeStore.setSearchResult(matchedNodes);
         treeStore.setSearchResultKeys(matchedKeys);
         treeStore.setExpandedKeys([...parentIdsWithMatches, ...treeStore.expandedKeys]);
       }, 300),
-      [],
+      [aiDataCollection],
     );
 
     useUpdateEffect(() => {

--- a/chat2db-community-client/src/store/indexDB/index.ts
+++ b/chat2db-community-client/src/store/indexDB/index.ts
@@ -4,6 +4,7 @@ import { devtools } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
 import { StateCreator } from 'zustand/vanilla';
+import { resolveIndexedDbStorageKey } from './storageKey';
 
 interface IndexDBState {
   indexDB: any;
@@ -28,13 +29,13 @@ export const createIndexDBAction: StateCreator<
   IndexDBAction
 > = () => ({
   setValue: (key, value) => {
-    return set(`${runtimeEditionConfig.indexedDbKeyPrefix}:${key}`, value);
+    return set(resolveIndexedDbStorageKey(key, runtimeEditionConfig.indexedDbKeyPrefix), value);
   },
   getValue: (key) => {
-    return get(`${runtimeEditionConfig.indexedDbKeyPrefix}:${key}`);
+    return get(resolveIndexedDbStorageKey(key, runtimeEditionConfig.indexedDbKeyPrefix));
   },
   deleteValue: (key) => {
-    return del(`${runtimeEditionConfig.indexedDbKeyPrefix}:${key}`);
+    return del(resolveIndexedDbStorageKey(key, runtimeEditionConfig.indexedDbKeyPrefix));
   },
 });
 

--- a/chat2db-community-client/src/store/indexDB/storageKey.test.ts
+++ b/chat2db-community-client/src/store/indexDB/storageKey.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { resolveIndexedDbStorageKey } from './storageKey';
+
+assert.equal(resolveIndexedDbStorageKey('workspaceTabId', ''), 'workspaceTabId');
+assert.equal(resolveIndexedDbStorageKey('consoleId', ''), 'consoleId');
+assert.equal(resolveIndexedDbStorageKey('workspaceTabId', 'chat2db'), 'chat2db:workspaceTabId');
+assert.equal(resolveIndexedDbStorageKey('workspaceTabId', 'chat2db_community'), 'chat2db_community:workspaceTabId');
+
+console.log('IndexedDB storage key tests passed');

--- a/chat2db-community-client/src/store/indexDB/storageKey.ts
+++ b/chat2db-community-client/src/store/indexDB/storageKey.ts
@@ -1,0 +1,3 @@
+export function resolveIndexedDbStorageKey(key: string, prefix: string) {
+  return prefix ? `${prefix}:${key}` : key;
+}


### PR DESCRIPTION
Summary:
- preserve the published Local 5.3.0 client storage keys
- use runtime AI dataset capability while filtering the workspace tree
- add focused storage compatibility tests

Verification:
- yarn test:runtime-edition-storage
- yarn test:runtime-capabilities