### PR TITLE
chore: scope community code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 # Public ownership is intentionally explicit while the maintainer rotation grows.
-* @openai0229
+* @openai0229 @OtterMind/community-maintainers
 
 /.github/ @openai0229
 /script/github/ @openai0229
+/script/package/ @openai0229
+/docker/ @openai0229


### PR DESCRIPTION
## Summary
- add the community-maintainers team to ordinary code ownership
- keep GitHub workflows, packaging, GitHub automation, and Docker paths owner-owned

## Verification
- git diff --check

This is the repository-side CODEOWNERS half of the maintainer permission rollout. GitHub Rulesets and Actions defaults are configured separately.