### PR TITLE
ci(release): remove Community CDN publication

### DIFF
--- a/.github/workflows/jcef_release.yml
+++ b/.github/workflows/jcef_release.yml
@@ -27,10 +27,7 @@ jobs:
       version: ${{ steps.metadata.outputs.version }}
       tag_name: ${{ steps.metadata.outputs.tag_name }}
       channel: ${{ steps.metadata.outputs.channel }}
-      update_latest: ${{ steps.metadata.outputs.update_latest }}
       publish: ${{ steps.metadata.outputs.publish }}
-      package_prefix: ${{ steps.metadata.outputs.package_prefix }}
-      update_prefix: ${{ steps.metadata.outputs.update_prefix }}
     steps:
       - name: Validate version
         id: metadata
@@ -50,7 +47,6 @@ jobs:
             fi
             version="${REF_NAME#v}"
             channel=release
-            update_latest=true
             publish=true
           else
             if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
@@ -59,7 +55,6 @@ jobs:
             fi
             version="${INPUT_VERSION}"
             channel=beta
-            update_latest=false
             publish=false
           fi
 
@@ -80,17 +75,11 @@ jobs:
             exit 1
           fi
 
-          package_prefix="community/${version}"
-          update_prefix="community/updates/${version}"
-
           {
             echo "version=${version}"
             echo "tag_name=v${version}"
             echo "channel=${channel}"
-            echo "update_latest=${update_latest}"
             echo "publish=${publish}"
-            echo "package_prefix=${package_prefix}"
-            echo "update_prefix=${update_prefix}"
           } >> "${GITHUB_OUTPUT}"
 
   notify_start:
@@ -337,356 +326,11 @@ jobs:
             jpackage/input/sourceFile/*.jar
             jpackage/input/sourceFile/*.zip
 
-  cdn_release:
-    name: Publish Community release packages to CDN
-    needs:
-      - resolve
-      - build
-    if: ${{ needs.resolve.outputs.channel == 'release' }}
-    environment: community-release
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-    steps:
-      - name: Download platform artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          pattern: chat2db-community-${{ needs.resolve.outputs.version }}-*
-          path: downloaded-artifacts
-
-      - name: Validate CDN bundle and generate manifest
-        shell: bash
-        env:
-          VERSION: ${{ needs.resolve.outputs.version }}
-          CHANNEL: ${{ needs.resolve.outputs.channel }}
-          PACKAGE_PREFIX: ${{ needs.resolve.outputs.package_prefix }}
-          UPDATE_PREFIX: ${{ needs.resolve.outputs.update_prefix }}
-          CDN_BASE_URL: https://cdn.chat2db-ai.com
-          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-
-          expected=(
-            "Chat2DB-Community-${VERSION}-arm64.dmg"
-            "Chat2DB-Community-${VERSION}-x64.dmg"
-            "Chat2DB-Community-${VERSION}.msi"
-            "Chat2DB-Community-${VERSION}-amd64.deb"
-            "Chat2DB-Community-${VERSION}-arm64.deb"
-            "Chat2DB-Community-${VERSION}-x86_64.rpm"
-            "Chat2DB-Community-${VERSION}-aarch64.rpm"
-            "Chat2DB-Community-${VERSION}-x86_64.AppImage"
-            "Chat2DB-Community-${VERSION}-arm64.AppImage"
-          )
-
-          mapfile -d '' installers < <(
-            find downloaded-artifacts -type f \
-              \( -name '*.dmg' -o -name '*.msi' -o -name '*.deb' -o -name '*.rpm' -o -name '*.AppImage' \) \
-              -print0
-          )
-          if [ "${#installers[@]}" -ne "${#expected[@]}" ]; then
-            echo "Expected ${#expected[@]} installers, found ${#installers[@]}" >&2
-            printf ' - %s\n' "${installers[@]}" >&2
-            exit 1
-          fi
-
-          mkdir -p cdn-assets/release cdn-assets/updates
-          for asset in "${expected[@]}"; do
-            mapfile -t matches < <(find downloaded-artifacts -type f -name "${asset}")
-            if [ "${#matches[@]}" -ne 1 ]; then
-              echo "Expected exactly one ${asset}, found ${#matches[@]}" >&2
-              exit 1
-            fi
-            test -s "${matches[0]}"
-            cp "${matches[0]}" "cdn-assets/release/${asset}"
-          done
-
-          windows_artifact_dir="downloaded-artifacts/chat2db-community-${VERSION}-windows"
-          test -d "${windows_artifact_dir}" || {
-            echo "Windows artifact directory is missing: ${windows_artifact_dir}" >&2
-            exit 1
-          }
-          for payload in version.json chat2db-community.jar lib.zip dist.zip; do
-            mapfile -t matches < <(find "${windows_artifact_dir}" -type f -name "${payload}")
-            if [ "${#matches[@]}" -ne 1 ]; then
-              echo "Expected exactly one Windows update payload ${payload}, found ${#matches[@]}" >&2
-              exit 1
-            fi
-            test -s "${matches[0]}"
-            cp "${matches[0]}" "cdn-assets/updates/${payload}"
-          done
-
-          (
-            cd cdn-assets/release
-            sha256sum "${expected[@]}" > SHA256SUMS
-          )
-
-          VERSION="${VERSION}" CHANNEL="${CHANNEL}" PACKAGE_PREFIX="${PACKAGE_PREFIX}" UPDATE_PREFIX="${UPDATE_PREFIX}" CDN_BASE_URL="${CDN_BASE_URL}" RUN_URL="${RUN_URL}" python3 - <<'PY'
-          import hashlib
-          import json
-          import os
-          from pathlib import Path
-
-          release_dir = Path("cdn-assets/release")
-          files = []
-          for path in sorted(release_dir.iterdir()):
-              if path.name == "SHA256SUMS":
-                  continue
-              files.append(
-                  {
-                      "name": path.name,
-                      "size": path.stat().st_size,
-                      "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
-                      "url": f"{os.environ['CDN_BASE_URL']}/{os.environ['PACKAGE_PREFIX']}/{path.name}",
-                  }
-              )
-
-          update_metadata_path = Path("cdn-assets/updates/version.json")
-          update_metadata = json.loads(update_metadata_path.read_text(encoding="utf-8"))
-          for file in update_metadata.get("files", []):
-              file["url"] = (
-                  f"{os.environ['CDN_BASE_URL']}/{os.environ['UPDATE_PREFIX']}"
-                  f"/{file['serverFileName']}"
-              )
-          update_metadata_path.write_text(
-              json.dumps(update_metadata, ensure_ascii=False, indent=2) + "\n",
-              encoding="utf-8",
-          )
-
-          manifest = {
-              "edition": "Chat2DB Community",
-              "version": os.environ["VERSION"],
-              "channel": os.environ["CHANNEL"],
-              "run_url": os.environ["RUN_URL"],
-              "files": files,
-          }
-          Path("cdn-assets/release-manifest.json").write_text(
-              json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
-              encoding="utf-8",
-          )
-          PY
-
-      - name: Set up ossutil
-        uses: yizhoumo/setup-ossutil@02384914fef2758596b303e2035c47b8c3f80fb2
-        with:
-          endpoint: oss-us-west-1.aliyuncs.com
-          access-key-id: ${{ secrets.COMMUNITY_OSS_ACCESS_KEY_ID }}
-          access-key-secret: ${{ secrets.COMMUNITY_OSS_ACCESS_KEY_SECRET }}
-          ossutil-version: '1.7.16'
-
-      - name: Set up Aliyun CLI
-        uses: aliyun/setup-aliyun-cli-action@09a5f86915bb556e27bf050e9a5e339aeb073df5
-        with:
-          version: '3.4.8'
-
-      - name: Upload validated Community packages to CDN
-        shell: bash
-        env:
-          VERSION: ${{ needs.resolve.outputs.version }}
-          CHANNEL: ${{ needs.resolve.outputs.channel }}
-          PACKAGE_PREFIX: ${{ needs.resolve.outputs.package_prefix }}
-          UPDATE_PREFIX: ${{ needs.resolve.outputs.update_prefix }}
-          OSS_BUCKET_NAME: chat2db-cdn
-          CDN_BASE_URL: https://cdn.chat2db-ai.com
-          FEISHU_WEBHOOK_URL: ${{ secrets.COMMUNITY_FEISHU_RELEASE_NOTIFY_WEBHOOK }}
-          UPDATE_LATEST_VERSION_JSON: ${{ needs.resolve.outputs.update_latest }}
-        run: |
-          set -euo pipefail
-
-          send_package_notification() {
-            local package_name="$1"
-            local package_url="$2"
-            PACKAGE_NAME="${package_name}" PACKAGE_URL="${package_url}" CHANNEL="${CHANNEL}" python3 - <<'PY'
-          import json
-          import os
-          import urllib.error
-          import urllib.request
-
-          webhook = os.environ.get("FEISHU_WEBHOOK_URL", "")
-          if not webhook:
-              print("FEISHU_RELEASE_NOTIFY_WEBHOOK is not configured; skip package notification.")
-              raise SystemExit(0)
-
-          text = "\n".join(
-              [
-                  "Chat2DB Community package published to CDN",
-                  f"Version: {os.environ['VERSION']}",
-                  f"Channel: {os.environ['CHANNEL']}",
-                  f"Package: {os.environ['PACKAGE_NAME']}",
-                  f"Download URL: {os.environ['PACKAGE_URL']}",
-              ]
-          )
-          payload = json.dumps(
-              {"msg_type": "text", "content": {"text": text}}, ensure_ascii=False
-          ).encode("utf-8")
-          request = urllib.request.Request(
-              webhook,
-              data=payload,
-              headers={"Content-Type": "application/json"},
-              method="POST",
-          )
-          try:
-              with urllib.request.urlopen(request, timeout=15) as response:
-                  result = json.loads(response.read().decode("utf-8"))
-              if result.get("code", 0) != 0:
-                  print(f"::warning::Feishu package notification was rejected: {result}")
-          except urllib.error.URLError as exc:
-              print(f"::warning::Feishu package notification failed: {exc}")
-          PY
-          }
-
-          for file in cdn-assets/release/*; do
-            name="$(basename "${file}")"
-            destination="oss://${OSS_BUCKET_NAME}/${PACKAGE_PREFIX}/${name}"
-            ossutil cp -f --meta "Cache-Control:no-cache" "${file}" "${destination}"
-            ossutil stat "${destination}"
-            if [ "${name}" != "SHA256SUMS" ]; then
-              send_package_notification "${name}" "${CDN_BASE_URL}/${PACKAGE_PREFIX}/${name}"
-            fi
-          done
-
-          for file in cdn-assets/updates/*; do
-            name="$(basename "${file}")"
-            destination="oss://${OSS_BUCKET_NAME}/${UPDATE_PREFIX}/${name}"
-            ossutil cp -f --meta "Cache-Control:no-cache" "${file}" "${destination}"
-            ossutil stat "${destination}"
-          done
-
-          if [ "${UPDATE_LATEST_VERSION_JSON}" = "true" ]; then
-            VERSION="${VERSION}" UPDATE_PREFIX="${UPDATE_PREFIX}" CDN_BASE_URL="${CDN_BASE_URL}" python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          payload = {
-              "latestVersion": os.environ["VERSION"],
-              "metadataUrl": f"{os.environ['CDN_BASE_URL']}/{os.environ['UPDATE_PREFIX']}/version.json",
-              "forceUpdate": False,
-          }
-          Path("cdn-assets/latest_version.json").write_text(
-              json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
-              encoding="utf-8",
-          )
-          PY
-            destination="oss://${OSS_BUCKET_NAME}/community/updates/latest_version.json"
-            ossutil cp -f --meta "Cache-Control:no-cache" cdn-assets/latest_version.json "${destination}"
-            ossutil stat "${destination}"
-          fi
-
-          manifest_destination="oss://${OSS_BUCKET_NAME}/${PACKAGE_PREFIX}/release-manifest.json"
-          ossutil cp -f --meta "Cache-Control:no-cache" cdn-assets/release-manifest.json "${manifest_destination}"
-          ossutil stat "${manifest_destination}"
-
-      - name: Refresh Community CDN cache
-        if: ${{ needs.resolve.outputs.channel == 'release' }}
-        shell: bash
-        env:
-          ALIBABA_CLOUD_ACCESS_KEY_ID: ${{ secrets.COMMUNITY_OSS_ACCESS_KEY_ID }}
-          ALIBABA_CLOUD_ACCESS_KEY_SECRET: ${{ secrets.COMMUNITY_OSS_ACCESS_KEY_SECRET }}
-          ALIBABA_CLOUD_REGION_ID: cn-hangzhou
-          PACKAGE_PREFIX: ${{ needs.resolve.outputs.package_prefix }}
-          UPDATE_PREFIX: ${{ needs.resolve.outputs.update_prefix }}
-          CDN_BASE_URL: https://cdn.chat2db-ai.com
-          UPDATE_LATEST_VERSION_JSON: ${{ needs.resolve.outputs.update_latest }}
-        run: |
-          set -euo pipefail
-
-          refresh_task_ids=()
-
-          submit_refresh() {
-            local object_path="$1"
-            local object_type="$2"
-            local force="${3:-}"
-            local -a command=(
-              aliyun cdn RefreshObjectCaches
-              --ObjectPath "${object_path}"
-              --ObjectType "${object_type}"
-            )
-            if [ -n "${force}" ]; then
-              command+=(--Force "${force}")
-            fi
-
-            local output task_id
-            output="$("${command[@]}")"
-            echo "${output}"
-            task_id="$(jq -r '.RefreshTaskId // empty' <<<"${output}")"
-            if [ -z "${task_id}" ]; then
-              echo "CDN refresh response did not include RefreshTaskId for ${object_path}" >&2
-              exit 1
-            fi
-            refresh_task_ids+=("${task_id}")
-          }
-
-          wait_for_refresh() {
-            local task_id="$1"
-            local deadline=$((SECONDS + 300))
-
-            while [ "${SECONDS}" -lt "${deadline}" ]; do
-              local output status
-              output="$(aliyun cdn DescribeRefreshTasks --TaskId "${task_id}")"
-              status="$(jq -r '
-                (.Tasks.CDNTask // []) as $tasks
-                | if ($tasks | length) == 0 then "Pending"
-                  elif any($tasks[]; .Status == "Failed") then "Failed"
-                  elif all($tasks[]; .Status == "Complete") then "Complete"
-                  else "Refreshing"
-                  end
-              ' <<<"${output}")"
-
-              if [ "${status}" = "Complete" ]; then
-                echo "CDN refresh task ${task_id} completed"
-                return 0
-              fi
-              if [ "${status}" = "Failed" ]; then
-                echo "CDN refresh task ${task_id} failed: ${output}" >&2
-                return 1
-              fi
-              sleep 5
-            done
-
-            echo "Timed out waiting for CDN refresh task ${task_id}" >&2
-            return 1
-          }
-
-          submit_refresh \
-            "${CDN_BASE_URL}/${PACKAGE_PREFIX}/" \
-            Directory \
-            true
-          submit_refresh \
-            "${CDN_BASE_URL}/${UPDATE_PREFIX}/" \
-            Directory \
-            true
-
-          if [ "${UPDATE_LATEST_VERSION_JSON}" = "true" ]; then
-            submit_refresh \
-              "${CDN_BASE_URL}/community/updates/latest_version.json" \
-              File
-          fi
-
-          mapfile -t refresh_task_ids < <(
-            printf '%s\n' "${refresh_task_ids[@]}" | sort -u
-          )
-          for task_id in "${refresh_task_ids[@]}"; do
-            wait_for_refresh "${task_id}"
-          done
-
-      - name: Upload CDN distribution receipt
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: community-cdn-receipt-${{ needs.resolve.outputs.version }}
-          if-no-files-found: error
-          overwrite: true
-          path: |
-            cdn-assets/release/SHA256SUMS
-            cdn-assets/release-manifest.json
-            cdn-assets/latest_version.json
-
   notify_summary:
     name: Notify Feishu Community beta build summary
     needs:
       - resolve
       - build
-      - cdn_release
     if: ${{ always() && needs.resolve.outputs.channel == 'beta' }}
     environment: community-beta-signing
     runs-on: ubuntu-latest
@@ -880,7 +524,6 @@ jobs:
     needs:
       - resolve
       - stage_release
-      - cdn_release
     if: ${{ needs.resolve.outputs.publish == 'true' }}
     uses: ./.github/workflows/pushdocker.yml
     with:
@@ -895,7 +538,6 @@ jobs:
     needs:
       - resolve
       - stage_release
-      - cdn_release
       - docker
     if: ${{ needs.resolve.outputs.publish == 'true' }}
     environment: community-release


### PR DESCRIPTION
## Related issue

Closes #2724

## Summary

Remove the Alibaba Cloud OSS/CDN publication job from the Community desktop release workflow. Formal numeric `v*` tags continue to build signed/notarized packages, stage and publish the validated GitHub Release, and publish Docker images; manual beta builds remain GitHub Actions artifact-only.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `actionlint .github/workflows/jcef_release.yml` passed; Ruby YAML parsing passed; `git diff --check` passed; search confirmed no `cdn_release`, `COMMUNITY_OSS_*`, OSS bucket, or Aliyun setup references remain.
- Manual verification: Reviewed the resulting dependency graph: beta summary depends on `resolve` and `build`; Docker depends on `resolve` and `stage_release`; final GitHub Release depends on `resolve`, `stage_release`, and `docker`.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A; no application API or stored data changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: Removes Alibaba Cloud credentials from this workflow; Apple signing, Feishu, and Docker credentials are unchanged.
- Community / Local / Pro boundary: Community desktop release workflow only.
- Backward compatibility: Existing CDN objects remain untouched, but future releases will be distributed through GitHub Releases and Docker Hub only and will no longer update CDN updater metadata.

## Reviewer map

- Start here: `.github/workflows/jcef_release.yml`, from the end of the matrix build into `notify_summary`, `stage_release`, `docker`, and `publish_release`.
- Failure condition: A formal tag no longer reaches GitHub Release or Docker publication, or the workflow still references Alibaba Cloud OSS/CDN inputs.
- Rollback or disable path: Revert this commit to restore the former `cdn_release` job and dependencies.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with the scoped workflow edit and static verification.