### PR TITLE
chore(repo): update Community maintainer team owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Public ownership is intentionally explicit while the maintainer rotation grows.
-* @openai0229 @OtterMind/community-maintainers
+* @openai0229 @OtterMind/chat2db-community-maintainers
 
 /.github/ @openai0229
 /script/github/ @openai0229


### PR DESCRIPTION
## Related issue

Closes #2726

## Summary

Update the default CODEOWNERS entry after the organization team was renamed from `community-maintainers` to `chat2db-community-maintainers`. Owner-only workflow, packaging, Docker, and GitHub automation paths remain assigned to `@openai0229`.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `git diff --check` passed; repository search found no remaining `@OtterMind/community-maintainers` reference.
- Manual verification: Read back the renamed team ID and its unchanged Write association to `OtterMind/Chat2DB`.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: Restores the intended Code Owner mapping to the active team slug.
- Community / Local / Pro boundary: Repository contribution ownership only.
- Backward compatibility: The old team slug no longer resolves after the rename.

## Reviewer map

- Start here: `.github/CODEOWNERS`.
- Failure condition: The renamed team is not recognized as default source owner.
- Rollback or disable path: Rename the team back or revert this CODEOWNERS entry.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with the scoped CODEOWNERS update and verification.