### PR TITLE
chore(repo): align Community contributor ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Public ownership is intentionally explicit while the maintainer rotation grows.
-* @openai0229 @OtterMind/chat2db-community-maintainers
+* @openai0229 @OtterMind/chat2db-community-contributors
 
 /.github/ @openai0229
 /script/github/ @openai0229


### PR DESCRIPTION
## Related issue

Closes #2728

## Summary

Update the default CODEOWNERS entry to the renamed `chat2db-community-contributors` Team. The name reflects trusted contributors with gated Write/merge and beta-build access without implying project maintainer or release-owner authority.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `git diff --check` passed; repository search found no remaining old Team slug.
- Manual verification: Team id `19064630` retains both members and exactly one repository association, `OtterMind/Chat2DB`, at Write permission.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: Keeps Code Owner resolution aligned with the active least-privilege Team.
- Community / Local / Pro boundary: Community contribution ownership only.
- Backward compatibility: Past mentions of the old slug may no longer resolve, which is inherent to the Team rename.

## Reviewer map

- Start here: `.github/CODEOWNERS`.
- Failure condition: The renamed Team is not recognized as a default source owner.
- Rollback or disable path: Rename the Team back or revert this CODEOWNERS entry.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with the scoped Team-name alignment and verification.