### PR TITLE
docs(repo): define trusted contributor review role

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,47 @@
 /script/github/ @openai0229
 /script/package/ @openai0229
 /docker/ @openai0229
+
+# AI changes should go directly to auenger; openai0229 is the backup owner
+# when auenger authored or made the latest push to the pull request.
+/chat2db-community-client/src/blocks/AI/ @auenger @openai0229
+/chat2db-community-client/src/store/ai/ @auenger @openai0229
+/chat2db-community-client/src/store/*/slices/ai/ @auenger @openai0229
+/chat2db-community-client/src/service/ai*.ts @auenger @openai0229
+/chat2db-community-client/src/service/magicStick.ts @auenger @openai0229
+/chat2db-community-client/src/service/knowledgeManagement.ts @auenger @openai0229
+/chat2db-community-client/src/service/llm/ @auenger @openai0229
+/chat2db-community-client/src/hooks/useStreamChatAI.ts @auenger @openai0229
+/chat2db-community-client/src/typings/ai.ts @auenger @openai0229
+/chat2db-community-client/src/typings/knowledgeManagement.ts @auenger @openai0229
+/chat2db-community-client/src/typings/llm/ @auenger @openai0229
+/chat2db-community-client/src/i18n/**/ai.ts @auenger @openai0229
+/chat2db-community-client/src/i18n/**/knowledgeManagement.ts @auenger @openai0229
+/chat2db-community-client/src/constants/knowledgeManagement.ts @auenger @openai0229
+/chat2db-community-client/src/components/AI*/ @auenger @openai0229
+/chat2db-community-client/src/components/ChangeAiTableInfo/ @auenger @openai0229
+/chat2db-community-client/src/components/FieldPromptInput/ @auenger @openai0229
+/chat2db-community-client/src/components/PromptExample/ @auenger @openai0229
+/chat2db-community-client/src/blocks/DatabaseTableEditor/AICreateTable/ @auenger @openai0229
+/chat2db-community-client/src/blocks/NewTree/functions/ai.ts @auenger @openai0229
+/chat2db-community-client/src/blocks/NewTree/functions/createAiDataCollection.tsx @auenger @openai0229
+/chat2db-community-client/src/pages/main/knowledgeManagement/ @auenger @openai0229
+/chat2db-community-client/src/pages/main/workspace/components/NewViewAllTable/components/addAiDataCollection.tsx @auenger @openai0229
+/chat2db-community-client/src/utils/staticModal/createAiDataCollectionTips.tsx @auenger @openai0229
+
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/enums/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/model/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/model/request/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/service/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/converter/AiModelConfigConverter.java @auenger @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/converter/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/enums/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/model/request/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/model/response/ai/ @auenger @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/controller/AiChatController.java @auenger @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/controller/AiCharacterController.java @auenger @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/mcp/adapter/AiToolMcpAdapter.java @auenger @openai0229
+/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/adapter/ai/ @auenger @openai0229

--- a/.github/COMMUNITY_OPERATIONS.md
+++ b/.github/COMMUNITY_OPERATIONS.md
@@ -135,8 +135,14 @@ Review in this order:
 5. Documentation, migration, and rollback needs.
 
 All required checks and review conversations must pass before merge. When a
-real second reviewer joins the rotation, enable a required approving review on
-`main`; until then, do not claim that independent review is enforced.
+pull request targets `main`, the active repository rules require one approving
+review, Code Owner approval, approval after the latest push by someone other
+than the latest pusher, all required status checks, and resolution of every
+review conversation. Trusted Contributors may review and merge only after
+GitHub reports that all of these requirements are satisfied. The current role,
+review request path, protected ownership paths, beta-build permission, and
+release boundaries are documented in
+[`CONTRIBUTING.md`](../CONTRIBUTING.md#trusted-contributors).
 
 ### 7. Milestone And Release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,76 @@ A good pull request description should include:
 
 Please avoid mixing unrelated changes in one pull request.
 
+## Trusted Contributors
+
+Trusted Contributors are experienced Community contributors invited by the
+repository administrators to help review and land changes. The role is granted
+through the `@OtterMind/chat2db-community-contributors` team and is scoped to
+this repository. It is not a Maintainer or Release Owner appointment.
+
+The current Trusted Contributor is:
+
+- [@auenger](https://github.com/auenger)
+
+The repository administrator, Code Owner, and Release Owner is
+[@openai0229](https://github.com/openai0229). This is a separate role with
+additional permissions.
+
+### Requesting A Review
+
+Pull request authors and maintainers may request a review from
+`@OtterMind/chat2db-community-contributors` or from an individual Trusted
+Contributor. Use the GitHub reviewer selector when it is available; otherwise,
+mention the team or reviewer in a pull request comment.
+
+Trusted Contributors may comment, approve, or request changes. For general
+repository paths, a valid approval from a Trusted Contributor can satisfy the
+required approval and Code Owner review. The approval must be from someone
+other than the author and the person who made the latest push.
+
+Pull requests that change the AI frontend, model configuration, chat stream,
+or Community AI backend paths listed in [`CODEOWNERS`](.github/CODEOWNERS)
+should request [@auenger](https://github.com/auenger) directly. His approval
+can satisfy the Code Owner requirement for those paths. `@openai0229` remains
+the backup Code Owner when `@auenger` authored or made the latest push to the
+pull request.
+
+Changes under `.github/`, `script/github/`, `script/package/`, and `docker/`
+require Code Owner approval from `@openai0229`. Trusted Contributor reviews are
+welcome on these changes, but they do not replace that approval.
+
+### Role Permissions And Boundaries
+
+Trusted Contributors may:
+
+- create and update non-protected repository branches;
+- review Community pull requests and help contributors resolve review threads;
+- merge a pull request into `main` after GitHub reports that every required
+  review, Code Owner approval, latest-push approval, status check, and review
+  conversation has passed; and
+- manually run the `Build Community Desktop Release` workflow from `main` with
+  a numeric version without the `v` prefix, such as `5.3.4`, to produce beta
+  artifacts in GitHub Actions.
+
+Trusted Contributors may not:
+
+- push or force-push directly to `main`;
+- bypass required reviews, status checks, Code Owner approval, latest-push
+  approval, or unresolved review conversations;
+- create, update, or delete release tags;
+- publish a formal GitHub Release or Community Docker image;
+- change repository access, rulesets, environments, or Actions secrets; or
+- treat access to beta workflows as access to signing credentials. Secret
+  values remain confidential and must never be printed, copied, or disclosed.
+
+Beta runs publish GitHub Actions artifacts only. Formal releases and Docker
+publication start from a protected tag and remain the responsibility of the
+Release Owner.
+
+Repository administrators grant or revoke the role based on sustained useful
+contributions, review quality, security judgment, familiarity with the
+Community workflow, and the project's current need for additional reviewers.
+
 ## Local Setup
 
 Please refer to the README for the latest setup instructions.


### PR DESCRIPTION
## Related issue

N/A - repository governance documentation requested by the repository administrator.

## Summary

- Document the Trusted Contributor role, current role holder, review path, merge gates, beta permission, and release boundaries.
- Route Community AI ownership to @auenger with @openai0229 as backup for self-authored or latest-push cases.
- Update the maintainer runbook to match the active main branch rulesets.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [x] Documentation only

## Verification

- Commands and results: ruby script/github/validate-community-operations.rb passed; git diff --check passed; GitHub CODEOWNERS errors API returned an empty errors list for this branch.
- Manual verification: Confirmed @auenger has Write permission and compared the documented gates with all three active repository rulesets.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A - documentation and review ownership only.
- Database or driver compatibility: N/A.
- Network, privacy, or security: Clarifies that beta access does not expose secret values and preserves release-owner-only tag publication.
- Community / Local / Pro boundary: Community repository governance only.
- Backward compatibility: Existing protected paths remain owned by @openai0229; AI paths add @auenger with an owner fallback.

## Reviewer map

- Start here: CONTRIBUTING.md, Trusted Contributors.
- Failure condition: GitHub rejects a CODEOWNERS pattern or requests the wrong owner for an AI path.
- Rollback or disable path: Revert this documentation commit and restore the previous CODEOWNERS entries.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A - administrator-directed repository governance update.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below.

AI assistance: Codex drafted the documentation and mapped the source paths; the repository administrator supplied the role and review policy.