### PR TITLE
docs(repo): define Trusted Contributor focus areas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,54 @@
 /script/package/ @openai0229
 /docker/ @openai0229
 
+# Database changes should go directly to Aias00; openai0229 remains an owner
+# for cross-cutting changes and when Aias00 authored or made the latest push.
+/chat2db-community-client/src/blocks/CanvasTable/ @Aias00 @openai0229
+/chat2db-community-client/src/blocks/CreateConnection/ @Aias00 @openai0229
+/chat2db-community-client/src/blocks/DatabaseTableEditor/ @Aias00 @openai0229
+/chat2db-community-client/src/blocks/EditTableView/ @Aias00 @openai0229
+/chat2db-community-client/src/blocks/RedisAllData/ @Aias00 @openai0229
+/chat2db-community-client/src/blocks/SchemaSync/ @Aias00 @openai0229
+/chat2db-community-client/src/blocks/SearchResult/ @Aias00 @openai0229
+/chat2db-community-client/src/components/SQLEditor/ @Aias00 @openai0229
+/chat2db-community-client/src/service/connection.ts @Aias00 @openai0229
+/chat2db-community-client/src/service/database/ @Aias00 @openai0229
+/chat2db-community-client/src/service/dataSource*.ts @Aias00 @openai0229
+/chat2db-community-client/src/service/nonRelationalDatabase/ @Aias00 @openai0229
+/chat2db-community-client/src/service/schemaSync.ts @Aias00 @openai0229
+/chat2db-community-client/src/service/sql*.ts @Aias00 @openai0229
+/chat2db-community-client/src/store/tree/ @Aias00 @openai0229
+/chat2db-community-client/src/typings/connection.ts @Aias00 @openai0229
+/chat2db-community-client/src/typings/console.ts @Aias00 @openai0229
+/chat2db-community-client/src/typings/database.ts @Aias00 @openai0229
+/chat2db-community-client/src/typings/redis.ts @Aias00 @openai0229
+/chat2db-community-client/src/typings/schema.ts @Aias00 @openai0229
+/chat2db-community-client/src/typings/sqlParser.ts @Aias00 @openai0229
+
+/chat2db-community-server/chat2db-community-plugins/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-spi/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/enums/completion/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/enums/parser/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/model/completion/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/model/datasource/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/model/metadata/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/model/request/db/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/model/request/sql/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/service/db/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/completion/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/completion/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/db/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/controller/Db*.java @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/converter/data/source/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/converter/db/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/converter/driver/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/model/request/db/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/model/request/driver/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/model/response/db/ @Aias00 @openai0229
+/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/model/response/driver/ @Aias00 @openai0229
+
 # AI changes should go directly to auenger; openai0229 is the backup owner
 # when auenger authored or made the latest push to the pull request.
 /chat2db-community-client/src/blocks/AI/ @auenger @openai0229

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,9 +178,10 @@ repository administrators to help review and land changes. The role is granted
 through the `@OtterMind/chat2db-community-contributors` team and is scoped to
 this repository. It is not a Maintainer or Release Owner appointment.
 
-The current Trusted Contributor is:
+The current Trusted Contributors are:
 
 - [@auenger](https://github.com/auenger)
+- [@Aias00](https://github.com/Aias00)
 
 The repository administrator, Code Owner, and Release Owner is
 [@openai0229](https://github.com/openai0229). This is a separate role with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,19 @@ Pull request authors and maintainers may request a review from
 Contributor. Use the GitHub reviewer selector when it is available; otherwise,
 mention the team or reviewer in a pull request comment.
 
+Use these focus areas to choose the first reviewer for an Issue or pull
+request:
+
+| Reviewer | Primary focus |
+| --- | --- |
+| [@auenger](https://github.com/auenger) | AI UI, model configuration, chat streams, prompts, knowledge management, and Community AI backend behavior |
+| [@Aias00](https://github.com/Aias00) | Database connections, plugins and SPI, metadata and object management, SQL execution, SQL editing, and result handling |
+| [@openai0229](https://github.com/openai0229) | Any area, especially cross-cutting changes, repository governance, security, packaging, and releases |
+
+These focus areas are routing guidance, not exclusive ownership. Any Issue or
+pull request may request `@openai0229`, including work initially reviewed by a
+Trusted Contributor.
+
 Trusted Contributors may comment, approve, or request changes. For general
 repository paths, a valid approval from a Trusted Contributor can satisfy the
 required approval and Code Owner review. The approval must be from someone
@@ -201,10 +214,17 @@ other than the author and the person who made the latest push.
 
 Pull requests that change the AI frontend, model configuration, chat stream,
 or Community AI backend paths listed in [`CODEOWNERS`](.github/CODEOWNERS)
-should request [@auenger](https://github.com/auenger) directly. His approval
+should request [@auenger](https://github.com/auenger) directly. Their approval
 can satisfy the Code Owner requirement for those paths. `@openai0229` remains
 the backup Code Owner when `@auenger` authored or made the latest push to the
 pull request.
+
+Pull requests that change database connections, database plugins or SPI,
+metadata and object management, SQL execution or editing, or result handling
+paths listed in [`CODEOWNERS`](.github/CODEOWNERS) should request
+[@Aias00](https://github.com/Aias00) directly. Their approval can satisfy the
+Code Owner requirement for those paths. `@openai0229` remains the backup Code
+Owner when `@Aias00` authored or made the latest push to the pull request.
 
 Changes under `.github/`, `script/github/`, `script/package/`, and `docker/`
 require Code Owner approval from `@openai0229`. Trusted Contributor reviews are


### PR DESCRIPTION
## Related issue

N/A - repository governance documentation requested by the repository administrator.

## Summary

- Sync the documented Trusted Contributor list with the active Team: @auenger and @Aias00.
- Route AI reviews primarily to @auenger and database reviews primarily to @Aias00.
- Keep @openai0229 available for every Issue and pull request and as Code Owner backup for both focus areas.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [x] Documentation only

## Verification

- Commands and results: ruby script/github/validate-community-operations.rb passed; git diff --check passed; GitHub CODEOWNERS errors API returned an empty errors list for this branch.
- Manual verification: Confirmed @auenger and @Aias00 each have Write without Maintain/Admin and confirmed active Team membership.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A - documentation and review ownership only.
- Database or driver compatibility: No implementation changes.
- Network, privacy, or security: No secret or environment changes.
- Community / Local / Pro boundary: Community repository governance only.
- Backward compatibility: @openai0229 remains an owner for every routed path; AI-specific paths follow database paths so the more specific AI ownership wins on overlap.

## Reviewer map

- Start here: CONTRIBUTING.md reviewer focus table and .github/CODEOWNERS database section.
- Failure condition: GitHub rejects a CODEOWNERS pattern or requests the wrong focus owner.
- Rollback or disable path: Revert the two commits in this pull request.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A - administrator-directed repository governance update.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below.

AI assistance: Codex mapped the source boundaries and drafted the documentation; the repository administrator supplied the contributor membership and focus-area policy.