### PR TITLE
chore(release): standardize GitHub Release titles

### DIFF
--- a/.github/COMMUNITY_OPERATIONS.md
+++ b/.github/COMMUNITY_OPERATIONS.md
@@ -159,6 +159,12 @@ Before closing a Milestone, the release owner verifies:
 - release notes link the delivered Issues and pull requests;
 - post-release installation or smoke verification is recorded.
 
+Formal version tags use `vX.Y.Z`. The corresponding GitHub Release title uses
+`Chat2DB vX.Y.Z`; do not append an edition suffix such as `Community` to the
+Release title. Application, installer, and package names may still use
+`Chat2DB Community` where the edition distinction is part of the product
+identity.
+
 The Milestone closes only after the GitHub Release is published and verified.
 
 ## Project State Matrix

--- a/.github/workflows/jcef_release.yml
+++ b/.github/workflows/jcef_release.yml
@@ -500,21 +500,24 @@ jobs:
           VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           set -euo pipefail
+          RELEASE_TITLE="Chat2DB v${VERSION}"
 
           if draft=$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null); then
             if [ "${draft}" != "true" ]; then
               echo "Release ${TAG_NAME} is already published; refusing to replace it" >&2
               exit 1
             fi
+            gh release edit "${TAG_NAME}" --title "${RELEASE_TITLE}"
             gh release upload "${TAG_NAME}" release-assets/* --clobber
           else
             gh release create "${TAG_NAME}" release-assets/* \
               --verify-tag \
               --draft \
               --generate-notes \
-              --title "Chat2DB Community ${VERSION}"
+              --title "${RELEASE_TITLE}"
           fi
 
+          test "$(gh release view "${TAG_NAME}" --json name --jq '.name')" = "${RELEASE_TITLE}"
           find release-assets -maxdepth 1 -type f -exec basename {} \; | sort > expected-assets.txt
           gh release view "${TAG_NAME}" --json assets --jq '.assets[].name' | sort > actual-assets.txt
           diff -u expected-assets.txt actual-assets.txt


### PR DESCRIPTION
## Summary

- name formal GitHub Releases as `Chat2DB vX.Y.Z` while keeping `vX.Y.Z` tags
- normalize the title when an existing draft Release is refreshed
- verify the resolved title before validating assets
- document the distinction between the GitHub Release title and the `Chat2DB Community` application/package identity

## Validation

- `actionlint .github/workflows/jcef_release.yml`
- Ruby YAML parsing
- `ruby script/github/validate-community-operations.rb`
- `git diff --check`
- live `gh release view v5.3.4 --json name,tagName,isDraft,isImmutable` field verification

## Operational state

Existing Releases `v5.3.0` through `v5.3.4` have already been normalized to `Chat2DB v5.3.x`; this PR makes future tag-driven releases follow the same rule.