### PR TITLE
fix(client): close confirmation before saved SQL naming

### DIFF
--- a/chat2db-community-client/src/utils/editorCloseConfirmation.tsx
+++ b/chat2db-community-client/src/utils/editorCloseConfirmation.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Button } from 'antd';
 import { staticModal } from '@chat2db/ui';
 import i18n from '@/i18n';
@@ -21,31 +20,24 @@ interface EditorCloseDialogFooterProps {
 const footerButtonStyle = { marginInlineStart: 0 };
 
 function EditorCloseDialogFooter({ editor, onDecision }: EditorCloseDialogFooterProps) {
-  const [saving, setSaving] = useState(false);
-
-  const handleSave = async () => {
-    if (!editor.saveBeforeClose || saving) {
+  const handleSave = () => {
+    if (!editor.saveBeforeClose) {
       return;
     }
-    setSaving(true);
-    try {
-      if (await editor.saveBeforeClose()) {
-        onDecision('saved');
-      }
-    } finally {
-      setSaving(false);
-    }
+    // Resolve the dialog before starting the save. An unnamed draft opens a
+    // second modal to collect its name, which must be the only active layer.
+    onDecision('save');
   };
 
   return (
     <div style={{ display: 'grid', gap: 8, width: '100%' }}>
-      <Button block type="primary" loading={saving} style={footerButtonStyle} onClick={handleSave}>
+      <Button block type="primary" style={footerButtonStyle} onClick={handleSave}>
         {i18n('common.button.save')}
       </Button>
-      <Button block disabled={saving} style={footerButtonStyle} onClick={() => onDecision('discard')}>
+      <Button block style={footerButtonStyle} onClick={() => onDecision('discard')}>
         {i18n('workspace.editorClose.dontSave')}
       </Button>
-      <Button block disabled={saving} style={footerButtonStyle} onClick={() => onDecision('cancel')}>
+      <Button block style={footerButtonStyle} onClick={() => onDecision('cancel')}>
         {i18n('common.button.cancel')}
       </Button>
     </div>
@@ -54,14 +46,13 @@ function EditorCloseDialogFooter({ editor, onDecision }: EditorCloseDialogFooter
 
 function requestEditorCloseDecision(tab: IWorkspaceTab, editor: EditorCloseGuardRef) {
   return new Promise<EditorCloseDecision>((resolve) => {
-    let settled = false;
-    const finish = (decision: EditorCloseDecision) => {
-      if (settled) {
+    let selectedDecision: EditorCloseDecision | undefined;
+    const finish = (nextDecision: EditorCloseDecision) => {
+      if (selectedDecision !== undefined) {
         return;
       }
-      settled = true;
+      selectedDecision = nextDecision;
       modal.destroy();
-      resolve(decision);
     };
     const modal = staticModal.confirm({
       icon: null,
@@ -75,10 +66,7 @@ function requestEditorCloseDecision(tab: IWorkspaceTab, editor: EditorCloseGuard
       footer: () => <EditorCloseDialogFooter editor={editor} onDecision={finish} />,
       onCancel: () => finish('cancel'),
       afterClose: () => {
-        if (!settled) {
-          settled = true;
-          resolve('cancel');
-        }
+        resolve(selectedDecision ?? 'cancel');
       },
     });
   });

--- a/chat2db-community-client/src/utils/editorCloseGuard.test.ts
+++ b/chat2db-community-client/src/utils/editorCloseGuard.test.ts
@@ -129,6 +129,21 @@ async function run() {
     3,
     'all close-dialog actions share the same horizontal alignment',
   );
+  assert.match(
+    confirmationSource,
+    /const handleSave = \(\) => \{[\s\S]*?onDecision\('save'\)/,
+    'the save action resolves the close dialog before the guard starts saving',
+  );
+  assert.doesNotMatch(
+    confirmationSource,
+    /await editor\.saveBeforeClose\(\)/,
+    'the close dialog must not keep a second save modal blocked behind it',
+  );
+  assert.match(
+    confirmationSource,
+    /afterClose: \(\) => \{[\s\S]*?resolve\(selectedDecision \?\? 'cancel'\)/,
+    'the guard waits for the close mask to finish its exit lifecycle',
+  );
 
   console.log('Editor close guard tests passed');
 }


### PR DESCRIPTION
## Related issue

Closes #2735

## Summary

When saving an unnamed dirty SQL draft from the editor-close confirmation, the confirmation modal previously stayed open while `saveBeforeClose()` opened the saved-SQL naming modal. The later static modal mask covered the name input and made it appear unclickable.

The Save action now resolves the close decision first. The close guard waits for the confirmation modal `afterClose` lifecycle, then invokes `saveBeforeClose()` exactly once. Existing saved queries and local SQL files continue through their normal save adapters.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:editor-close` - passed.
  - `yarn eslint src/utils/editorCloseConfirmation.tsx src/utils/editorCloseGuard.test.ts --max-warnings=0` - passed.
  - `python3 skills/chat2db-knowledge/scripts/knowledge_tool.py lint --project /Users/dawn/work/chat2db` - passed.
  - `git diff --check` - passed.
  - `yarn tsc --noEmit` - blocked by existing unrelated missing commercial modules and repository-wide type errors; no errors were reported for the changed files.
- Manual verification: Community frontend dev server responds at `http://127.0.0.1:8889/` with HTTP 200. Browser/JCEF click-through was not run.
- UI evidence: N/A; the fix changes modal sequencing and the regression is covered by the focused editor-close contract.

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Community frontend only; no backend or storage contract changes.
- Backward compatibility: Existing Save, Do not Save, and Cancel close decisions retain their behavior.

## Reviewer map

- Start here: `chat2db-community-client/src/utils/editorCloseConfirmation.tsx`.
- Failure condition: opening `InitialSaveNameModal` while the static editor-close confirmation mask is still mounted.
- Rollback or disable path: revert this commit; the persisted editor-close setting remains unchanged.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex implemented and verified the focused frontend fix and tests.