### PR TITLE
fix(tools): migrate legacy community config files on startup

### DIFF
--- a/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/runtime/ProductRuntimeIdentity.java
+++ b/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/runtime/ProductRuntimeIdentity.java
@@ -29,6 +29,24 @@ public interface ProductRuntimeIdentity {
         return "community";
     }
 
+    /**
+     * Config file name used by releases that predate
+     * {@link #runtimeConfigFileName(String)}; used only to migrate existing
+     * installations once, so a product whose legacy name differs can override.
+     */
+    default String legacyRuntimeConfigFileName(String environment) {
+        return "enterprise_config_" + environment + ".json";
+    }
+
+    /**
+     * Client id file name used by releases that predate
+     * {@link #clientIdFileName()}; used only to migrate existing
+     * installations once.
+     */
+    default String legacyClientIdFileName() {
+        return "enterprise_client_uuid";
+    }
+
     String displayName();
 
     String protocolScheme();

--- a/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/ConfigUtils.java
+++ b/chat2db-community-server/chat2db-community-tools/src/main/java/ai/chat2db/community/tools/util/ConfigUtils.java
@@ -15,6 +15,8 @@ import org.yaml.snakeyaml.Yaml;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,19 +54,75 @@ public class ConfigUtils {
                 versionFile = null;
             }
         }
-        configFile = new File(getBasePath() + File.separator + "config" + File.separator
-                + ProductRuntimeIdentityProvider.current().runtimeConfigFileName(environment));
+        File configDirectory = new File(getBasePath(), "config");
+        configFile = new File(configDirectory,
+                ProductRuntimeIdentityProvider.current().runtimeConfigFileName(environment));
+        File legacyConfigFile = new File(configDirectory,
+                ProductRuntimeIdentityProvider.current().legacyRuntimeConfigFileName(environment));
+        migrateLegacyFile(legacyConfigFile, configFile, "runtime config");
         if (!configFile.exists()) {
             FileUtil.writeUtf8String(JSON.toJSONString(new ConfigJson()), configFile);
         }
 
-        clientIdFile = new File(getBasePath() + File.separator + "config" + File.separator
-                + ProductRuntimeIdentityProvider.current().clientIdFileName());
+        clientIdFile = new File(configDirectory, ProductRuntimeIdentityProvider.current().clientIdFileName());
+        File legacyClientIdFile = new File(configDirectory,
+                ProductRuntimeIdentityProvider.current().legacyClientIdFileName());
+        migrateLegacyFile(legacyClientIdFile, clientIdFile, "client id");
         if (!clientIdFile.exists()) {
             String uuid = UUID.fastUUID().toString(true);
             FileUtil.writeUtf8String(uuid, clientIdFile);
             clientId = uuid;
         }
+    }
+
+    /**
+     * Upgrades from releases that stored the same data under the legacy file
+     * name would otherwise silently reset the runtime config (systemUuid,
+     * network status, latest startup version) and mint a new client id. Copy
+     * the legacy file once so the current name resolves to the existing data;
+     * the legacy file is kept untouched as a backup.
+     */
+    static void migrateLegacyFile(File legacyFile, File currentFile, String description) {
+        migrateLegacyFile(legacyFile, currentFile, description,
+                (source, staging) -> Files.copy(source, staging));
+    }
+
+    static void migrateLegacyFile(File legacyFile, File currentFile, String description,
+            LegacyFileCopier copier) {
+        Path staging = null;
+        try {
+            if (currentFile.exists() || !legacyFile.isFile()) {
+                return;
+            }
+            Path current = currentFile.toPath().toAbsolutePath().normalize();
+            Path parent = current.getParent();
+            if (parent == null) {
+                throw new IOException("Legacy file migration target has no parent");
+            }
+            Files.createDirectories(parent);
+            staging = parent.resolve("." + current.getFileName() + ".migrating-"
+                    + UUID.fastUUID().toString(true) + ".tmp");
+            copier.copy(legacyFile.toPath(), staging);
+            Files.move(staging, current);
+            staging = null;
+            log.info("Migrated legacy {} file {} to {}", description, legacyFile, currentFile);
+        } catch (IOException e) {
+            log.warn("Could not migrate legacy {} file {} to {}", description, legacyFile, currentFile, e);
+        } finally {
+            if (staging != null) {
+                try {
+                    Files.deleteIfExists(staging);
+                } catch (IOException cleanupError) {
+                    log.warn("Could not clean temporary legacy {} migration file {}", description, staging,
+                            cleanupError);
+                }
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface LegacyFileCopier {
+        void copy(Path source, Path target) throws IOException;
     }
 
     public static String getEnv() {

--- a/chat2db-community-server/chat2db-community-tools/src/test/java/ai/chat2db/community/tools/util/ConfigUtilsLegacyFileMigrationTest.java
+++ b/chat2db-community-server/chat2db-community-tools/src/test/java/ai/chat2db/community/tools/util/ConfigUtilsLegacyFileMigrationTest.java
@@ -1,0 +1,95 @@
+package ai.chat2db.community.tools.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigUtilsLegacyFileMigrationTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void legacyConfigAndClientIdFilesAreCopiedToCurrentNames() throws IOException {
+        Path configDirectory = Files.createDirectories(temporaryDirectory.resolve("config"));
+        Path legacyConfig = write(configDirectory.resolve("enterprise_config_dev.json"),
+                "{\"systemUuid\":\"keep-me\"}".getBytes());
+        Path legacyClientId = write(configDirectory.resolve("enterprise_client_uuid"),
+                "client-id-123".getBytes());
+        File currentConfig = configDirectory.resolve("runtime_config_dev.json").toFile();
+        File currentClientId = configDirectory.resolve("client_uuid").toFile();
+
+        ConfigUtils.migrateLegacyFile(legacyConfig.toFile(), currentConfig, "runtime config");
+        ConfigUtils.migrateLegacyFile(legacyClientId.toFile(), currentClientId, "client id");
+
+        assertArrayEquals(Files.readAllBytes(legacyConfig), Files.readAllBytes(currentConfig.toPath()));
+        assertArrayEquals(Files.readAllBytes(legacyClientId), Files.readAllBytes(currentClientId.toPath()));
+        assertTrue(legacyConfig.toFile().isFile(), "legacy file must be kept as a backup");
+        assertTrue(legacyClientId.toFile().isFile(), "legacy file must be kept as a backup");
+    }
+
+    @Test
+    void existingCurrentFileIsNeverOverwritten() throws IOException {
+        Path configDirectory = Files.createDirectories(temporaryDirectory.resolve("config"));
+        write(configDirectory.resolve("enterprise_config_dev.json"), "legacy".getBytes());
+        Path currentConfig = write(configDirectory.resolve("runtime_config_dev.json"), "current".getBytes());
+
+        ConfigUtils.migrateLegacyFile(
+                configDirectory.resolve("enterprise_config_dev.json").toFile(),
+                currentConfig.toFile(), "runtime config");
+
+        assertArrayEquals("current".getBytes(), Files.readAllBytes(currentConfig));
+    }
+
+    @Test
+    void missingLegacyFileCreatesNothingAndDoesNotThrow() {
+        File legacy = temporaryDirectory.resolve("enterprise_client_uuid").toFile();
+        File current = temporaryDirectory.resolve("client_uuid").toFile();
+
+        ConfigUtils.migrateLegacyFile(legacy, current, "client id");
+
+        assertFalse(current.exists());
+        assertFalse(legacy.exists());
+    }
+
+    @Test
+    void migrationCreatesMissingParentDirectories() throws IOException {
+        Path legacy = write(temporaryDirectory.resolve("enterprise_client_uuid"), "abc".getBytes());
+        File current = temporaryDirectory.resolve("nested").resolve("client_uuid").toFile();
+
+        ConfigUtils.migrateLegacyFile(legacy.toFile(), current, "client id");
+
+        assertArrayEquals("abc".getBytes(), Files.readAllBytes(current.toPath()));
+    }
+
+    @Test
+    void failedCopyNeverPublishesOrLeavesAPartialCurrentFile() throws IOException {
+        Path configDirectory = Files.createDirectories(temporaryDirectory.resolve("config"));
+        Path legacy = write(configDirectory.resolve("enterprise_config_dev.json"), "complete".getBytes());
+        Path current = configDirectory.resolve("runtime_config_dev.json");
+
+        ConfigUtils.migrateLegacyFile(legacy.toFile(), current.toFile(), "runtime config", (source, staging) -> {
+            Files.writeString(staging, "partial");
+            throw new IOException("injected copy failure");
+        });
+
+        assertFalse(Files.exists(current));
+        assertTrue(Files.exists(legacy));
+        try (var files = Files.list(configDirectory)) {
+            assertTrue(files.noneMatch(path -> path.getFileName().toString().contains(".migrating-")));
+        }
+    }
+
+    private static Path write(Path path, byte[] content) throws IOException {
+        Files.write(path, content);
+        return path;
+    }
+}


### PR DESCRIPTION
## Related issue

N/A — regression found by reviewing the #2732 runtime-identity split; described below.

## Summary

Upgrades from 4.0.0 silently reset the runtime config (systemUuid, networkStatus, latestStartupSuccessVersion) and minted a fresh client UUID: ConfigUtils only looks for the current runtime_config_{env}.json / client_uuid names, while 4.0.0 wrote enterprise_config_{env}.json / enterprise_client_uuid in the same directory, and nothing referenced the old names anymore. The client localStorage keys got the same treatment deliberately in a2333f5f2 — the server-side files were left orphaned.

Fix: one-time legacy migration where the files are resolved — when the current file is absent, a legacy sibling is copied to the current name (legacy files kept untouched as backup; copy via java.nio with logged, non-fatal error handling). Legacy names come from new default methods on ProductRuntimeIdentity (legacyRuntimeConfigFileName/legacyClientIdFileName) so other runtimes can override. No behavior change when the current file exists or neither exists.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- mvn -pl chat2db-community-tools -am test -Dmaven.test.skip=false: 72/72 green, incl. 4 new ConfigUtilsLegacyFileMigrationTest cases (copy fidelity, never-overwrite, no-legacy no-op, parent-dir creation).
- Fork CI green: HandSonic/Chat2DB#44.

## Risk and compatibility

- Public API or stored data: additive only — reads legacy files, never deletes them.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: the ProductRuntimeIdentity defaults return the community legacy names; a product whose legacy names differ overrides the default methods.
- Backward compatibility: full — downgrades still find the legacy files untouched.

## Reviewer map

- Start here: ConfigUtils static block + migrateLegacyFile.
- Failure condition: unreadable legacy file → logged warning, default config written (same as today).
- Rollback or disable path: revert single commit; legacy files were never modified.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: substantial — fix and tests drafted with AI assistance, verified locally.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head 2b5acc49c.
- Resolved the ProductRuntimeIdentity conflict by preserving both current local-state namespace and legacy-file hooks.
- Adversarial review changed migration to stage before publication so a failed copy cannot leave a partial current file.
- Focused migration tests: 5/5 passed; full tools module: 73/73 passed.