### PR TITLE
fix(task): scope user exit preparation to the requesting owner

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/task/LocalTaskManager.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/task/LocalTaskManager.java
@@ -32,9 +32,11 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
@@ -65,7 +67,9 @@ public class LocalTaskManager {
 
     private final ReentrantLock lifecycleLock = new ReentrantLock();
 
-    private boolean preparingForExit;
+    private boolean applicationExiting;
+
+    private final Set<TaskOwner> exitingOwners = new HashSet<>();
 
     public LocalTaskManager(TaskStorage taskStorage, TaskExecutorRegistry taskExecutorRegistry,
             ArtifactService artifactService, ConnectionContextConverter connectionContextConverter,
@@ -102,7 +106,7 @@ public class LocalTaskManager {
             ConnectInfo connectInfo) {
         lifecycleLock.lock();
         try {
-            if (preparingForExit) {
+            if (applicationExiting || exitingOwners.contains(ownerOf(task))) {
                 throw new RejectedExecutionException("The application is preparing to exit");
             }
             Task persistedTask = taskStorage.create(task, createdEvent);
@@ -193,10 +197,10 @@ public class LocalTaskManager {
                 new TaskOwner(userId, organizationId));
     }
 
-    void abortUserExit() {
+    void abortUserExit(Long userId, Long organizationId) {
         lifecycleLock.lock();
         try {
-            preparingForExit = false;
+            exitingOwners.remove(new TaskOwner(userId, organizationId));
         } finally {
             lifecycleLock.unlock();
         }
@@ -213,10 +217,14 @@ public class LocalTaskManager {
     private void terminateActiveTasks(String errorCode, String eventCode, String message, TaskOwner owner) {
         lifecycleLock.lock();
         try {
-            if (preparingForExit && owner != null) {
+            if (applicationExiting && owner != null) {
                 return;
             }
-            preparingForExit = true;
+            if (owner == null) {
+                applicationExiting = true;
+            } else {
+                exitingOwners.add(owner);
+            }
             List<Task> activeTasks = taskStorage.listNonTerminalTasks();
             List<RunningTask> tasksToAwait = new ArrayList<>();
             List<Long> tasksToCleanup = new ArrayList<>();
@@ -343,6 +351,10 @@ public class LocalTaskManager {
     private boolean belongsTo(Task task, Long userId, Long organizationId) {
         return Objects.equals(task.getUserId(), userId)
                 && Objects.equals(task.getOrganizationId(), organizationId);
+    }
+
+    private TaskOwner ownerOf(Task task) {
+        return new TaskOwner(task.getUserId(), task.getOrganizationId());
     }
 
     private TaskSubmissionContext extensionContext(Task task, TaskSpec spec, ConnectInfo connectInfo) {

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/task/TaskServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/task/TaskServiceImpl.java
@@ -143,7 +143,8 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     public void abortUserExit() {
-        localTaskManager.abortUserExit();
+        TaskOwner owner = currentOwner();
+        localTaskManager.abortUserExit(owner.userId(), owner.organizationId());
     }
 
     @Override

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/task/LocalTaskManagerTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/task/LocalTaskManagerTest.java
@@ -313,13 +313,66 @@ class LocalTaskManagerTest {
         taskManager = manager(storage, (spec, context) -> {});
         taskManager.prepareForUserExit(null, null);
 
-        taskManager.abortUserExit();
+        taskManager.abortUserExit(null, null);
         Task submitted = taskManager.submit(newTask(), event(TaskEventCode.TASK_CREATED.name()),
                 spec(), null, null);
 
         assertNotNull(submitted);
         assertTrue(storage.awaitTerminal());
         assertEquals(TaskStatus.SUCCESS.name(), storage.get(submitted.getId()).orElseThrow().getStatus());
+    }
+
+    @Test
+    void userExitPreparationOnlyRejectsTasksOfTheExitingOwner() throws Exception {
+        TestTaskStorage storage = new TestTaskStorage();
+        taskManager = manager(storage, (spec, context) -> {});
+
+        taskManager.prepareForUserExit(1L, 10L);
+
+        assertThrows(RejectedExecutionException.class,
+                () -> taskManager.submit(newTask(1L, 10L), event(TaskEventCode.TASK_CREATED.name()),
+                        spec(), null, null));
+        Task otherOwnerTask = taskManager.submit(newTask(2L, 10L),
+                event(TaskEventCode.TASK_CREATED.name()), spec(), null, null);
+
+        assertNotNull(otherOwnerTask);
+        assertTrue(storage.awaitTerminal());
+        assertEquals(TaskStatus.SUCCESS.name(),
+                storage.get(otherOwnerTask.getId()).orElseThrow().getStatus());
+        assertTrue(storage.listNonTerminalTasks().isEmpty());
+    }
+
+    @Test
+    void abortUserExitUnblocksOnlyTheRequestingOwner() throws Exception {
+        TestTaskStorage storage = new TestTaskStorage();
+        taskManager = manager(storage, (spec, context) -> {});
+        taskManager.prepareForUserExit(1L, 10L);
+        taskManager.prepareForUserExit(2L, 10L);
+
+        taskManager.abortUserExit(1L, 10L);
+
+        Task firstOwnerTask = taskManager.submit(newTask(1L, 10L),
+                event(TaskEventCode.TASK_CREATED.name()), spec(), null, null);
+        assertNotNull(firstOwnerTask);
+        assertThrows(RejectedExecutionException.class,
+                () -> taskManager.submit(newTask(2L, 10L), event(TaskEventCode.TASK_CREATED.name()),
+                        spec(), null, null));
+    }
+
+    @Test
+    void applicationExitRejectsTasksOfAllOwners() {
+        TestTaskStorage storage = new TestTaskStorage();
+        taskManager = manager(storage, (spec, context) -> {});
+
+        taskManager.shutdown();
+
+        assertThrows(RejectedExecutionException.class,
+                () -> taskManager.submit(newTask(1L, 10L), event(TaskEventCode.TASK_CREATED.name()),
+                        spec(), null, null));
+        assertThrows(RejectedExecutionException.class,
+                () -> taskManager.submit(newTask(2L, 10L), event(TaskEventCode.TASK_CREATED.name()),
+                        spec(), null, null));
+        assertTrue(storage.listNonTerminalTasks().isEmpty());
     }
 
     @Test
@@ -558,10 +611,16 @@ class LocalTaskManagerTest {
     }
 
     private Task newTask() {
+        return newTask(null, null);
+    }
+
+    private Task newTask(Long userId, Long organizationId) {
         return Task.builder()
                 .type(TaskType.QUERY_RESULT_EXPORT.name())
                 .name("Export result")
                 .target(TaskTargetSnapshot.builder().dataSourceId(1L).build())
+                .userId(userId)
+                .organizationId(organizationId)
                 .build();
     }
 


### PR DESCRIPTION
## Related issue

N/A — server-contract defect found by reviewing the #2712 task-system rebuild; described below.

## Summary

LocalTaskManager's preparingForExit flag was global: the user-scoped prepareForUserExit path (triggered today by the desktop close flow via /api/tasks/prepare-user-exit) set a flag that rejected EVERY owner's task submissions with "The application is preparing to exit". Today only the desktop client drives this flow (web never calls it), so the practical blast radius is the same user — but the endpoint is a server/web API, and any API client (or future web adoption) hitting it locks out all other owners with no timeout reset. The flag is now split correctly:

- applicationExiting — set only by the owner==null application shutdown path (global semantics preserved)
- Set<TaskOwner> exitingOwners keyed by the TaskOwner record — submit() rejects only the requesting owner's new tasks; abortUserExit(userId, organizationId) removes exactly that key

Everything stays under the existing lifecycleLock; terminateActiveTasks keeps the original guard semantics; the public TaskService/REST surface is unchanged.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- mvn -pl chat2db-community-domain/chat2db-community-domain-core -am test -Dmaven.test.skip=false: 216/216 green, incl. 3 new LocalTaskManagerTest cases (ownerA blocked + ownerB allowed; abort unblocks only the requesting owner; application-level shutdown blocks all owners).
- Verified the client flow: useApplicationExit is desktop-gated (isDesktop), cancel always pairs abortUserExit, and confirming the exit terminates the whole process — so no lingering-key scenario exists in the current client.
- Fork CI green: HandSonic/Chat2DB#48.

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: single-user desktop behavior unchanged (one owner).

## Reviewer map

- Start here: LocalTaskManager fields + submit() + terminateActiveTasks().
- Failure condition: an exiting-owner entry lingers until abort or restart (bounded by distinct owners, harmless).
- Rollback or disable path: revert single commit restores the global flag.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: substantial — fix and tests drafted with AI assistance, verified locally and by adversarial review (including a client-flow audit of who actually calls these endpoints).