### PR TITLE
fix(workspace): remember left panel width across collapse

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -85,7 +85,7 @@
     "test:sql-in-clipboard": "tsx src/utils/sqlInClipboard.test.ts && tsx src/components/SQLEditor/helper/sqlInsertValueDefaults.test.ts",
     "test:console-tab-name": "tsx src/store/workspace/utils/consoleTabName.test.ts && tsx src/utils/workspaceObjectTabTitle.test.ts",
     "test:workspace-tab-scroll": "tsx src/store/workspace/utils/workspaceTabScrollRequest.test.ts && tsx src/components/Tabs/activeTabScroll.test.ts && tsx src/components/Tabs/wheelScroll.test.ts && tsx src/components/Tabs/tabAccentColor.test.ts",
-    "test:workspace-split-lifecycle": "tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabLayout.test.ts",
+    "test:workspace-split-lifecycle": "tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabLayout.test.ts && tsx src/store/workspace/slices/config/panelLeftLayout.test.ts",
     "test:tree-title-highlight": "tsx src/blocks/NewTree/components/TitleRender/highlightSearchText.test.ts",
     "test:tree-search-lifecycle": "tsx src/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle.test.ts && tsx src/pages/main/workspace/components/WorkspaceTreeSearch/refresh.test.ts",
     "test:tree-data-update": "tsx src/store/tree/treeDataUpdate.test.ts",

--- a/chat2db-community-client/src/store/workspace/slices/config/action.ts
+++ b/chat2db-community-client/src/store/workspace/slices/config/action.ts
@@ -1,7 +1,7 @@
 import { produce } from 'immer';
 import type { StateCreator } from 'zustand/vanilla';
 import { WorkspaceStore } from '../../store';
-import { ConfigState, initConfigState } from './initialState';
+import { ConfigState, nextPanelLeftLayout } from './initialState';
 
 export interface ConfigAction {
   togglePanelRight: (show?: boolean) => void;
@@ -23,9 +23,10 @@ export const createConfigAction: StateCreator<WorkspaceStore, [['zustand/devtool
   togglePanelLeft: () => {
     set(
       produce((state: ConfigState) => {
-        const show = state.layout.panelLeftWidth === 0;
-        state.layout.panelLeft = show;
-        state.layout.panelLeftWidth = show ? initConfigState.layout.panelLeftWidth : 0;
+        const next = nextPanelLeftLayout(state.layout);
+        state.layout.panelLeft = next.panelLeft;
+        state.layout.panelLeftWidth = next.panelLeftWidth;
+        state.layout.lastPanelLeftWidth = next.lastPanelLeftWidth;
       }),
     );
   },
@@ -34,6 +35,9 @@ export const createConfigAction: StateCreator<WorkspaceStore, [['zustand/devtool
       produce((state: ConfigState) => {
         state.layout.panelLeftWidth = width;
         state.layout.panelLeft = width > 0;
+        if (width > 0) {
+          state.layout.lastPanelLeftWidth = width;
+        }
       }),
     );
   },

--- a/chat2db-community-client/src/store/workspace/slices/config/initialState.ts
+++ b/chat2db-community-client/src/store/workspace/slices/config/initialState.ts
@@ -4,6 +4,8 @@ export interface ConfigState {
     panelLeftWidth: number;
     panelRight: boolean;
     panelRightWidth: number;
+    /** Last non-zero left panel width, so expanding restores the user's width. */
+    lastPanelLeftWidth: number;
   };
 }
 
@@ -13,5 +15,33 @@ export const initConfigState: ConfigState = {
     panelRight: true,
     panelLeftWidth: 260,
     panelRightWidth: 300,
+    lastPanelLeftWidth: 260,
   },
 };
+
+export interface PanelLeftToggleLayout {
+  panelLeft: boolean;
+  panelLeftWidth: number;
+  lastPanelLeftWidth: number;
+}
+
+/**
+ * Collapsing must not destroy the user's custom width, and expanding must
+ * restore it instead of resetting to the default 260px.
+ */
+export function nextPanelLeftLayout(layout: ConfigState['layout']): PanelLeftToggleLayout {
+  if (layout.panelLeftWidth > 0) {
+    return {
+      panelLeft: false,
+      panelLeftWidth: 0,
+      lastPanelLeftWidth: layout.panelLeftWidth,
+    };
+  }
+  const remembered =
+    layout.lastPanelLeftWidth > 0 ? layout.lastPanelLeftWidth : initConfigState.layout.panelLeftWidth;
+  return {
+    panelLeft: true,
+    panelLeftWidth: remembered,
+    lastPanelLeftWidth: remembered,
+  };
+}

--- a/chat2db-community-client/src/store/workspace/slices/config/panelLeftLayout.test.ts
+++ b/chat2db-community-client/src/store/workspace/slices/config/panelLeftLayout.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert';
+import { initConfigState, nextPanelLeftLayout } from './initialState';
+
+const collapsedAfterCollapse = nextPanelLeftLayout({
+  ...initConfigState.layout,
+  panelLeftWidth: 420,
+});
+
+assert.equal(collapsedAfterCollapse.panelLeft, false, 'collapsing hides the left panel');
+assert.equal(collapsedAfterCollapse.panelLeftWidth, 0, 'collapsing zeroes the live width');
+assert.equal(
+  collapsedAfterCollapse.lastPanelLeftWidth,
+  420,
+  'collapsing must remember the custom width instead of destroying it',
+);
+
+const restoredAfterExpand = nextPanelLeftLayout({
+  ...initConfigState.layout,
+  panelLeft: false,
+  panelLeftWidth: 0,
+  lastPanelLeftWidth: 420,
+});
+
+assert.equal(restoredAfterExpand.panelLeft, true, 'expanding shows the left panel');
+assert.equal(
+  restoredAfterExpand.panelLeftWidth,
+  420,
+  'expanding must restore the remembered custom width, not the 260px default',
+);
+
+const defaultWhenNothingRemembered = nextPanelLeftLayout({
+  ...initConfigState.layout,
+  panelLeft: false,
+  panelLeftWidth: 0,
+  lastPanelLeftWidth: 0,
+});
+
+assert.equal(
+  defaultWhenNothingRemembered.panelLeftWidth,
+  initConfigState.layout.panelLeftWidth,
+  'expanding with nothing remembered falls back to the default width',
+);
+
+console.log('panel left layout tests passed');

--- a/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.test.ts
+++ b/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.test.ts
@@ -191,6 +191,7 @@ const persistableLayout = getPersistableWorkspaceLayout({
   panelLeftWidth: 260,
   panelRight: circularPanelState,
   panelRightWidth: 300,
+  lastPanelLeftWidth: 420,
 } as any);
 
 assert.equal(persistableLayout.panelRight, false, 'non-boolean panel state must not reach persisted storage');
@@ -201,9 +202,10 @@ assert.doesNotThrow(
 
 const migratedClosedLeftPanelLayout = getPersistableWorkspaceLayout({
   panelLeft: false,
-  panelLeftWidth: 260,
+  panelLeftWidth: 0,
   panelRight: false,
   panelRightWidth: 300,
+  lastPanelLeftWidth: 420,
 });
 
 assert.equal(
@@ -212,12 +214,19 @@ assert.equal(
   'legacy closed-left-panel state must remain closed after width-based layout migration',
 );
 
+assert.equal(
+  migratedClosedLeftPanelLayout.lastPanelLeftWidth,
+  420,
+  'a collapsed left panel must keep its remembered width in persisted storage',
+);
+
 const hydratedLegacyLayout = getHydratedWorkspaceLayout(
   {
     panelLeft: true,
     panelLeftWidth: 240,
     panelRight: false,
     panelRightWidth: 300,
+    lastPanelLeftWidth: 240,
   },
   {
     panelLeft: false,
@@ -232,10 +241,33 @@ assert.deepEqual(
   {
     panelLeft: false,
     panelLeftWidth: 0,
+    lastPanelLeftWidth: 240,
     panelRight: false,
     panelRightWidth: 300,
   },
   'hydration must normalize legacy and malformed panel values before the workspace renders',
+);
+
+const legacyHydrationWithoutRememberedWidth = getHydratedWorkspaceLayout(
+  {
+    panelLeft: true,
+    panelLeftWidth: 240,
+    panelRight: false,
+    panelRightWidth: 300,
+    lastPanelLeftWidth: 240,
+  },
+  {
+    panelLeft: false,
+    panelLeftWidth: 0,
+    panelRight: false,
+    panelRightWidth: 300,
+  },
+);
+
+assert.equal(
+  legacyHydrationWithoutRememberedWidth.lastPanelLeftWidth,
+  240,
+  'legacy persisted layouts without a remembered width fall back to the current width',
 );
 
 console.log('workspace tab persistence tests passed');

--- a/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.ts
+++ b/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.ts
@@ -56,6 +56,12 @@ export function getPersistableWorkspaceLayout(layout: ConfigState['layout']): Co
       ? Math.max(0, layout.panelLeftWidth)
       : initConfigState.layout.panelLeftWidth;
   const panelLeftWidth = layout.panelLeft === false ? 0 : normalizedPanelLeftWidth;
+  const rememberedPanelLeftWidth =
+    typeof layout.lastPanelLeftWidth === 'number' && Number.isFinite(layout.lastPanelLeftWidth) && layout.lastPanelLeftWidth > 0
+      ? layout.lastPanelLeftWidth
+      : normalizedPanelLeftWidth > 0
+        ? normalizedPanelLeftWidth
+        : initConfigState.layout.panelLeftWidth;
   const panelRightWidth =
     typeof layout.panelRightWidth === 'number' && Number.isFinite(layout.panelRightWidth)
       ? Math.max(0, layout.panelRightWidth)
@@ -64,6 +70,7 @@ export function getPersistableWorkspaceLayout(layout: ConfigState['layout']): Co
   return {
     panelLeft: panelLeftWidth > 0,
     panelLeftWidth,
+    lastPanelLeftWidth: rememberedPanelLeftWidth,
     panelRight: typeof layout.panelRight === 'boolean' ? layout.panelRight : false,
     panelRightWidth,
   };


### PR DESCRIPTION
## Related issue

N/A — regression found by reviewing 277142633 + its persistence helper; described below.

## Summary

togglePanelLeft reset the live width to the 260px default on expand, and getPersistableWorkspaceLayout stored 0 while collapsed — a user's custom sidebar width was permanently lost after collapsing (or reloading while collapsed). The layout now tracks lastPanelLeftWidth alongside the live width via a pure nextPanelLeftLayout helper: collapsing remembers the current width, expanding restores it, setPanelLeftWidth keeps it fresh, and persistence/hydration carry the remembered value (legacy layouts without it fall back to previous behavior).

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- New panelLeftLayout.test.ts (collapse remembers 420, expand restores 420 not 260, default fallback when nothing remembered) and extended workspaceTabPersistence.test.ts (remembered width persisted while collapsed; legacy hydration) — all green.
- Fork CI green: HandSonic/Chat2DB#47.

## Risk and compatibility

- Public API or stored data: persisted workspace layout gains one additive key; missing key hydrates to legacy behavior.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: legacy persisted 0 still means collapsed.

## Reviewer map

- Start here: slices/config/initialState.ts (nextPanelLeftLayout) then action.ts and workspaceTabPersistence.ts.
- Failure condition: none expected; default 260 only when nothing was ever remembered.
- Rollback or disable path: revert single commit.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: substantial — fix and tests drafted with AI assistance, verified locally.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head a9c2f110d.
- Workspace layout/persistence tests and targeted ESLint passed.
- Playwright resized the left panel from 260px to about 420px, collapsed and restored the exact width, then reloaded and confirmed the persisted width.
- Included in the green combined Community production build and bundle verification.