### PR TITLE
fix(desktop): restore maximized window dragged by the caption

### DIFF
--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/WindowsDesktopWindowChrome.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/WindowsDesktopWindowChrome.java
@@ -6,6 +6,7 @@ import javax.swing.JComponent;
 import javax.swing.JRootPane;
 import javax.swing.SwingUtilities;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Point;
 import java.awt.event.InputEvent;
@@ -67,6 +68,23 @@ final class WindowsDesktopWindowChrome {
         );
     }
 
+    /**
+     * Native Windows behavior when a maximized window is dragged: restore it
+     * and place it so the pointer stays at the same relative position inside
+     * the window, instead of leaving it pinned against the maximized bounds.
+     */
+    static Point restoredDragOrigin(Dimension maximizedSize, Dimension restoredSize,
+            Point windowOrigin, Point pointerScreen) {
+        double ratioX = maximizedSize.width <= 0 ? 0.5
+                : (double) (pointerScreen.x - windowOrigin.x) / maximizedSize.width;
+        double ratioY = maximizedSize.height <= 0 ? 0.5
+                : (double) (pointerScreen.y - windowOrigin.y) / maximizedSize.height;
+        return new Point(
+                pointerScreen.x - (int) Math.round(ratioX * restoredSize.width),
+                pointerScreen.y - (int) Math.round(ratioY * restoredSize.height)
+        );
+    }
+
     private static final class BrowserWindowDragHandler extends MouseAdapter {
 
         private final Frame frame;
@@ -96,7 +114,14 @@ final class WindowsDesktopWindowChrome {
                     || (event.getModifiersEx() & InputEvent.BUTTON1_DOWN_MASK) == 0) {
                 return;
             }
-            frame.setLocation(draggedWindowLocation(windowOrigin, pointerOrigin, event.getLocationOnScreen()));
+            Point pointer = event.getLocationOnScreen();
+            if ((frame.getExtendedState() & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+                Dimension maximizedSize = frame.getSize();
+                frame.setExtendedState(frame.getExtendedState() & ~Frame.MAXIMIZED_BOTH);
+                windowOrigin = restoredDragOrigin(maximizedSize, frame.getSize(), windowOrigin, pointer);
+                pointerOrigin = pointer;
+            }
+            frame.setLocation(draggedWindowLocation(windowOrigin, pointerOrigin, pointer));
         }
 
         @Override

--- a/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/WindowsDesktopWindowChromeTest.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/WindowsDesktopWindowChromeTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JRootPane;
+import java.awt.Dimension;
 import java.awt.Point;
 import java.util.function.Function;
 
@@ -74,6 +75,35 @@ class WindowsDesktopWindowChromeTest {
                         new Point(100, 200),
                         new Point(400, 300),
                         new Point(430, 275)
+                )
+        );
+    }
+
+    @Test
+    void shouldAnchorRestoredWindowUnderThePointer() {
+        // Maximized 1000x800 at (0,0); the drag started with the pointer a
+        // quarter across and 5% down. After restoring to 800x600 the window
+        // must jump so the pointer keeps that relative position.
+        assertEquals(
+                new Point(250 - 200, 40 - 30),
+                WindowsDesktopWindowChrome.restoredDragOrigin(
+                        new Dimension(1000, 800),
+                        new Dimension(800, 600),
+                        new Point(0, 0),
+                        new Point(250, 40)
+                )
+        );
+    }
+
+    @Test
+    void shouldFallBackToCenterAnchorsWhenMaximizedSizeIsUnknown() {
+        assertEquals(
+                new Point(600 - 400, 300 - 300),
+                WindowsDesktopWindowChrome.restoredDragOrigin(
+                        new Dimension(0, 0),
+                        new Dimension(800, 600),
+                        new Point(0, 0),
+                        new Point(600, 300)
                 )
         );
     }


### PR DESCRIPTION
## Related issue

N/A — defect found by reviewing the #2711 desktop chrome series; described below.

## Summary

Dragging the custom Windows title bar while the window is maximized kept calling setLocation against the maximized bounds: the window stayed pinned instead of following the pointer until the user restored it by double-clicking. The drag handler now clears MAXIMIZED_BOTH on the first drag event and re-anchors the window under the pointer at the same relative position (new pure restoredDragOrigin), matching native Windows behavior.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- mvn -pl chat2db-community-jcef -am test -Dmaven.test.skip=false: WindowsCommunityWindowChromeTest 7/7 green, incl. 2 new cases (proportional re-anchor; center fallback when the maximized size is unknown).
- Fork CI green: HandSonic/Chat2DB#45.

## Risk and compatibility

- Public API or stored data: N/A.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Windows community chrome only.
- Backward compatibility: non-maximized dragging unchanged (draggedWindowLocation untouched).

## Reviewer map

- Start here: BrowserWindowDragHandler.mouseDragged + restoredDragOrigin in WindowsCommunityWindowChrome.
- Failure condition: if the frame size updates asynchronously after un-maximizing, the anchor degrades gracefully to the stale-size proportion.
- Rollback or disable path: revert single commit.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: substantial — fix and tests drafted with AI assistance, verified locally.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head 641e3f103.
- Updated the test fixture for the current WindowsDesktopWindowChrome class name after the mainline rename.
- Focused Windows desktop chrome tests: 7/7 passed.