### PR TITLE
fix(environment): give DEV an identity color

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/sys/SysEnvironmentServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/sys/SysEnvironmentServiceImpl.java
@@ -27,6 +27,7 @@ public class SysEnvironmentServiceImpl implements ISysEnvironmentService {
             .id(3L)
             .name("DEV")
             .shortName("Development Environment")
+            .color("BLUE")
             .build();
 
     @Override

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/sys/SysEnvironmentServiceImplTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/sys/SysEnvironmentServiceImplTest.java
@@ -1,6 +1,8 @@
 package ai.chat2db.community.domain.core.impl.sys;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
@@ -17,5 +19,15 @@ class SysEnvironmentServiceImplTest {
                 environments.stream().map(Environment::getName).toList());
         assertEquals(List.of(1L, 3L, 2L),
                 environments.stream().map(Environment::getId).toList());
+    }
+
+    @Test
+    void everyEnvironmentCarriesAnIdentityColor() {
+        // The web client types Environment.color as non-null and lowercases it
+        // for badge styling; DEV was shipped without a color by mistake.
+        for (Environment environment : new SysEnvironmentServiceImpl().listAll()) {
+            assertNotNull(environment.getColor(), environment.getName() + " must define a color");
+            assertFalse(environment.getColor().isBlank(), environment.getName() + " must define a color");
+        }
     }
 }


### PR DESCRIPTION
## Related issue

N/A — contract gap found by reviewing 14729e027 (identity colors); described below.

## Summary

SysEnvironmentServiceImpl defines colors for TEST (GREEN) and RELEASE (RED) but DEV shipped with none: /api/common/environment/list_all returns color: null for DEV while the client types Environment.color as non-null and uses it directly for badge styling (current consumers happen to guard; any new consumer calling .color.toLocaleLowerCase() throws). DEV now carries BLUE, and a test pins that every environment defines a non-blank color.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- mvn -pl chat2db-community-domain/chat2db-community-domain-core -am test -Dmaven.test.skip=false -Dtest=SysEnvironmentServiceImplTest: 2/2 green (incl. new everyEnvironmentCarriesAnIdentityColor).
- Fork CI green: HandSonic/Chat2DB#42.

## Risk and compatibility

- Public API or stored data: N/A (computed list, nothing persisted).
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: N/A.
- Backward compatibility: null → BLUE only adds information.

## Reviewer map

- Start here: SysEnvironmentServiceImpl DEV constant.
- Failure condition: none.
- Rollback or disable path: revert single commit.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: substantial — fix and tests drafted with AI assistance, verified locally.