### PR TITLE
fix(client): stabilize tree deletion, tab focus, and split layout

### DIFF
--- a/chat2db-community-client/src/blocks/NewTree/hooks/useCreateRightClickMenu.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/hooks/useCreateRightClickMenu.tsx
@@ -54,7 +54,6 @@ import { resolveDataSourceAuthorization } from '@/utils/dataSourceAuthorization'
 import accountAdminService, { AccountActionType, formatAccountExecuteMessage } from '@/service/accountAdmin';
 import CreateAccountContent, { CreateAccountValues } from '../components/CreateAccountContent';
 import DeleteDatabaseSchemaConfirmContent from '../components/DeleteDatabaseSchemaConfirmContent';
-import { emitSavedConsoleUpdated } from '@/utils/savedConsoleEvents';
 import { buildWorkspaceObjectTabTitle } from '@/utils/workspaceObjectTabTitle';
 import { allowsResourceOperations } from '@/client-extension/resourceOperationCapabilities';
 import type { ResourceOperation, ResourceOperationCapabilities } from '@/client-extension/types';
@@ -989,8 +988,13 @@ export const useCreateRightClickMenu = () => {
         text: i18n('workspace.menu.removeConsole'),
         icon: 'icon-trash',
         handle: () => {
-          removeSavedConsole(treeNodeData.id!).then(() => {
-            emitSavedConsoleUpdated(extraParams);
+          openUnifiedConfirmationModal({
+            title: i18n('common.text.deleteConfirmTitle'),
+            content: i18n('common.text.deleteConfirmTip', treeNodeData.originalTitle),
+            onOk: async () => {
+              await removeSavedConsole(treeNodeData.id!);
+              await refreshAfterDelete();
+            },
           });
         },
       },

--- a/chat2db-community-client/src/blocks/NewTree/style.ts
+++ b/chat2db-community-client/src/blocks/NewTree/style.ts
@@ -6,12 +6,15 @@ export const useStyles = createStyles(({ css, token }) => {
       display: flex;
       flex-direction: column;
       font-size: 14px;
+      min-width: 0;
       overflow-x: auto;
       overflow-y: hidden;
       /* position: relative; */
 
       .ant-tree {
         background-color: transparent;
+        width: max-content;
+        min-width: 100%;
       }
 
       .ant-tree-switcher {
@@ -19,14 +22,14 @@ export const useStyles = createStyles(({ css, token }) => {
       }
 
       .ant-tree-list {
-        width: fit-content;
+        width: max-content;
         min-width: 100%;
         position: inherit !important;
       }
 
       .ant-tree-list-holder {
-        min-width: fit-content;
-        width: 100%;
+        width: max-content;
+        min-width: 100%;
         & > div {
           position: inherit !important;
           overflow: visible !important;
@@ -34,12 +37,13 @@ export const useStyles = createStyles(({ css, token }) => {
       }
 
       .ant-tree-list-holder-inner {
-        width: 100%;
+        width: max-content;
+        min-width: 100%;
         position: inherit !important;
       }
 
       .ant-tree-treenode {
-        /* width: max-content; */
+        width: max-content;
         min-width: 100%;
       }
 

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/style.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/style.ts
@@ -4,17 +4,21 @@ export const useStyles = createStyles(({ css, token }) => {
   return {
     treeBox: css`
       flex: 1;
+      min-width: 0;
+      min-height: 0;
       padding-left: 6px;
     `,
     panelPane: css`
       display: none;
       min-height: 0;
+      min-width: 0;
       flex: 1;
       flex-direction: column;
     `,
     panelPaneActive: css`
       display: flex;
       min-height: 0;
+      min-width: 0;
       flex: 1;
       flex-direction: column;
     `,

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
@@ -47,6 +47,7 @@ import TerminalTab from './TerminalTab';
 // ---- store -----
 import { useWorkspaceStore } from '@/store/workspace';
 import { useGlobalStore } from '@/store/global';
+import { getPersistableActiveConsoleId } from '@/store/workspace/utils/workspaceTabPersistence';
 import { isWorkspaceResultInspectorCode } from '@/store/workspace/utils/resultInspector';
 import { isConsoleTabNameCustomized } from '@/store/workspace/utils/consoleTabName';
 import { useTreeStore } from '@/store/tree';
@@ -754,7 +755,6 @@ const WorkspaceTabs = memo(() => {
     editorList,
     getOpenConsoleList,
     setActiveConsoleId,
-    setWorkspaceTabList,
     createConsole,
   } = useWorkspaceStore((state) => {
     return {
@@ -766,7 +766,6 @@ const WorkspaceTabs = memo(() => {
       editorList: state.editorList,
       getOpenConsoleList: state.getOpenConsoleList,
       setActiveConsoleId: state.setActiveConsoleId,
-      setWorkspaceTabList: state.setWorkspaceTabList,
       createConsole: state.createConsole,
     };
   });
@@ -827,12 +826,18 @@ const WorkspaceTabs = memo(() => {
     const orderedTabs = orderPinnedWorkspaceTabsFirst(tabs);
     const orderedLayout = orderSplitLayoutPaneIdsByPinned(layout || null, orderedTabs);
     const normalizedLayout = normalizeWorkspaceTabSplitLayout(orderedLayout, orderedTabs, nextActiveConsoleId);
-    setWorkspaceTabList(orderedTabs);
-    if (!areWorkspaceTabSplitLayoutsEqual(useWorkspaceStore.getState().workspaceTabSplitLayout, normalizedLayout)) {
-      useWorkspaceStore.setState({
-        workspaceTabSplitLayout: normalizedLayout,
-      });
+    const currentState = useWorkspaceStore.getState();
+    const nextState: Partial<typeof currentState> = {
+      workspaceTabList: orderedTabs,
+      activeConsoleId: getPersistableActiveConsoleId({
+        activeConsoleId: nextActiveConsoleId,
+        workspaceTabList: orderedTabs,
+      }),
+    };
+    if (!areWorkspaceTabSplitLayoutsEqual(currentState.workspaceTabSplitLayout, normalizedLayout)) {
+      nextState.workspaceTabSplitLayout = normalizedLayout;
     }
+    useWorkspaceStore.setState(nextState);
   };
 
   const updateWorkspaceTabSplitLayout = (layout: IWorkspaceTabSplitLayout | null | undefined) => {
@@ -1606,7 +1611,6 @@ const WorkspaceTabs = memo(() => {
     } as IWorkspaceTabSplitLayout;
 
     setWorkspaceTabsState(nextWorkspaceTabList, nextLayout, nextTabId);
-    setActiveConsoleId(nextTabId);
   };
 
   // Render the SQL executor.
@@ -1987,6 +1991,7 @@ const WorkspaceTabs = memo(() => {
           onEdit={(action, data) => handelTabsEdit(action, data || [], paneId)}
           beforeRemove={confirmWorkspaceTabItemsClose}
           activeKey={activeKey}
+          activeTabScrollKey={activeKey}
           editableNameOnBlur={editableNameOnBlur}
           items={items}
           contextActions={commonWorkspaceTabContextActions}


### PR DESCRIPTION
## Summary
- add confirmation before deleting saved queries and refresh the saved-query tree after a successful deletion
- allow long database-tree titles to grow the Tree content and use the outer pane for horizontal scrolling
- pass the active tab scroll key so opening a saved query locates its tab header
- commit workspace tabs, active tab, and split layout together to avoid an intermediate full-page render during pane splitting

## Validation
- yarn test:community-boundary
- git diff --check
- focused TypeScript tests and lint were not runnable locally because this checkout has no installed frontend dependencies (tsx unavailable); PR CI should run the full Community validation.