### PR TITLE
fix(client): make long result cells readable without unbounded rows

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -50,7 +50,7 @@
     "test:redis-explorer": "tsx src/blocks/RedisAllData/redisExplorer.test.ts",
     "test:result-markdown": "tsx src/blocks/SearchResult/components/ResultSetTable/event/onContextmenuCell/handleCopyAsMarkdown.test.ts",
     "test:result-set-ui": "tsx src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts",
-    "test:result-table-layout": "tsx src/blocks/SearchResult/components/ResultSetTable/layoutOptions.test.ts",
+    "test:result-table-layout": "tsx src/blocks/SearchResult/components/ResultSetTable/layoutOptions.test.ts && tsx src/blocks/SearchResult/components/ResultSetTable/rowHeight.test.ts",
     "test:result-status": "tsx src/blocks/SearchResult/components/StatusBar/resultSummary.test.ts",
     "test:runtime-storage": "tsx src/store/indexDB/storageKey.test.ts && tsx src/pages/main/workspace/components/WorkspaceLeft/desktopBridge.test.ts",
     "test:result-tab-preferences": "tsx src/blocks/SearchResult/resultTabPreferences.test.ts && tsx src/service/resultTabShortcut.test.ts",

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/index.tsx
@@ -37,6 +37,7 @@ import {
 } from './columnState';
 import { resolveResultSelectionActiveCell, ResultSelectionCause } from './selectionState';
 import { RESULT_TABLE_CONTENT_LAYOUT_OPTIONS } from './layoutOptions';
+import { capResultTableAutoRowHeights } from './rowHeight';
 
 interface IProps {
   className?: string;
@@ -158,6 +159,16 @@ const ResultSetTable = forwardRef((props: IProps, ref: ForwardedRef<ResultSetTab
   ]);
   const records = useMemo(() => buildResultRecords(resultData), [resultData]);
   const headerTooltip = useHeaderTooltip({ tableInstance });
+
+  useEffect(() => {
+    if (!tableInstance) {
+      return;
+    }
+    const capAutoRowHeights = () => capResultTableAutoRowHeights(tableInstance);
+    const eventId = tableInstance.on('after_render', capAutoRowHeights);
+    capAutoRowHeights();
+    return () => tableInstance.off(eventId);
+  }, [tableInstance]);
 
   const clearColumnSensitiveSelection = useCallback(() => {
     interactionRevisionRef.current += 1;

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/layoutOptions.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/layoutOptions.test.ts
@@ -5,7 +5,7 @@ import { RESULT_TABLE_CONTENT_LAYOUT_OPTIONS } from './layoutOptions';
 test('result tables measure multiline cell content instead of clipping it', () => {
   assert.deepEqual(RESULT_TABLE_CONTENT_LAYOUT_OPTIONS, {
     autoWrapText: true,
-    defaultRowHeight: 'auto',
     heightMode: 'autoHeight',
+    maxCharactersNumber: Number.MAX_SAFE_INTEGER,
   });
 });

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/layoutOptions.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/layoutOptions.ts
@@ -1,5 +1,9 @@
+export const RESULT_TABLE_MAX_AUTO_ROW_HEIGHT = 240;
+
 export const RESULT_TABLE_CONTENT_LAYOUT_OPTIONS = {
   autoWrapText: true,
-  defaultRowHeight: 'auto',
   heightMode: 'autoHeight',
+  // VTable defaults to truncating every cell after 200 characters. Large values
+  // are handled by the cell metadata renderer; ordinary result text remains complete.
+  maxCharactersNumber: Number.MAX_SAFE_INTEGER,
 } as const;

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/rowHeight.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/rowHeight.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ITableInstance } from '@/blocks/CanvasTable/typings';
+import { capResultTableAutoRowHeights } from './rowHeight';
+
+function tableFixture(overrides: Partial<ITableInstance> = {}) {
+  const heights = new Map<number, number>([
+    [0, 32],
+    [1, 520],
+    [2, 360],
+    [3, 28],
+  ]);
+  const resizedRows = new Set([2]);
+  const resized: Array<[number, number]> = [];
+  const table = {
+    heightMode: 'autoHeight',
+    rowCount: 4,
+    columnHeaderLevelCount: 1,
+    bottomFrozenRowCount: 0,
+    getRowHeight: (row: number) => heights.get(row) || 0,
+    internalProps: { _heightResizedRowMap: resizedRows },
+    scenegraph: {
+      setRowHeight: (row: number, height: number) => {
+        heights.set(row, height);
+        resized.push([row, height]);
+      },
+    },
+    ...overrides,
+  } as unknown as ITableInstance;
+  return { table, heights, resized };
+}
+
+test('caps automatic rows while preserving manually resized rows', () => {
+  const { table, heights, resized } = tableFixture();
+
+  assert.equal(capResultTableAutoRowHeights(table, 240), 1);
+  assert.equal(heights.get(1), 240);
+  assert.equal(heights.get(2), 360);
+  assert.deepEqual(resized, [[1, 240]]);
+});
+
+test('does not cap rows when the table is not in auto-height mode', () => {
+  const { table, heights, resized } = tableFixture({ heightMode: 'standard' } as Partial<ITableInstance>);
+
+  assert.equal(capResultTableAutoRowHeights(table, 240), 0);
+  assert.equal(heights.get(1), 520);
+  assert.deepEqual(resized, []);
+});

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/rowHeight.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSetTable/rowHeight.ts
@@ -1,0 +1,27 @@
+import type { ITableInstance } from '@/blocks/CanvasTable/typings';
+import { RESULT_TABLE_MAX_AUTO_ROW_HEIGHT } from './layoutOptions';
+
+/** Keep automatic rows readable without preventing manual row resizing. */
+export function capResultTableAutoRowHeights(
+  table: ITableInstance,
+  maxHeight = RESULT_TABLE_MAX_AUTO_ROW_HEIGHT,
+) {
+  if (table.heightMode !== 'autoHeight' || !Number.isFinite(maxHeight) || maxHeight <= 0) {
+    return 0;
+  }
+
+  const resizedRows = table.internalProps._heightResizedRowMap;
+  const firstBodyRow = table.columnHeaderLevelCount;
+  const lastBodyRow = table.rowCount - table.bottomFrozenRowCount;
+  let cappedRows = 0;
+
+  for (let row = firstBodyRow; row < lastBodyRow; row += 1) {
+    if (resizedRows.has(row) || table.getRowHeight(row) <= maxHeight) {
+      continue;
+    }
+    table.scenegraph.setRowHeight(row, maxHeight);
+    cappedRows += 1;
+  }
+
+  return cappedRows;
+}


### PR DESCRIPTION
## Summary

Rework the merged #2752 result-cell fix so ordinary long SQL/DDL values remain complete without allowing one row to grow without bound.

## Root cause

The previous PR only enabled VTable auto wrapping and auto row height. VTable still applied its default `maxCharactersNumber = 200` before measuring or rendering text, so the row expanded around an already-truncated value. `defaultRowHeight: 'auto'` was also redundant once `heightMode: 'autoHeight'` is enabled.

## Changes

- Keep `autoWrapText` and `heightMode: 'autoHeight'` scoped to `ResultSetTable`.
- Set `maxCharactersNumber` to `Number.MAX_SAFE_INTEGER` so ordinary result text is not truncated by VTable. Existing `largeValue` metadata rendering and chunked value viewing are unchanged.
- Cap automatically calculated body rows at 240px after VTable rendering. Rows recorded by VTable as manually resized are left untouched, so dragging a row boundary reveals more content.
- Replace the previous layout-only regression assertion with coverage for the effective layout contract and automatic/manual row-height behavior.

## Verification

- `yarn test:result-table-layout`
- `yarn test:result-set-ui` (35/35)
- Targeted ESLint with `--max-warnings=0`
- Community production Webpack compilation
- `git diff --check`
