### PR TITLE
fix(client): preserve tree search clicks before locating

### DIFF
--- a/chat2db-community-client/src/blocks/NewTree/index.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/index.tsx
@@ -75,6 +75,7 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
     expandedKeys,
     scrollTargetKey,
     setScrollTargetKey,
+    searchBarValue,
     dataSourceList,
   } = useTreeStore((state) => ({
     editingTreeNode: state.editingTreeNode,
@@ -85,6 +86,7 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
     expandedKeys: state.expandedKeys,
     scrollTargetKey: state.scrollTargetKey,
     setScrollTargetKey: state.setScrollTargetKey,
+    searchBarValue: state.searchBarValue,
     dataSourceList: state.dataSourceList,
   }));
   const identityTreeData = useMemo(
@@ -104,7 +106,7 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
   }, [setTreeRef]);
 
   useEffect(() => {
-    if (!scrollTargetKey || !filteredTreeData?.length) {
+    if (searchBarValue || !scrollTargetKey || !filteredTreeData?.length) {
       return;
     }
 
@@ -125,7 +127,7 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
         window.cancelAnimationFrame(frameId);
       }
     };
-  }, [scrollTargetKey, filteredTreeData, expandedKeys, setScrollTargetKey]);
+  }, [searchBarValue, scrollTargetKey, filteredTreeData, expandedKeys, setScrollTargetKey]);
 
   const treeSize = useSize(treeBoxRef);
 

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceHeaderSearch/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceHeaderSearch/index.tsx
@@ -57,7 +57,9 @@ const WorkspaceHeaderSearch = ({
     }
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (!searchRef.current?.contains(event.target as Node)) {
+      const target = event.target;
+      const clickedTree = target instanceof Element && target.closest('.ant-tree');
+      if (!searchRef.current?.contains(target as Node) && !clickedTree) {
         closeSearch();
       }
     };


### PR DESCRIPTION
## Summary

Fix the remaining click failure after merged PR #2751. Search results can be rendered, but clicking a result was intercepted by the global search close handler before the tree node click completed.

## Root cause

`WorkspaceHeaderSearch` listens for document-level `pointerdown` events and immediately clears the search whenever the pointer is outside the input. A pointerdown on a tree result therefore clears `searchResult` and unmounts the clicked node before its React `onClick` handler can restore the source node. PR #2751 fixed source-node lookup and scroll timing but did not protect this event boundary.

## Changes

- Keep the workspace tree search open while a pointerdown targets `.ant-tree`; the tree node click handler then clears search after resolving the source node.
- Keep the locate effect suspended while search text is non-empty, so `scrollTargetKey` is consumed only after the source tree is restored.
- Leave clicks outside the search input and tree unchanged: they still close the search.

## Verification

- Tree loading/state/switcher/database-path/saved-console tests
- Tree node path tests (3/3)
- Targeted ESLint with `--max-warnings=0`
- Community production Webpack compilation
- `git diff --check`
