### PR TITLE
feat: add LiteLLM as an AI provider

### DIFF
--- a/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/index.tsx
@@ -27,6 +27,7 @@ const providerOptions = [
   { label: 'Claude', value: 'CLAUDE' },
   { label: 'Gemini', value: 'GEMINI' },
   { label: 'MiniMax', value: 'MINIMAX' },
+  { label: 'LiteLLM', value: 'LITELLM' },
 ];
 
 const emptyFormValues: IAIModelConfigSaveRequest = {
@@ -307,7 +308,8 @@ export default function AIModelConfigModal({ open, onClose, onChanged }: AIModel
                   required:
                     (currentProvider === 'OPENAI' ||
                       currentProvider === 'CLAUDE' ||
-                      currentProvider === 'MINIMAX') &&
+                      currentProvider === 'MINIMAX' ||
+                      currentProvider === 'LITELLM') &&
                     !currentConfig?.hasApiKey,
                   message: i18n('setting.modelConfig.validation.apiKey'),
                 },

--- a/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/modelConfigDefaults.test.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/modelConfigDefaults.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {
+  DEFAULT_LITELLM_BASE_URL,
   DEFAULT_MINIMAX_BASE_URL,
   resolveBaseUrlOnProviderChange,
   resolveProviderBaseUrl,
@@ -10,8 +11,16 @@ assert.equal(resolveProviderBaseUrl('MINIMAX', '   '), DEFAULT_MINIMAX_BASE_URL)
 assert.equal(resolveProviderBaseUrl('MINIMAX', 'https://api.minimax.chat/v1'), 'https://api.minimax.chat/v1');
 assert.equal(resolveProviderBaseUrl('OPENAI', ''), '');
 
+// LiteLLM: self-hosted proxy default, overridable by the user.
+assert.equal(resolveProviderBaseUrl('LITELLM', ''), DEFAULT_LITELLM_BASE_URL);
+assert.equal(resolveProviderBaseUrl('LITELLM', '   '), DEFAULT_LITELLM_BASE_URL);
+assert.equal(resolveProviderBaseUrl('LITELLM', 'http://litellm.internal:8000/v1'), 'http://litellm.internal:8000/v1');
+
 assert.equal(resolveBaseUrlOnProviderChange('MINIMAX', ''), DEFAULT_MINIMAX_BASE_URL);
+assert.equal(resolveBaseUrlOnProviderChange('LITELLM', ''), DEFAULT_LITELLM_BASE_URL);
 assert.equal(resolveBaseUrlOnProviderChange('OPENAI', DEFAULT_MINIMAX_BASE_URL), '');
+// Switching away from LiteLLM clears its auto-filled default too.
+assert.equal(resolveBaseUrlOnProviderChange('OPENAI', DEFAULT_LITELLM_BASE_URL), '');
 assert.equal(
   resolveBaseUrlOnProviderChange('OPENAI', 'https://proxy.example.com/v1'),
   'https://proxy.example.com/v1',

--- a/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/modelConfigDefaults.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/modelConfigDefaults.ts
@@ -1,19 +1,29 @@
 import type { AIProvider } from '@/service/aiModelConfig';
 
 export const DEFAULT_MINIMAX_BASE_URL = 'https://api.minimax.io/v1';
+// LiteLLM is self-hosted; default to the proxy's conventional local address.
+export const DEFAULT_LITELLM_BASE_URL = 'http://localhost:4000/v1';
+
+const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<AIProvider, string>> = {
+  MINIMAX: DEFAULT_MINIMAX_BASE_URL,
+  LITELLM: DEFAULT_LITELLM_BASE_URL,
+};
 
 export const resolveProviderBaseUrl = (provider: AIProvider, baseUrl?: string): string => {
-  if (provider === 'MINIMAX' && !baseUrl?.trim()) {
-    return DEFAULT_MINIMAX_BASE_URL;
+  const providerDefault = PROVIDER_DEFAULT_BASE_URLS[provider];
+  if (providerDefault && !baseUrl?.trim()) {
+    return providerDefault;
   }
   return baseUrl || '';
 };
 
 export const resolveBaseUrlOnProviderChange = (provider: AIProvider, baseUrl?: string): string => {
-  if (provider === 'MINIMAX') {
+  if (PROVIDER_DEFAULT_BASE_URLS[provider]) {
     return resolveProviderBaseUrl(provider, baseUrl);
   }
-  if (baseUrl?.trim() === DEFAULT_MINIMAX_BASE_URL) {
+  // Clear a previously auto-filled provider default when switching to a provider
+  // that has none, so a stale default URL is not carried over.
+  if (baseUrl && Object.values(PROVIDER_DEFAULT_BASE_URLS).includes(baseUrl.trim())) {
     return '';
   }
   return baseUrl || '';

--- a/chat2db-community-client/src/service/aiModelConfig.ts
+++ b/chat2db-community-client/src/service/aiModelConfig.ts
@@ -2,7 +2,7 @@ import { clientRuntime } from '@client-runtime';
 import aiStreamService, { IModelOptionItem } from './aiStream';
 import createRequest from './base';
 
-export type AIProvider = 'OPENAI' | 'CLAUDE' | 'GEMINI' | 'MINIMAX';
+export type AIProvider = 'OPENAI' | 'CLAUDE' | 'GEMINI' | 'MINIMAX' | 'LITELLM';
 
 export interface IAIModelConfigItem {
   id: string;

--- a/chat2db-community-client/src/service/aiStream.ts
+++ b/chat2db-community-client/src/service/aiStream.ts
@@ -2,14 +2,14 @@ import createRequest from './base';
 import { IChatAttachment } from './aiAttachment';
 
 export interface IModelCatalogItem {
-  provider: 'OPENAI' | 'CLAUDE' | 'GEMINI' | 'MINIMAX';
+  provider: 'OPENAI' | 'CLAUDE' | 'GEMINI' | 'MINIMAX' | 'LITELLM';
   models: string[];
 }
 
 export interface IModelOptionItem {
   value: string;
   label: string;
-  provider: 'OPENAI' | 'CLAUDE' | 'GEMINI' | 'MINIMAX';
+  provider: 'OPENAI' | 'CLAUDE' | 'GEMINI' | 'MINIMAX' | 'LITELLM';
   model: string;
   modelConfigId?: string;
   customOption?: boolean;

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/enums/ai/AiProviderEnum.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/enums/ai/AiProviderEnum.java
@@ -6,7 +6,8 @@ public enum AiProviderEnum {
     OPENAI,
     CLAUDE,
     GEMINI,
-    MINIMAX;
+    MINIMAX,
+    LITELLM;
 
     public static AiProviderEnum from(String value) {
         if (value == null || value.trim().isEmpty()) {

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImpl.java
@@ -56,6 +56,8 @@ public class AiModelConfigServiceImpl implements IAiModelConfigService {
     private static final String DEFAULT_GEMINI_LOCATION = "us-central1";
     private static final String DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
     private static final String DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
+    // LiteLLM is self-hosted; default to the proxy's conventional local address.
+    private static final String DEFAULT_LITELLM_BASE_URL = "http://localhost:4000/v1";
     private static final int TEST_ERROR_BODY_MAX_LENGTH = 2000;
     private static final String CONFIG_VALUE_PREFIX = "config:";
     private static final String PRESET_VALUE_PREFIX = "preset:";
@@ -224,6 +226,9 @@ public class AiModelConfigServiceImpl implements IAiModelConfigService {
             }
             return testOpenAiCompatibleConfig(request, DEFAULT_MINIMAX_BASE_URL);
         }
+        if (provider == AiProviderEnum.LITELLM) {
+            return testOpenAiCompatibleConfig(request, DEFAULT_LITELLM_BASE_URL);
+        }
         return ModelConfigTestResponse.failure(null, null,
                 "Connection test currently supports OpenAI-compatible models only.");
     }
@@ -298,7 +303,8 @@ public class AiModelConfigServiceImpl implements IAiModelConfigService {
      */
     private void normalizeRuntimeBaseUrl(AiRuntimeModel runtimeModel) {
         AiProviderEnum provider = AiProviderEnum.from(runtimeModel.getProvider());
-        if (provider != AiProviderEnum.OPENAI && provider != AiProviderEnum.CLAUDE && provider != AiProviderEnum.MINIMAX) {
+        if (provider != AiProviderEnum.OPENAI && provider != AiProviderEnum.CLAUDE
+                && provider != AiProviderEnum.MINIMAX && provider != AiProviderEnum.LITELLM) {
             return;
         }
         runtimeModel.setBaseUrl(stripTrailingV1(runtimeModel.getBaseUrl()));
@@ -346,6 +352,12 @@ public class AiModelConfigServiceImpl implements IAiModelConfigService {
             runtimeModel.setBaseUrl(defaultValue(trimToNull(runtimeModel.getBaseUrl()), trimToNull(System.getenv("ANTHROPIC_BASE_URL"))));
             return;
         }
+        if (provider == AiProviderEnum.LITELLM) {
+            runtimeModel.setApiKey(defaultValue(trimToNull(runtimeModel.getApiKey()), trimToNull(System.getenv("LITELLM_API_KEY"))));
+            runtimeModel.setBaseUrl(defaultValue(trimToNull(runtimeModel.getBaseUrl()), trimToNull(System.getenv("LITELLM_BASE_URL"))));
+            runtimeModel.setBaseUrl(defaultValue(trimToNull(runtimeModel.getBaseUrl()), DEFAULT_LITELLM_BASE_URL));
+            return;
+        }
         if (provider == AiProviderEnum.GEMINI) {
             runtimeModel.setProjectId(defaultValue(trimToNull(runtimeModel.getProjectId()), trimToNull(System.getenv("GOOGLE_CLOUD_PROJECT"))));
             runtimeModel.setLocation(defaultValue(trimToNull(runtimeModel.getLocation()), trimToNull(System.getenv("GOOGLE_CLOUD_LOCATION"))));
@@ -364,7 +376,8 @@ public class AiModelConfigServiceImpl implements IAiModelConfigService {
         if (provider == null) {
             throw new IllegalArgumentException("Unsupported provider: " + runtimeModel.getProvider());
         }
-        if (provider == AiProviderEnum.OPENAI || provider == AiProviderEnum.CLAUDE) {
+        if (provider == AiProviderEnum.OPENAI || provider == AiProviderEnum.CLAUDE
+                || provider == AiProviderEnum.LITELLM) {
             return;
         }
         if (provider == AiProviderEnum.GEMINI) {

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/ai/AiModelFactory.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/ai/AiModelFactory.java
@@ -72,6 +72,12 @@ public class AiModelFactory {
         if (provider == AiProviderEnum.GEMINI) {
             return geminiClient(runtimeModel, retryTemplate);
         }
+        if (provider == AiProviderEnum.LITELLM) {
+            // LiteLLM exposes an OpenAI-compatible endpoint (the LiteLLM proxy), so it
+            // reuses the OpenAI client pointed at the user's configured base URL. One
+            // provider entry then reaches every model the proxy is configured to serve.
+            return openAiClient(runtimeModel, retryTemplate);
+        }
         throw new IllegalArgumentException("Unsupported provider: " + runtimeModel.getProvider());
     }
 


### PR DESCRIPTION
## Summary

Adds **LiteLLM** as a first class AI provider, alongside OpenAI, Claude, Gemini, and MiniMax.

LiteLLM exposes an **OpenAI compatible endpoint** (the self hosted LiteLLM proxy), so a single "LiteLLM" provider entry lets a user reach **100+ models across every provider LiteLLM supports** (OpenAI, Anthropic, Gemini, Bedrock, Vertex, Azure, Groq, Mistral, DeepSeek, local models, and more) through one configuration, without needing a Vertex or GCP project for Gemini or a separate entry per vendor.

Because the LiteLLM proxy speaks the OpenAI protocol, the provider **reuses the existing `OpenAiChatModel` client** pointed at the user's configured base URL. 


## Affected surfaces

- [x] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

* Commands and results:
  * **Backend compiles** (JDK 21): `mvn -pl chat2db-community-web -am compile` gives **BUILD SUCCESS** (0 errors; `AiProviderEnum`, `AiModelFactory`, `AiModelConfigServiceImpl` all compiled).
  * **Frontend unit test** (repo's own runner): `tsx src/blocks/AI/components/AIModelConfigModal/modelConfigDefaults.test.ts` prints `AI model config default tests passed.` (extended with the LiteLLM base URL default and provider switch cases).
* Manual verification:
  * Provider `LITELLM` routes through `AiModelFactory.openAiClient(...)` (the OpenAI compatible path). Wire compatibility is the standard LiteLLM proxy OpenAI endpoint (`POST <baseUrl>/v1/chat/completions`), which is the same endpoint the existing OpenAI provider already targets and the repo already ships and tests.
* UI evidence: added `{ label: 'LiteLLM', value: 'LITELLM' }` to the provider dropdown and the api key required rule; no layout change (reuses the existing base URL and API key fields). Screenshot can be added on request.

## Risk and compatibility
* Backward compatibility: additive. OpenAI, Claude, Gemini, and MiniMax behavior is untouched.

## Reviewer map

* Start here: `AiModelFactory.java` (the `LITELLM` to `openAiClient` branch) and `AiModelConfigServiceImpl.java` (test, normalize, env fallback, and validate branches).
* Failure condition: a `LITELLM` config with no reachable `base_url` fails exactly like an OpenAI config with a bad base URL (surfaced by the existing connection test).
* Rollback or disable path: remove the `LITELLM` enum value and its branches; no data migration needed.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: This provider integration was implemented with AI assisted coding and reviewed before submission.
