### PR TITLE
fix(client): stabilize database tree horizontal scrolling

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -80,7 +80,7 @@
     "test:console-tab-name": "tsx src/store/workspace/utils/consoleTabName.test.ts && tsx src/utils/workspaceObjectTabTitle.test.ts",
     "test:tree-title-highlight": "tsx src/blocks/NewTree/components/TitleRender/highlightSearchText.test.ts",
     "test:tree-data-update": "tsx src/store/tree/treeDataUpdate.test.ts",
-    "test:tree-loading": "tsx src/store/tree/loadNamespaceTree.test.ts && tsx src/store/tree/treeDataUpdate.test.ts && tsx src/store/tree/hiddenTreeNodeState.test.ts && tsx src/blocks/NewTree/components/TitleRender/switcherAction.test.ts && tsx src/pages/main/workspace/components/WorkspaceLeft/loadDatabaseTreePath.test.ts && tsx src/store/tree/savedConsoleTreeRefresh.test.ts",
+    "test:tree-loading": "tsx src/store/tree/loadNamespaceTree.test.ts && tsx src/store/tree/treeDataUpdate.test.ts && tsx src/store/tree/hiddenTreeNodeState.test.ts && tsx src/blocks/NewTree/components/TitleRender/switcherAction.test.ts && tsx src/blocks/NewTree/treeScrollWidth.test.ts && tsx src/pages/main/workspace/components/WorkspaceLeft/loadDatabaseTreePath.test.ts && tsx src/store/tree/savedConsoleTreeRefresh.test.ts",
     "test:tree-node-lookup": "tsx src/utils/treeNodeLookup.test.ts",
     "test:data-source-watermark": "tsx src/utils/dataSourceWatermark.test.ts",
     "test:terminal": "tsx src/constants/terminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendNav/quickTerminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/terminalTabPlacement.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/terminalAttachmentLifecycle.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabSelection.test.ts",

--- a/chat2db-community-client/src/blocks/NewTree/index.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useRef, useMemo, forwardRef } from 'react';
+import React, { memo, useCallback, useEffect, useLayoutEffect, useRef, useMemo, forwardRef, useState } from 'react';
 import { Tree, TreeProps, ConfigProvider, TreeDataNode, Spin } from 'antd';
 import { useStyles } from './style';
 import { useStyles as renderTitleUseStyles } from './renderTitleStyle';
@@ -23,6 +23,7 @@ import { useGlobalStore } from '@/store/global';
 import connectionService from '@/service/connection';
 import { useSize } from 'ahooks';
 import { decorateDataSourceIdentityTree } from './dataSourceIdentity';
+import { measureTreeScrollWidth, resolveNextTreeScrollWidth } from './treeScrollWidth';
 
 interface IProps extends TreeProps<TreeNodeData> {
   className?: string;
@@ -65,6 +66,11 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
   // TreeRef
   const treeRef = useRef<any>(null);
   const lastTreeSize = useRef<{ width: number; height: number }>();
+  const horizontalMeasureFrameRef = useRef<number>();
+  const horizontalMeasureResetRef = useRef(false);
+  const horizontalScrollHideTimerRef = useRef<number>();
+  const [treeScrollWidth, setTreeScrollWidth] = useState<number>();
+  const [isHorizontalScrolling, setIsHorizontalScrolling] = useState(false);
   const filteredTreeData = useTrimTreeData({ leafNodes, hiddenNoPermission, excludeNodes });
   const {
     editingTreeNode,
@@ -130,6 +136,63 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
   }, [searchBarValue, scrollTargetKey, filteredTreeData, expandedKeys, setScrollTargetKey]);
 
   const treeSize = useSize(treeBoxRef);
+
+  const measureHorizontalScrollWidth = useCallback((resetMeasurement = false) => {
+    horizontalMeasureResetRef.current ||= resetMeasurement;
+    if (horizontalMeasureFrameRef.current !== undefined) {
+      window.cancelAnimationFrame(horizontalMeasureFrameRef.current);
+    }
+    horizontalMeasureFrameRef.current = window.requestAnimationFrame(() => {
+      horizontalMeasureFrameRef.current = undefined;
+      const shouldResetMeasurement = horizontalMeasureResetRef.current;
+      horizontalMeasureResetRef.current = false;
+      const container = treeBoxRef.current;
+      if (!container) {
+        return;
+      }
+      const measuredWidth = measureTreeScrollWidth(container);
+      setTreeScrollWidth((currentWidth) =>
+        resolveNextTreeScrollWidth(currentWidth, measuredWidth, shouldResetMeasurement),
+      );
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (treeBoxRef.current?.scrollLeft) {
+      treeBoxRef.current.scrollLeft = 0;
+    }
+    measureHorizontalScrollWidth(true);
+    return () => {
+      if (horizontalMeasureFrameRef.current !== undefined) {
+        window.cancelAnimationFrame(horizontalMeasureFrameRef.current);
+        horizontalMeasureFrameRef.current = undefined;
+      }
+    };
+  }, [editingTreeNode, expandedKeys, identityTreeData, measureHorizontalScrollWidth, treeSize?.width]);
+
+  useEffect(() => {
+    return () => {
+      if (horizontalScrollHideTimerRef.current !== undefined) {
+        window.clearTimeout(horizontalScrollHideTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleHorizontalWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
+    const isShiftScroll = event.shiftKey && event.deltaY !== 0 && event.deltaX === 0;
+    const isHorizontalScroll = isShiftScroll || Math.abs(event.deltaX) > Math.abs(event.deltaY);
+    if (!isHorizontalScroll) {
+      return;
+    }
+    setIsHorizontalScrolling(true);
+    if (horizontalScrollHideTimerRef.current !== undefined) {
+      window.clearTimeout(horizontalScrollHideTimerRef.current);
+    }
+    horizontalScrollHideTimerRef.current = window.setTimeout(() => {
+      horizontalScrollHideTimerRef.current = undefined;
+      setIsHorizontalScrolling(false);
+    }, 600);
+  }, []);
 
   // right-click menu
   const onRightClick = ({ event, node }) => {
@@ -258,6 +321,7 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
       motion: false,
       itemHeight: 26,
       height: treeHeight,
+      scrollWidth: treeScrollWidth,
       selectedKeys,
       expandedKeys,
       // Ant Design 5.21.5 supports custom loading and switcher icons.
@@ -300,18 +364,29 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
       onDrop,
       onScroll: () => {
         treeDropdownRef.current?.closeMenu();
+        measureHorizontalScrollWidth();
       },
       titleRender,
       ...restProps,
     };
-  }, [selectedKeys, expandedKeys, treeSize?.height, editingTreeNode, identityTreeData, restProps]);
+  }, [
+    selectedKeys,
+    expandedKeys,
+    treeSize?.height,
+    editingTreeNode,
+    identityTreeData,
+    restProps,
+    treeScrollWidth,
+    measureHorizontalScrollWidth,
+  ]);
 
   return (
     <div
       ref={treeBoxRef}
-      className={cx('bashful-scroller', styles.treeBox, className)}
+      className={cx(styles.treeBox, isHorizontalScrolling && styles.horizontalScrolling, className)}
       tabIndex={0}
       onKeyDown={handleDatabaseTreeShortcut}
+      onWheelCapture={handleHorizontalWheel}
     >
       <ConfigProvider
         theme={{

--- a/chat2db-community-client/src/blocks/NewTree/style.ts
+++ b/chat2db-community-client/src/blocks/NewTree/style.ts
@@ -31,8 +31,9 @@ export const useStyles = createStyles(({ css, token }) => {
       .ant-tree-list-scrollbar-horizontal {
         bottom: 0 !important;
         height: 6px !important;
+        visibility: visible !important;
         opacity: 0;
-        pointer-events: none;
+        pointer-events: auto;
         transition: opacity 0.1s ease;
       }
 
@@ -43,7 +44,6 @@ export const useStyles = createStyles(({ css, token }) => {
       .ant-tree-list-scrollbar-horizontal:active,
       .ant-tree-list-scrollbar-horizontal:has(.ant-tree-list-scrollbar-thumb:active) {
         opacity: 1;
-        pointer-events: auto;
       }
 
       .ant-tree-switcher {
@@ -119,7 +119,6 @@ export const useStyles = createStyles(({ css, token }) => {
     horizontalScrolling: css`
       .ant-tree-list-scrollbar-horizontal {
         opacity: 1;
-        pointer-events: auto;
       }
     `,
     spinBox: css`

--- a/chat2db-community-client/src/blocks/NewTree/style.ts
+++ b/chat2db-community-client/src/blocks/NewTree/style.ts
@@ -7,44 +7,47 @@ export const useStyles = createStyles(({ css, token }) => {
       flex-direction: column;
       font-size: 14px;
       min-width: 0;
-      overflow-x: auto;
-      overflow-y: hidden;
-      /* position: relative; */
+      min-height: 0;
+      overflow: hidden;
 
       .ant-tree {
+        flex: 1 1 auto;
+        width: 100%;
+        height: 100%;
+        min-height: 0;
         background-color: transparent;
-        width: max-content;
-        min-width: 100%;
+      }
+
+      .ant-tree-list,
+      .ant-tree-list-holder {
+        height: 100%;
+        min-height: 0;
+      }
+
+      .ant-tree-list-holder {
+        max-height: 100% !important;
+      }
+
+      .ant-tree-list-scrollbar-horizontal {
+        bottom: 0 !important;
+        height: 6px !important;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.1s ease;
+      }
+
+      .ant-tree-list-scrollbar-horizontal .ant-tree-list-scrollbar-thumb {
+        background-color: ${token.colorFill} !important;
+      }
+
+      .ant-tree-list-scrollbar-horizontal:active,
+      .ant-tree-list-scrollbar-horizontal:has(.ant-tree-list-scrollbar-thumb:active) {
+        opacity: 1;
+        pointer-events: auto;
       }
 
       .ant-tree-switcher {
         display: none;
-      }
-
-      .ant-tree-list {
-        width: max-content;
-        min-width: 100%;
-        position: inherit !important;
-      }
-
-      .ant-tree-list-holder {
-        width: max-content;
-        min-width: 100%;
-        & > div {
-          position: inherit !important;
-          overflow: visible !important;
-        }
-      }
-
-      .ant-tree-list-holder-inner {
-        width: max-content;
-        min-width: 100%;
-        position: inherit !important;
-      }
-
-      .ant-tree-treenode {
-        width: max-content;
-        min-width: 100%;
       }
 
       .ant-tree-treenode.chat2db-data-source-identity-node {
@@ -89,7 +92,7 @@ export const useStyles = createStyles(({ css, token }) => {
         white-space: nowrap;
       }
 
-      .ant-tree-list-scrollbar-thumb {
+      .ant-tree-list-scrollbar-vertical .ant-tree-list-scrollbar-thumb {
         background-color: ${token.colorFill} !important;
         transition: background-color 0.1s ease;
       }
@@ -111,6 +114,12 @@ export const useStyles = createStyles(({ css, token }) => {
           background-color: CanvasText;
           box-shadow: none;
         }
+      }
+    `,
+    horizontalScrolling: css`
+      .ant-tree-list-scrollbar-horizontal {
+        opacity: 1;
+        pointer-events: auto;
       }
     `,
     spinBox: css`

--- a/chat2db-community-client/src/blocks/NewTree/treeScrollWidth.test.ts
+++ b/chat2db-community-client/src/blocks/NewTree/treeScrollWidth.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import {
+  resolveNextTreeScrollWidth,
+  resolveTreeScrollWidth,
+  resolveTreeVirtualScrollOffset,
+} from './treeScrollWidth';
+
+assert.equal(
+  resolveNextTreeScrollWidth(853, 190, true),
+  190,
+  'a new measurement cycle discards widths from collapsed or replaced nodes',
+);
+assert.equal(
+  resolveNextTreeScrollWidth(190, 853, false),
+  853,
+  'a measurement cycle retains the widest virtualized node encountered so far',
+);
+assert.equal(
+  resolveTreeVirtualScrollOffset('-240px', '0px'),
+  240,
+  'left-to-right virtual scrolling is restored before measuring title positions',
+);
+assert.equal(
+  resolveTreeVirtualScrollOffset('0px', '-120px'),
+  120,
+  'right-to-left virtual scrolling is restored before measuring title positions',
+);
+
+assert.equal(resolveTreeScrollWidth(320, []), 320, 'the tree viewport remains the minimum scroll width');
+assert.equal(
+  resolveTreeScrollWidth(320, [{ left: 72, width: 360 }]),
+  440,
+  'node indentation and title width extend the horizontal scroll range',
+);
+assert.equal(
+  resolveTreeScrollWidth(320, [
+    { left: 20, width: 100 },
+    { left: 64, width: 500.2 },
+  ]),
+  573,
+  'the widest rendered title determines the scroll range',
+);
+
+console.log('Tree horizontal scroll width tests passed');

--- a/chat2db-community-client/src/blocks/NewTree/treeScrollWidth.ts
+++ b/chat2db-community-client/src/blocks/NewTree/treeScrollWidth.ts
@@ -1,0 +1,49 @@
+const TREE_SCROLL_END_PADDING = 8;
+
+export interface TreeTitleWidth {
+  left: number;
+  width: number;
+}
+
+export function resolveNextTreeScrollWidth(
+  currentWidth: number | undefined,
+  measuredWidth: number,
+  resetMeasurement: boolean,
+) {
+  return resetMeasurement ? measuredWidth : Math.max(currentWidth || 0, measuredWidth);
+}
+
+export function resolveTreeVirtualScrollOffset(marginLeft: string, marginRight: string) {
+  const offsets = [marginLeft, marginRight].map((margin) => {
+    const value = Number.parseFloat(margin);
+    return Number.isFinite(value) ? -value : 0;
+  });
+  return Math.max(0, ...offsets);
+}
+
+export function resolveTreeScrollWidth(containerWidth: number, titles: TreeTitleWidth[]) {
+  return Math.ceil(
+    titles.reduce(
+      (maximum, title) => Math.max(maximum, title.left + title.width + TREE_SCROLL_END_PADDING),
+      Math.max(0, containerWidth),
+    ),
+  );
+}
+
+export function measureTreeScrollWidth(container: HTMLElement) {
+  const containerRect = container.getBoundingClientRect();
+  const holderInner = container.querySelector<HTMLElement>('.ant-tree-list-holder-inner');
+  const holderInnerStyle = holderInner ? window.getComputedStyle(holderInner) : null;
+  const virtualScrollOffset = holderInnerStyle
+    ? resolveTreeVirtualScrollOffset(holderInnerStyle.marginLeft, holderInnerStyle.marginRight)
+    : 0;
+  const titles = Array.from(container.querySelectorAll<HTMLElement>('.ant-tree-title > :first-child')).map((title) => {
+    const titleRect = title.getBoundingClientRect();
+    return {
+      left: Math.max(0, titleRect.left - containerRect.left + virtualScrollOffset),
+      width: Math.max(title.scrollWidth, titleRect.width),
+    };
+  });
+
+  return resolveTreeScrollWidth(container.clientWidth, titles);
+}


### PR DESCRIPTION
## Summary
- replace the legacy `max-content`, inherited positioning, and visible-overflow overrides with `rc-virtual-list` horizontal scrolling
- measure rendered tree-title widths while preserving vertical virtualization, including virtual horizontal-offset compensation
- reset stale width ranges when tree data, expansion state, editing state, or panel width changes, while accumulating wider nodes during vertical browsing
- keep the horizontal scrollbar at the bottom, hide it while idle, and keep it visible during thumb dragging
- add focused tests for width calculation, measurement-cycle reset, and virtual-scroll offset handling

## Root cause
The previous CSS-based approach forced content sizing through multiple internal Ant Tree and virtual-list layers. Those overrides conflicted with virtualization: horizontal wheel events were consumed by the inner list, stale outer offsets clipped expand icons, and narrow panels could not scroll reliably.

## Validation
- `yarn test:tree-loading`
- targeted ESLint for the changed NewTree files
- `git diff --check`
- Community JCEF Webpack hot-reload compilation and manual narrow-panel verification

## Notes
The repository-wide `yarn tsc --noEmit --pretty false` command still reports existing unrelated type errors across the frontend; it reported no new error in the files changed by this PR.