### PR TITLE
fix(jcef): preserve pagination parameters for streamed results

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -67,7 +67,7 @@
     "test:sql-execution-batch": "tsx src/service/sqlExecutionBatch.test.ts",
     "test:data-source-execution-snapshot": "tsx src/service/dataSourceExecutionSnapshot.test.ts",
     "test:sql-execution-request-tracker": "tsx src/service/sqlExecutionRequestTracker.test.ts",
-    "test:sql-execution-stream": "tsx src/service/sqlExecutionStream.test.ts",
+    "test:sql-execution-stream": "tsx src/service/sqlExecutionStream.test.ts && tsx src/pages/main/workspace/components/SQLExecute/streamResultExecutionParams.test.ts",
     "test:result-set-editor": "tsx src/blocks/SearchResult/components/ResultSetTable/utils/editorType.test.ts && tsx src/blocks/CanvasTable/editor/SelectIEditor/index.test.ts && tsx src/blocks/CanvasTable/editor/MultiSelectIEditor/index.test.ts && tsx src/blocks/CanvasTable/editor/SelectIEditor/index.dom.test.ts",
     "test:local-file-tab-title": "tsx src/pages/main/workspace/utils/localTextFile.test.ts",
     "test:local-file-tab-refresh": "tsx src/store/workspace/utils/localFileWorkspaceTab.test.ts",

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
@@ -104,6 +104,7 @@ import {
 } from '@/service/sqlExecutionLog';
 import { isDesktop } from '@/utils/env';
 import { v4 as uuidv4 } from 'uuid';
+import { buildStreamResultExecuteSqlParams } from './streamResultExecutionParams';
 
 const SplitPaneAny = SplitPane as any;
 const HISTORY_BATCH_LIMIT = 30;
@@ -228,6 +229,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
   const availabilityGenerationByExecutionSequenceRef = useRef(new Map<number, number>());
   const keepExistingOutputByExecutionSequenceRef = useRef<Record<number, boolean>>({});
   const desktopExecutionCallbackBySequenceRef = useRef<Record<number, DesktopExecutionCallbackState>>({});
+  const executionParamsBySequenceRef = useRef<Record<number, IExecuteSqlParams>>({});
   const currentStatementSequenceByExecutionIdRef = useRef<Record<string, number>>({});
   const [resultBatchKey, setResultBatchKey] = useState(0);
   const [forceOutputTab, setForceOutputTab] = useState(false);
@@ -424,6 +426,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
       delete keepExistingOutputByExecutionSequenceRef.current[executionSequence];
       delete resultDisplayBatchSequenceByExecutionRef.current[executionSequence];
       delete desktopExecutionCallbackBySequenceRef.current[executionSequence];
+      delete executionParamsBySequenceRef.current[executionSequence];
     }
   }, [discardPendingRows]);
   const handleSqlExecutionRequestStart = useCallback(
@@ -542,6 +545,11 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
         setResultDataList((prev) => {
           const nextResult = {
             ...resultWithIdentity,
+            executeSqlParams: buildStreamResultExecuteSqlParams(
+              executionParamsBySequenceRef.current[executionSequence],
+              resultWithIdentity,
+              resultSequence,
+            ),
             extra: {
               ...(resultWithIdentity.extra || {}),
               executionSequence,
@@ -624,6 +632,11 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
         const resultKey = event.resultKey || buildResultKey(event.executionId, statementSequence, resultSequence);
         const nextResult = {
           ...resultWithIdentity,
+          executeSqlParams: buildStreamResultExecuteSqlParams(
+            executionParamsBySequenceRef.current[executionSequence],
+            resultWithIdentity,
+            resultSequence,
+          ),
           displayName: getResultDisplayName({
             executionSequence: displayBatchSequence,
             statementSequence,
@@ -853,6 +866,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
       databaseName: executionSnapshot.databaseName,
       schemaName: executionSnapshot.schemaName,
     };
+    executionParamsBySequenceRef.current[executionSequence] = executeSqlParams;
 
     const webExecutionId = isDesktop ? undefined : uuidv4();
     const executionLogContext = getExecutionLogContext(executionSnapshot);
@@ -1001,6 +1015,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
         delete keepExistingOutputByExecutionSequenceRef.current[executionSequence];
         delete resultDisplayBatchSequenceByExecutionRef.current[executionSequence];
         delete desktopExecutionCallbackBySequenceRef.current[executionSequence];
+        delete executionParamsBySequenceRef.current[executionSequence];
       });
   };
 

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/streamResultExecutionParams.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/streamResultExecutionParams.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { buildStreamResultExecuteSqlParams } from './streamResultExecutionParams';
+
+const params = {
+  sql: 'select * from records',
+  dataSourceId: 42,
+  databaseName: 'app',
+  pageNo: 1,
+  pageSize: 1_000_000,
+};
+
+assert.deepEqual(
+  buildStreamResultExecuteSqlParams(params, { originalSql: 'select * from records', resultSetId: 2 }, 9),
+  {
+    ...params,
+    resultSetId: 2,
+  },
+  'streamed results retain the selected page size and result set identity',
+);
+assert.equal(
+  buildStreamResultExecuteSqlParams(undefined, { originalSql: 'select 1', resultSetId: 1 }, 1),
+  undefined,
+  'missing execution parameters remain distinguishable from an empty parameter object',
+);
+
+console.log('Stream result execution parameter tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/streamResultExecutionParams.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/streamResultExecutionParams.ts
@@ -1,0 +1,17 @@
+import type { IExecuteSqlParams, IManageResultData } from '@/typings';
+
+export function buildStreamResultExecuteSqlParams(
+  executionParams: IExecuteSqlParams | undefined,
+  result: Pick<IManageResultData, 'originalSql' | 'resultSetId'>,
+  resultSequence: number,
+) {
+  if (!executionParams) {
+    return undefined;
+  }
+
+  return {
+    ...executionParams,
+    sql: result.originalSql || executionParams.sql,
+    resultSetId: result.resultSetId ?? resultSequence,
+  };
+}


### PR DESCRIPTION
## Summary
- preserve the original SQL execution parameters for JCEF streamed result batches
- attach the selected page size and result-set identity to streamed result metadata
- allow result pagination to issue the next request after a desktop execution

## Verification
- `yarn test:sql-execution-stream`
- `yarn test:result-pagination`
- `yarn test:settings-layout`
- targeted ESLint

The full community build is currently blocked by the existing missing `jsdom` dependency in `SelectIEditor/index.dom.test.ts`.