### PR TITLE
fix(community): align workspace data source header

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/style.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/style.ts
@@ -29,7 +29,7 @@ export const useStyles = createStyles(({ css, token }) => {
       flex-shrink: 0;
       height: 42px;
       box-sizing: border-box;
-      padding: 0 8px 0 12px;
+      padding: 0 8px 0 6px;
       border-bottom: 1px solid ${token.colorBorderLayout};
     `,
     resourceSelector: css`


### PR DESCRIPTION
## Related issue

N/A

## Summary

Align the Community workspace data source header with the action toolbar below it by using the same left padding baseline. This removes the visible horizontal offset between the “数据源” selector and the add-data-source button.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `yarn lint:eslint` passed; `git diff --check` passed; Community hot frontend recompiled successfully; `http://127.0.0.1:8889/umi.js` returned HTTP 200; `http://127.0.0.1:10825/api/system` returned HTTP 200 with `success: true`.
- Manual verification: Confirmed the one-line CSS change in the running Community JCEF/Web development environment.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A; CSS-only change.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Community frontend layout only.
- Backward compatibility: N/A; no behavior or contract changes.

## Reviewer map

- Start here: `chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/style.ts` (`resourceSwitcher` padding.
- Failure condition: The data source selector and toolbar appear on different horizontal baselines.
- Rollback or disable path: Revert commit `a9929f295`.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex made the CSS-only alignment change and ran the listed verification.