### PR TITLE
fix(community): stream table browse pagination

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -2,7 +2,12 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import { createPortal } from 'react-dom';
 import { useStyles } from './style';
 import ResultSetToolbar, { ToolbarOperationType } from '../ResultSetToolbar';
-import { buildResultPageExecuteParams, resolveResultPaging, ResultPaging } from './pagination';
+import {
+  buildResultPageExecuteParams,
+  resolveResultPaging,
+  ResultPaging,
+  runResultPagingRequest,
+} from './pagination';
 import ScreeningResult, { IScreeningResultRef } from '../ScreeningResult';
 import FESearch, { FESearchRef } from '../FESearch';
 import ResultSetTable, { IResultSetSelection, ResultSetTableRef } from '../ResultSetTable';
@@ -245,8 +250,18 @@ export default memo<IProps>(
           paging,
           viewTable ? screenResultRef.current?.getJointSQL() || '' : undefined,
         );
-        if (props.onResultPagingChange) {
-          props.onResultPagingChange(resultData, executeSqlParams);
+        const onResultPagingChange = props.onResultPagingChange;
+        if (onResultPagingChange) {
+          void runResultPagingRequest(
+            () => onResultPagingChange(resultData, executeSqlParams),
+            {
+              onSuccess: () => setExecuteErrorMessage(null),
+              onError: (message) => {
+                setExecuteErrorMessage(message);
+                setResultData((current) => ({ ...current }));
+              },
+            },
+          );
           return;
         }
         const requestSequence = ++executeRequestSequenceRef.current;

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import { createPortal } from 'react-dom';
 import { useStyles } from './style';
 import ResultSetToolbar, { ToolbarOperationType } from '../ResultSetToolbar';
-import { resolveResultPaging, ResultPaging } from './pagination';
+import { buildResultPageExecuteParams, resolveResultPaging, ResultPaging } from './pagination';
 import ScreeningResult, { IScreeningResultRef } from '../ScreeningResult';
 import FESearch, { FESearchRef } from '../FESearch';
 import ResultSetTable, { IResultSetSelection, ResultSetTableRef } from '../ResultSetTable';
@@ -12,8 +12,8 @@ import SQLPreviewExecute, { SQLPreviewExecuteRef } from '../SQLPreviewExecute';
 import ViewData, { ViewDataRef } from '../ViewData';
 import RowDetail, { IChangeDataParams, IViewDataParams, RowDetailRef } from '../RowDetail';
 import SelectionAggregates from '../SelectionAggregates';
-import { IManageResultData } from '@/typings';
-import { Button, Spin, Tabs, Tooltip } from 'antd';
+import { IExecuteSqlParams, IManageResultData } from '@/typings';
+import { Button, Tabs, Tooltip } from 'antd';
 import i18n from '@/i18n';
 import { copyToClipboard } from '@/utils';
 import StatusBar, { StatusBarRef } from '../StatusBar';
@@ -57,12 +57,13 @@ import {
 } from '../ResultSetTable/columnState';
 import { resolveResultInspectorActiveCell } from '../ResultSetTable/selectionState';
 import { areResultCellValuesEquivalent } from './inspectorState';
+import SqlExecutionLoading from '@/components/SqlExecutionLoading';
 
 interface IProps {
   resultData: IManageResultData;
   active: boolean;
   viewTable?: boolean;
-  onResultPagingChange?: (resultData: IManageResultData, paging: ResultPaging) => Promise<unknown> | void;
+  onResultPagingChange?: (resultData: IManageResultData, params: IExecuteSqlParams) => Promise<unknown> | void;
 }
 
 const RESULT_INSPECTOR_MODE_STORAGE_KEY = createResultInspectorModeStorageKey(
@@ -77,6 +78,9 @@ export default memo<IProps>(
     const { executeSQL, stopExecuteSQL, executing, canExecuteSQL } = useSqlExecutor();
     const [resultData, setResultData] = useState<IManageResultData>(props.resultData);
     const executeRequestSequenceRef = useRef(0);
+    const baseQuerySqlRef = useRef(
+      props.resultData.originalSql || props.resultData.sql || props.resultData.executeSqlParams?.sql || '',
+    );
     const screenResultRef = useRef<IScreeningResultRef>(null);
     const resultSetTableRef = useRef<ResultSetTableRef>(null);
     const [hasOperationRecord, setHasOperationRecord] = useState(false);
@@ -236,17 +240,14 @@ export default memo<IProps>(
         // If there is no executeSqlParams, the execution information is not known, and no execution is performed.
         if (!resultData.executeSqlParams) return;
         const paging = resolveResultPaging(resultData.executeSqlParams, pagingOverride);
+        const executeSqlParams = buildResultPageExecuteParams(
+          resultData.executeSqlParams,
+          paging,
+          viewTable ? screenResultRef.current?.getJointSQL() || '' : undefined,
+        );
         if (props.onResultPagingChange) {
-          props.onResultPagingChange(resultData, paging);
+          props.onResultPagingChange(resultData, executeSqlParams);
           return;
-        }
-        const executeSqlParams = {
-          ...resultData.executeSqlParams,
-          ...paging,
-        };
-        // Filter conditions when viewing tables
-        if (viewTable) {
-          executeSqlParams.sql = screenResultRef.current?.getJointSQL() || '';
         }
         const requestSequence = ++executeRequestSequenceRef.current;
         executeSQL(executeSqlParams).then((data) => {
@@ -800,14 +801,7 @@ export default memo<IProps>(
       <>
         <div tabIndex={0} className={cx(styles.container)} ref={resultSetRef} id={searchAreaId}>
           {(executing || submitLoading) && (
-            <div className={styles.tableLoading}>
-              <Spin />
-              {executing && (
-                <div className={styles.stopExecuteSql} onClick={stopExecuteSQL}>
-                  {i18n('common.button.cancelRequest')}
-                </div>
-              )}
-            </div>
+            <SqlExecutionLoading onCancel={executing ? stopExecuteSQL : undefined} />
           )}
           <>
             <ResultSetToolbar
@@ -822,7 +816,7 @@ export default memo<IProps>(
               <ScreeningResult
                 ref={screenResultRef}
                 onSearch={handleSearch}
-                originalSql={props.resultData.originalSql}
+                originalSql={baseQuerySqlRef.current}
                 promptWord={resultData.headerList}
                 orderByText={orderByText}
                 databaseType={resultData.executeSqlParams?.databaseType}

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { MAX_RESULT_PAGE_SIZE } from '@/constants/pagination';
-import { buildResultPageExecuteParams, resolveResultPaging } from './pagination';
+import { SqlExecutionBusyError } from '@/service/sqlExecutionRequestTracker';
+import {
+  buildResultPageExecuteParams,
+  resolveResultPaging,
+  runResultPagingRequest,
+} from './pagination';
 import './viewTablePagingFlow.test';
 
 test('matches the Java Integer transport boundary without restoring the old product cap', () => {
@@ -34,4 +39,29 @@ test('ordinary SQL paging preserves its existing SQL when no table-browser overr
     ),
     { sql: 'SELECT 1', dataSourceId: 42, pageNo: 2, pageSize: 5000 },
   );
+});
+
+test('a rejected paging request is handled and restores the confirmed pagination state', async () => {
+  const confirmedPaging = { pageNo: 2, pageSize: 1000 };
+  let visiblePaging = { pageNo: 1, pageSize: 50_000 };
+  let errorMessage = '';
+  const unhandledRejections: unknown[] = [];
+  const rejectionListener = (reason: unknown) => unhandledRejections.push(reason);
+  process.on('unhandledRejection', rejectionListener);
+
+  void runResultPagingRequest(
+    () => Promise.reject(new SqlExecutionBusyError()),
+    {
+      onError: (message) => {
+        errorMessage = message;
+        visiblePaging = { ...confirmedPaging };
+      },
+    },
+  );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  process.off('unhandledRejection', rejectionListener);
+
+  assert.equal(errorMessage, 'SQL execution is already in progress');
+  assert.deepEqual(visiblePaging, confirmedPaging);
+  assert.deepEqual(unhandledRejections, []);
 });

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { MAX_RESULT_PAGE_SIZE } from '@/constants/pagination';
-import { resolveResultPaging } from './pagination';
+import { buildResultPageExecuteParams, resolveResultPaging } from './pagination';
+import './viewTablePagingFlow.test';
 
 test('matches the Java Integer transport boundary without restoring the old product cap', () => {
   assert.equal(MAX_RESULT_PAGE_SIZE, 2_147_483_647);
@@ -23,4 +24,14 @@ test('preserves the current page size when only the page changes', () => {
 
 test('falls back to stable defaults when result metadata is incomplete', () => {
   assert.deepEqual(resolveResultPaging(undefined), { pageNo: 1, pageSize: 1000 });
+});
+
+test('ordinary SQL paging preserves its existing SQL when no table-browser override is supplied', () => {
+  assert.deepEqual(
+    buildResultPageExecuteParams(
+      { sql: 'SELECT 1', dataSourceId: 42, pageNo: 1, pageSize: 1000 },
+      { pageNo: 2, pageSize: 5000 },
+    ),
+    { sql: 'SELECT 1', dataSourceId: 42, pageNo: 2, pageSize: 5000 },
+  );
 });

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_RESULT_PAGE_SIZE } from '@/constants/pagination';
+import type { IExecuteSqlParams } from '@/typings';
 
 export interface ResultPaging {
   pageNo: number;
@@ -12,5 +13,17 @@ export function resolveResultPaging(
   return {
     pageNo: override?.pageNo ?? current?.pageNo ?? 1,
     pageSize: override?.pageSize ?? current?.pageSize ?? DEFAULT_RESULT_PAGE_SIZE,
+  };
+}
+
+export function buildResultPageExecuteParams(
+  current: IExecuteSqlParams,
+  paging: ResultPaging,
+  sql?: string,
+): IExecuteSqlParams {
+  return {
+    ...current,
+    ...paging,
+    ...(sql !== undefined ? { sql } : {}),
   };
 }

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.ts
@@ -27,3 +27,35 @@ export function buildResultPageExecuteParams(
     ...(sql !== undefined ? { sql } : {}),
   };
 }
+
+export function getResultPagingErrorMessage(error: unknown) {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object') {
+    const errorMessage = 'errorMessage' in error ? error.errorMessage : undefined;
+    if (typeof errorMessage === 'string') {
+      return errorMessage;
+    }
+    const message = 'message' in error ? error.message : undefined;
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+  return '';
+}
+
+export async function runResultPagingRequest(
+  request: () => Promise<unknown> | unknown,
+  callbacks: {
+    onSuccess?: () => void;
+    onError: (message: string) => void;
+  },
+) {
+  try {
+    await request();
+    callbacks.onSuccess?.();
+  } catch (error) {
+    callbacks.onError(getResultPagingErrorMessage(error));
+  }
+}

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/viewTablePagingFlow.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/viewTablePagingFlow.test.ts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DatabaseTypeCode } from '@/constants/common';
+import type { IManageResultData } from '@/typings';
+import { processResultDataList } from '@/utils/resultData';
+import { composeResultQuery } from '../ScreeningResult/queryComposer';
+import {
+  createViewTablePagingState,
+  reduceViewTablePagingEvent,
+  replaceViewTableResult,
+  type ViewTablePagingTransition,
+} from '@/hooks/viewTablePagingModel';
+import { cancelSqlExecutionWithReconciliation, type SqlExecutionEvent } from '@/service/sqlExecutionStream';
+import {
+  beginSqlExecutionRequest,
+  createSqlExecutionRequestTracker,
+  finishSqlExecutionRequest,
+  requestSqlExecutionCancellation,
+  setSqlExecutionRequestId,
+} from '@/service/sqlExecutionRequestTracker';
+import { buildResultPageExecuteParams, resolveResultPaging } from './pagination';
+
+const BASE_SQL = 'SELECT * FROM app.test_1m_records';
+
+function result(overrides: Partial<IManageResultData> = {}): IManageResultData {
+  return {
+    uuid: 'backend-result',
+    dataList: [],
+    headerList: [{ name: '#' }, { name: 'id' }, { name: 'status' }] as any,
+    description: '',
+    sql: BASE_SQL,
+    originalSql: BASE_SQL,
+    success: true,
+    sqlType: 'SELECT' as any,
+    refreshTargets: [],
+    resultSetId: 1,
+    pageNo: 1,
+    pageSize: 1000,
+    fuzzyTotal: '1000+',
+    hasNextPage: true,
+    ...overrides,
+  };
+}
+
+function event(
+  eventType: SqlExecutionEvent['eventType'],
+  message: IManageResultData,
+): SqlExecutionEvent<IManageResultData> {
+  return {
+    executionId: 'execution-50000',
+    eventType,
+    message,
+    statementSequence: 1,
+    resultSequence: 1,
+    resultKey: 'execution-50000:1:1',
+  };
+}
+
+test('table browse flows from the initial response through filtered 50000-row streaming completion', () => {
+  const initialRequest = {
+    dataSourceId: 42,
+    databaseName: 'app',
+    databaseType: DatabaseTypeCode.MYSQL,
+    tableName: 'test_1m_records',
+    pageNo: 1,
+    pageSize: 1000,
+  };
+  const [initialResult] = processResultDataList(
+    [result({ originalSql: '', sql: BASE_SQL })],
+    initialRequest,
+  );
+  const initialUuid = initialResult.uuid;
+
+  assert.equal(initialResult.originalSql, BASE_SQL, 'table browse falls back to the backend sql as its base query');
+  assert.equal(initialResult.executeSqlParams?.sql, BASE_SQL, 'subsequent actions retain the normalized base query');
+
+  const filteredSql = composeResultQuery({
+    databaseType: DatabaseTypeCode.MYSQL,
+    filterValue: "status = 'ACTIVE'",
+    orderByValue: 'id DESC',
+    originalSql: initialResult.originalSql,
+  });
+  const paging = resolveResultPaging(initialResult.executeSqlParams, { pageNo: 1, pageSize: 50_000 });
+  const executeParams = buildResultPageExecuteParams(initialResult.executeSqlParams!, paging, filteredSql);
+
+  assert.deepEqual(
+    executeParams,
+    {
+      ...initialResult.executeSqlParams,
+      pageNo: 1,
+      pageSize: 50_000,
+      sql: `${BASE_SQL} WHERE status = 'ACTIVE' ORDER BY id DESC`,
+    },
+    'the paging request carries datasource identity, composed SQL, and the selected page size together',
+  );
+
+  const requestSequence = 7;
+  let transition: ViewTablePagingTransition = {
+    state: createViewTablePagingState(requestSequence, executeParams),
+    completedResult: undefined as IManageResultData | undefined,
+  };
+
+  const staleTransition = reduceViewTablePagingEvent(
+    transition.state,
+    event('rows', result({ dataList: [[{ value: 'stale' }]] as any })),
+    requestSequence - 1,
+  );
+  assert.equal(staleTransition.state, transition.state, 'a stale execution cannot mutate the active result');
+  assert.equal(staleTransition.completedResult, undefined);
+
+  transition = reduceViewTablePagingEvent(
+    transition.state,
+    event('resultStarted', result({ dataList: [], pageSize: 50_000, originalSql: filteredSql })),
+    requestSequence,
+  );
+  assert.equal(transition.completedResult, undefined, 'result metadata does not replace the visible table');
+
+  transition = reduceViewTablePagingEvent(
+    transition.state,
+    event('rows', result({ dataList: [[{ value: 'row-1' }]] as any, originalSql: filteredSql })),
+    requestSequence,
+  );
+  assert.equal(transition.completedResult, undefined, 'the first row chunk remains buffered');
+
+  transition = reduceViewTablePagingEvent(
+    transition.state,
+    event('rows', result({ dataList: [[{ value: 'row-2' }]] as any, originalSql: filteredSql })),
+    requestSequence,
+  );
+  assert.equal(transition.completedResult, undefined, 'later chunks remain buffered without remounting editors');
+
+  transition = reduceViewTablePagingEvent(
+    transition.state,
+    event(
+      'resultFinished',
+      result({
+        dataList: [],
+        pageSize: 50_000,
+        fuzzyTotal: '50000+',
+        hasNextPage: true,
+        originalSql: filteredSql,
+      }),
+    ),
+    requestSequence,
+  );
+
+  assert.deepEqual(
+    transition.completedResult?.dataList,
+    [[{ value: 'row-1' }], [{ value: 'row-2' }]],
+    'completion preserves every buffered row chunk',
+  );
+  assert.equal(transition.completedResult?.pageSize, 50_000);
+  assert.equal(transition.completedResult?.executeSqlParams?.sql, filteredSql);
+
+  const replacedResults = replaceViewTableResult([initialResult], transition.completedResult!);
+  assert.equal(replacedResults[0].uuid, initialUuid, 'completion preserves the mounted result identity');
+  assert.equal(
+    composeResultQuery({
+      databaseType: DatabaseTypeCode.MYSQL,
+      filterValue: "status = 'ACTIVE'",
+      orderByValue: 'id DESC',
+      originalSql: initialResult.originalSql,
+    }),
+    filteredSql,
+    'later searches continue composing from the stable base query instead of nesting prior filters',
+  );
+});
+
+test('table browse SQL normalization follows originalSql, sql, then request SQL', () => {
+  const request = { sql: 'SELECT * FROM request_fallback', dataSourceId: 42 };
+  assert.equal(processResultDataList([result({ originalSql: 'SELECT 1', sql: 'SELECT 2' })], request)[0].originalSql, 'SELECT 1');
+  assert.equal(processResultDataList([result({ originalSql: '', sql: 'SELECT 2' })], request)[0].originalSql, 'SELECT 2');
+  assert.equal(processResultDataList([result({ originalSql: '', sql: '' })], request)[0].originalSql, request.sql);
+});
+
+test('a cancelled table browse never publishes its buffered partial rows', () => {
+  const params = { sql: BASE_SQL, dataSourceId: 42, pageNo: 1, pageSize: 50_000 };
+  const requestSequence = 8;
+  let transition = reduceViewTablePagingEvent(
+    createViewTablePagingState(requestSequence, params),
+    event('rows', result({ dataList: [[{ value: 'partial' }]] as any })),
+    requestSequence,
+  );
+  assert.equal(transition.completedResult, undefined);
+
+  transition = reduceViewTablePagingEvent(
+    transition.state,
+    event('cancelled', result()),
+    requestSequence,
+  );
+  assert.equal(transition.completedResult, undefined, 'cancellation leaves the visible completed result untouched');
+});
+
+test('table browse cancellation targets the active JCEF execution and releases the request', async () => {
+  const tracker = createSqlExecutionRequestTracker();
+  const requestSequence = beginSqlExecutionRequest(tracker)!;
+  assert.equal(setSqlExecutionRequestId(tracker, requestSequence, 'execution-50000'), true);
+  const executionId = requestSqlExecutionCancellation(tracker);
+  const cancelledExecutions: string[] = [];
+
+  await cancelSqlExecutionWithReconciliation(
+    executionId!,
+    {
+      onExecutionMissing: () => assert.fail('the active execution should exist'),
+      onError: (error) => assert.fail(String(error)),
+    },
+    async (targetExecutionId) => {
+      cancelledExecutions.push(targetExecutionId);
+      return true;
+    },
+  );
+
+  assert.deepEqual(cancelledExecutions, ['execution-50000']);
+  assert.equal(finishSqlExecutionRequest(tracker, requestSequence), true);
+  assert.equal(requestSqlExecutionCancellation(tracker), undefined, 'terminal cleanup removes the cancellation target');
+});

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/viewTablePagingFlow.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/viewTablePagingFlow.test.ts
@@ -6,6 +6,7 @@ import { processResultDataList } from '@/utils/resultData';
 import { composeResultQuery } from '../ScreeningResult/queryComposer';
 import {
   createViewTablePagingState,
+  normalizeViewTablePageResults,
   reduceViewTablePagingEvent,
   replaceViewTableResult,
   type ViewTablePagingTransition,
@@ -171,6 +172,38 @@ test('table browse SQL normalization follows originalSql, sql, then request SQL'
   assert.equal(processResultDataList([result({ originalSql: 'SELECT 1', sql: 'SELECT 2' })], request)[0].originalSql, 'SELECT 1');
   assert.equal(processResultDataList([result({ originalSql: '', sql: 'SELECT 2' })], request)[0].originalSql, 'SELECT 2');
   assert.equal(processResultDataList([result({ originalSql: '', sql: '' })], request)[0].originalSql, request.sql);
+});
+
+test('web table browse retains execution params across consecutive page requests', () => {
+  const firstRequest = {
+    sql: BASE_SQL,
+    dataSourceId: 42,
+    databaseName: 'app',
+    pageNo: 2,
+    pageSize: 5000,
+    resultSetId: 1,
+  };
+  const [firstPage] = normalizeViewTablePageResults(
+    [result({ originalSql: '', sql: '', pageNo: 2, pageSize: 5000 })],
+    firstRequest,
+  );
+
+  assert.deepEqual(firstPage.executeSqlParams, { ...firstRequest, single: undefined });
+
+  const secondRequest = buildResultPageExecuteParams(
+    firstPage.executeSqlParams!,
+    resolveResultPaging(firstPage.executeSqlParams, { pageNo: 3 }),
+  );
+  const [secondPage] = normalizeViewTablePageResults(
+    [result({ originalSql: '', sql: '', pageNo: 3, pageSize: 5000 })],
+    secondRequest,
+  );
+
+  assert.equal(secondRequest.pageNo, 3);
+  assert.equal(secondPage.executeSqlParams?.sql, BASE_SQL);
+  assert.equal(secondPage.executeSqlParams?.dataSourceId, 42);
+  assert.equal(secondPage.executeSqlParams?.pageNo, 3);
+  assert.equal(secondPage.executeSqlParams?.pageSize, 5000);
 });
 
 test('a cancelled table browse never publishes its buffered partial rows', () => {

--- a/chat2db-community-client/src/blocks/SearchResult/components/SearchResultItem/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/SearchResultItem/index.tsx
@@ -5,18 +5,17 @@ import StatusBar from '../StatusBar';
 import ResultSet from '../ResultSet';
 import i18n from '@/i18n';
 import { useStyles } from './style';
-import { IManageResultData } from '@/typings';
+import { IExecuteSqlParams, IManageResultData } from '@/typings';
 import { useAIStore } from '@/store/ai';
 import { useGlobalStore } from '@/store/global';
 import { useWorkspaceStore } from '@/store/workspace';
 import { QuestionType } from '@/constants/chat';
-import type { ResultPaging } from '../ResultSet/pagination';
 
 interface IProps {
   resultData: IManageResultData;
   active: boolean;
   viewTable?: boolean;
-  onResultPagingChange?: (resultData: IManageResultData, paging: ResultPaging) => Promise<unknown> | void;
+  onResultPagingChange?: (resultData: IManageResultData, params: IExecuteSqlParams) => Promise<unknown> | void;
 }
 
 export default memo<IProps>(

--- a/chat2db-community-client/src/blocks/SearchResult/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/index.tsx
@@ -14,7 +14,7 @@ import classnames from 'classnames';
 import { Dropdown, type MenuProps } from 'antd';
 import { ArrowDownUp, Check, SlidersHorizontal } from 'lucide-react';
 import CustomTabs, { ITabItem } from '@/components/Tabs';
-import { IManageResultData } from '@/typings';
+import { IExecuteSqlParams, IManageResultData } from '@/typings';
 import SearchResultItem from './components/SearchResultItem';
 import Abstract from '@/components/Abstract';
 import i18n from '@/i18n';
@@ -51,7 +51,6 @@ import { retainPinnedResults } from './resultTabPinning';
 import { useTreeStore } from '@/store/tree';
 import { resolveDataSourceIdentityColor } from '@/utils/dataSourceIdentity';
 import type { DataSourceExecutionTarget } from '@/service/dataSourceExecutionSnapshot';
-import type { ResultPaging } from './components/ResultSet/pagination';
 
 interface IProps {
   className?: string;
@@ -73,7 +72,7 @@ interface IProps {
     historyResultDataList: IManageResultData[];
     closedResultIdentities: SqlExecutionResultIdentity[];
   }) => void;
-  onResultPagingChange?: (resultData: IManageResultData, paging: ResultPaging) => Promise<unknown> | void;
+  onResultPagingChange?: (resultData: IManageResultData, params: IExecuteSqlParams) => Promise<unknown> | void;
 }
 
 const RESULT_TAB_ORDER_STORAGE_KEY = createResultTabOrderStorageKey('community', __RUNTIME_ENV__);

--- a/chat2db-community-client/src/components/SingleFileMonacoEditor/index.tsx
+++ b/chat2db-community-client/src/components/SingleFileMonacoEditor/index.tsx
@@ -53,9 +53,12 @@ const SingleFileMonacoEditor = memo<IProps>(
       handelEnter?.(value);
     }, [handelEnter]);
 
+    const handleEnterSearchRef = useRef(handleEnterSearch);
+    handleEnterSearchRef.current = handleEnterSearch;
+
     const shortcutController = useMemo(
-      () => createSingleFileShortcutController(window, handleEnterSearch),
-      [handleEnterSearch],
+      () => createSingleFileShortcutController(window, () => handleEnterSearchRef.current()),
+      [],
     );
 
     // Listen for keydown and prevent Enter's default behavior.

--- a/chat2db-community-client/src/components/SingleFileMonacoEditor/index.tsx
+++ b/chat2db-community-client/src/components/SingleFileMonacoEditor/index.tsx
@@ -1,8 +1,9 @@
-import { memo, useCallback, useMemo, ForwardedRef, forwardRef, useImperativeHandle, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, ForwardedRef, forwardRef, useImperativeHandle, useRef } from 'react';
 import styles from './index.less';
 import classnames from 'classnames';
 import MonacoEditor, { IExportRefFunction } from '@/components/MonacoEditor';
 import { v4 as uuid } from 'uuid';
+import { createSingleFileShortcutController } from './shortcut';
 
 interface IProps {
   className?: string;
@@ -41,40 +42,37 @@ const options = {
 const SingleFileMonacoEditor = memo<IProps>(
   forwardRef((props, ref: ForwardedRef<ISingleFileMonacoEditorRefFunction>) => {
     const { className, handelEnter, focusChange } = props;
-    const editorRef = useRef<any>(null);
     const monacoEditorRef = useRef<IExportRefFunction>(null);
 
     const editorId = useMemo(() => {
       return uuid();
     }, []);
 
-    const handleKeydown = useCallback((event) => {
-      if (event.key === 'Enter' && editorRef.current) {
-        const controller = editorRef.current.getContribution('editor.contrib.suggestController') as any;
-        const suggestWidget = controller._widget;
-        if (suggestWidget && suggestWidget.suggestWidgetVisible.get()) {
-          return;
-        }
-        // Otherwise prevent Enter's default behavior.
-        event.preventDefault();
-        handleEnterSearch();
-      }
-    }, []);
-
-    const handleEnterSearch = () => {
+    const handleEnterSearch = useCallback(() => {
       const value = monacoEditorRef.current?.getAllContent().trim() || '';
-      handelEnter && handelEnter(value);
-    };
+      handelEnter?.(value);
+    }, [handelEnter]);
+
+    const shortcutController = useMemo(
+      () => createSingleFileShortcutController(window, handleEnterSearch),
+      [handleEnterSearch],
+    );
 
     // Listen for keydown and prevent Enter's default behavior.
     const registerShortcutKey = useCallback((_editor, _monaco, isActive) => {
       if (isActive) {
-        editorRef.current = _editor;
-        window.addEventListener('keydown', handleKeydown);
+        shortcutController.activate(_editor);
       } else {
-        window.removeEventListener('keydown', handleKeydown);
+        shortcutController.deactivate();
       }
-    }, []);
+    }, [shortcutController]);
+
+    useEffect(
+      () => () => {
+        shortcutController.dispose();
+      },
+      [shortcutController],
+    );
 
     const getAllContent = () => {
       return monacoEditorRef.current?.getAllContent() || '';
@@ -82,7 +80,7 @@ const SingleFileMonacoEditor = memo<IProps>(
 
     useImperativeHandle(ref, () => ({
       getAllContent,
-      setValue: monacoEditorRef.current?.setValue,
+      setValue: (value) => monacoEditorRef.current?.setValue(value),
       onSearch: handleEnterSearch,
     }));
 

--- a/chat2db-community-client/src/components/SingleFileMonacoEditor/shortcut.ts
+++ b/chat2db-community-client/src/components/SingleFileMonacoEditor/shortcut.ts
@@ -1,0 +1,48 @@
+interface SuggestController {
+  _widget?: {
+    suggestWidgetVisible?: {
+      get?: () => boolean;
+    };
+  };
+}
+
+export interface SuggestEditor {
+  getContribution?: (id: string) => SuggestController | null | undefined;
+}
+
+interface KeydownTarget {
+  addEventListener: (type: 'keydown', listener: (event: KeyboardEvent) => void) => void;
+  removeEventListener: (type: 'keydown', listener: (event: KeyboardEvent) => void) => void;
+}
+
+export function isSuggestWidgetVisible(editor: SuggestEditor | null | undefined) {
+  const controller = editor?.getContribution?.('editor.contrib.suggestController');
+  return controller?._widget?.suggestWidgetVisible?.get?.() === true;
+}
+
+export function createSingleFileShortcutController(target: KeydownTarget, onEnter: () => void) {
+  let editor: SuggestEditor | null = null;
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (event.key !== 'Enter' || !editor || isSuggestWidgetVisible(editor)) {
+      return;
+    }
+    event.preventDefault();
+    onEnter();
+  };
+
+  const deactivate = () => {
+    target.removeEventListener('keydown', handleKeydown);
+    editor = null;
+  };
+
+  return {
+    activate(nextEditor: SuggestEditor) {
+      target.removeEventListener('keydown', handleKeydown);
+      editor = nextEditor;
+      target.addEventListener('keydown', handleKeydown);
+    },
+    deactivate,
+    dispose: deactivate,
+  };
+}

--- a/chat2db-community-client/src/components/SqlExecutionLoading/index.tsx
+++ b/chat2db-community-client/src/components/SqlExecutionLoading/index.tsx
@@ -1,0 +1,22 @@
+import { Spin } from 'antd';
+import i18n from '@/i18n';
+import { useStyles } from './style';
+
+interface SqlExecutionLoadingProps {
+  onCancel?: () => void;
+}
+
+export default function SqlExecutionLoading({ onCancel }: SqlExecutionLoadingProps) {
+  const { styles } = useStyles();
+
+  return (
+    <div className={styles.loading}>
+      <Spin />
+      {onCancel && (
+        <div className={styles.cancel} onClick={onCancel}>
+          {i18n('common.button.cancelRequest')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/chat2db-community-client/src/components/SqlExecutionLoading/style.ts
+++ b/chat2db-community-client/src/components/SqlExecutionLoading/style.ts
@@ -1,0 +1,31 @@
+import { createStyles } from 'antd-style';
+import { hexToRgba } from '@/utils/color';
+
+export const useStyles = createStyles(({ css, token }) => {
+  const loadingBackground = hexToRgba(token.colorFill, 20);
+
+  return {
+    loading: css`
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      background-color: ${loadingBackground};
+    `,
+    cancel: css`
+      margin-top: 30px;
+      cursor: pointer;
+
+      &:hover {
+        color: ${token.colorPrimary};
+      }
+    `,
+  };
+});

--- a/chat2db-community-client/src/components/ViewTable/index.tsx
+++ b/chat2db-community-client/src/components/ViewTable/index.tsx
@@ -51,7 +51,7 @@ const ViewTable = memo<IProps>((props) => {
       if (executeSqlParams.dataSourceId == null || !executeSqlParams.sql) {
         return;
       }
-      void executePage(executeSqlParams);
+      return executePage(executeSqlParams);
     },
     [executePage],
   );

--- a/chat2db-community-client/src/components/ViewTable/index.tsx
+++ b/chat2db-community-client/src/components/ViewTable/index.tsx
@@ -1,10 +1,11 @@
-import { memo, useState, useEffect, useRef } from 'react';
+import { memo, useCallback, useState, useEffect, useRef } from 'react';
 import SearchResult from '@/blocks/SearchResult';
 import { processResultDataList } from '@/utils/database';
-import { IManageResultData, IViewTableParams } from '@/typings';
-import { Spin } from 'antd';
-import i18n from '@/i18n';
+import { IExecuteSqlParams, IManageResultData, IViewTableParams } from '@/typings';
 import useViewTable from '@/hooks/useViewTable';
+import useViewTablePaging from '@/hooks/useViewTablePaging';
+import { replaceViewTableResult } from '@/hooks/viewTablePagingModel';
+import SqlExecutionLoading from '@/components/SqlExecutionLoading';
 import { useStyles } from './style';
 import { beginLatestRequest, invalidateLatestRequest, isLatestRequest } from '@/utils/latestRequest';
 
@@ -18,12 +19,17 @@ const ViewTable = memo<IProps>((props) => {
   const { styles } = useStyles();
   const [resultDataList, setResultDataList] = useState<IManageResultData[]>();
   const requestGenerationRef = useRef(0);
-  const { executing, executeSQL, stopExecuteSQL } = useViewTable();
-
+  const {
+    executing: initialExecuting,
+    executeSQL: executeInitialTable,
+    stopExecuteSQL: stopInitialTable,
+  } = useViewTable();
+  const { resultData: pagedResultData, executing: pagingExecuting, executePage, stopExecuteSQL: stopPaging } =
+    useViewTablePaging();
   useEffect(() => {
     if (viewTableParams) {
       const requestGeneration = beginLatestRequest(requestGenerationRef);
-      executeSQL(viewTableParams).then((data) => {
+      executeInitialTable(viewTableParams).then((data) => {
         if (!isLatestRequest(requestGenerationRef, requestGeneration)) return;
         const _resultDataList = processResultDataList(data, viewTableParams);
         setResultDataList(_resultDataList);
@@ -32,19 +38,36 @@ const ViewTable = memo<IProps>((props) => {
     return () => {
       invalidateLatestRequest(requestGenerationRef);
     };
-  }, []);
+  }, [executeInitialTable]);
+
+  useEffect(() => {
+    if (pagedResultData) {
+      setResultDataList((current) => replaceViewTableResult(current, pagedResultData));
+    }
+  }, [pagedResultData]);
+
+  const handleResultPagingChange = useCallback(
+    (_resultData: IManageResultData, executeSqlParams: IExecuteSqlParams) => {
+      if (executeSqlParams.dataSourceId == null || !executeSqlParams.sql) {
+        return;
+      }
+      void executePage(executeSqlParams);
+    },
+    [executePage],
+  );
 
   return (
     <div className={styles.container}>
-      {executing && (
-        <div className={styles.tableLoading}>
-          <Spin />
-          <div className={styles.stopExecuteSql} onClick={stopExecuteSQL}>
-            {i18n('common.button.cancelRequest')}
-          </div>
-        </div>
+      {(initialExecuting || pagingExecuting) && (
+        <SqlExecutionLoading onCancel={pagingExecuting ? stopPaging : stopInitialTable} />
       )}
-      {resultDataList && <SearchResult viewTable resultDataList={resultDataList} />}
+      {resultDataList && (
+        <SearchResult
+          viewTable
+          resultDataList={resultDataList}
+          onResultPagingChange={handleResultPagingChange}
+        />
+      )}
     </div>
   );
 });

--- a/chat2db-community-client/src/hooks/useViewTablePaging.ts
+++ b/chat2db-community-client/src/hooks/useViewTablePaging.ts
@@ -1,0 +1,60 @@
+import { useCallback, useRef, useState } from 'react';
+import type { IExecuteSqlParams } from '@/typings';
+import type { SqlExecutionEvent } from '@/service/sqlExecutionStream';
+import useSqlExecutor from './useSqlExecutor';
+import {
+  createViewTablePagingState,
+  reduceViewTablePagingEvent,
+  type ViewTablePagingState,
+} from './viewTablePagingModel';
+
+export default function useViewTablePaging() {
+  const requestSequenceRef = useRef<number>();
+  const paramsRef = useRef<IExecuteSqlParams>();
+  const pagingStateRef = useRef<ViewTablePagingState>();
+  const [resultData, setResultData] = useState<ViewTablePagingState['result']>();
+
+  const handleRequestStart = useCallback((requestSequence: number) => {
+    requestSequenceRef.current = requestSequence;
+    if (paramsRef.current) {
+      pagingStateRef.current = createViewTablePagingState(requestSequence, paramsRef.current);
+    }
+  }, []);
+
+  const handleExecutionEvent = useCallback((event: SqlExecutionEvent, requestSequence: number) => {
+    if (requestSequenceRef.current !== requestSequence || !pagingStateRef.current) {
+      return;
+    }
+
+    const transition = reduceViewTablePagingEvent(pagingStateRef.current, event, requestSequence);
+    pagingStateRef.current = transition.state;
+    if (transition.completedResult) {
+      setResultData(transition.completedResult);
+    }
+  }, []);
+
+  const { executeSQL, executing, stopExecuteSQL } = useSqlExecutor({
+    onExecutionRequestStart: handleRequestStart,
+    onExecutionEvent: handleExecutionEvent,
+  });
+
+  const executePage = useCallback(
+    (params: IExecuteSqlParams) => {
+      paramsRef.current = params;
+      return executeSQL(params).then((data) => {
+        if (data.length) {
+          setResultData(data[0]);
+        }
+        return data;
+      });
+    },
+    [executeSQL],
+  );
+
+  return {
+    resultData,
+    executing,
+    executePage,
+    stopExecuteSQL,
+  };
+}

--- a/chat2db-community-client/src/hooks/useViewTablePaging.ts
+++ b/chat2db-community-client/src/hooks/useViewTablePaging.ts
@@ -4,6 +4,7 @@ import type { SqlExecutionEvent } from '@/service/sqlExecutionStream';
 import useSqlExecutor from './useSqlExecutor';
 import {
   createViewTablePagingState,
+  normalizeViewTablePageResults,
   reduceViewTablePagingEvent,
   type ViewTablePagingState,
 } from './viewTablePagingModel';
@@ -42,8 +43,9 @@ export default function useViewTablePaging() {
     (params: IExecuteSqlParams) => {
       paramsRef.current = params;
       return executeSQL(params).then((data) => {
-        if (data.length) {
-          setResultData(data[0]);
+        const normalizedData = normalizeViewTablePageResults(data, params);
+        if (normalizedData.length) {
+          setResultData(normalizedData[0]);
         }
         return data;
       });

--- a/chat2db-community-client/src/hooks/viewTablePagingModel.ts
+++ b/chat2db-community-client/src/hooks/viewTablePagingModel.ts
@@ -1,0 +1,83 @@
+import type { IExecuteSqlParams, IManageResultData } from '@/typings';
+import type { SqlExecutionEvent } from '@/service/sqlExecutionStream';
+import { processResultDataList } from '@/utils/resultData';
+
+export type ViewTableStreamEventType = 'resultStarted' | 'rows' | 'resultFinished';
+
+export interface ViewTablePagingState {
+  requestSequence: number;
+  params: IExecuteSqlParams;
+  result?: IManageResultData;
+}
+
+export interface ViewTablePagingTransition {
+  state: ViewTablePagingState;
+  completedResult?: IManageResultData;
+}
+
+function isResultEvent(eventType: SqlExecutionEvent['eventType']): eventType is ViewTableStreamEventType {
+  return eventType === 'resultStarted' || eventType === 'rows' || eventType === 'resultFinished';
+}
+
+function mergeResultEvent(
+  current: IManageResultData | undefined,
+  eventResult: IManageResultData,
+  eventType: ViewTableStreamEventType,
+) {
+  const dataList =
+    eventType === 'rows'
+      ? [...(current?.dataList || []), ...(eventResult.dataList || [])]
+      : eventType === 'resultFinished' && current?.dataList?.length
+        ? current.dataList
+        : eventResult.dataList || [];
+
+  if (!current) {
+    return { ...eventResult, dataList };
+  }
+
+  return {
+    ...current,
+    ...eventResult,
+    uuid: current.uuid,
+    executeSqlParams: current.executeSqlParams || eventResult.executeSqlParams,
+    dataList,
+  };
+}
+
+export function createViewTablePagingState(requestSequence: number, params: IExecuteSqlParams) {
+  return { requestSequence, params } satisfies ViewTablePagingState;
+}
+
+export function reduceViewTablePagingEvent(
+  state: ViewTablePagingState,
+  event: SqlExecutionEvent,
+  requestSequence: number,
+): ViewTablePagingTransition {
+  if (state.requestSequence !== requestSequence || !isResultEvent(event.eventType)) {
+    return { state };
+  }
+
+  const eventResult = processResultDataList([event.message], state.params)[0];
+  if (!eventResult) {
+    return { state };
+  }
+
+  const result = mergeResultEvent(state.result, eventResult, event.eventType);
+  const nextState = { ...state, result };
+  return {
+    state: nextState,
+    completedResult: event.eventType === 'resultFinished' ? result : undefined,
+  };
+}
+
+export function replaceViewTableResult(
+  current: IManageResultData[] | undefined,
+  pagedResult: IManageResultData,
+) {
+  return [
+    {
+      ...pagedResult,
+      uuid: current?.[0]?.uuid || pagedResult.uuid,
+    },
+  ];
+}

--- a/chat2db-community-client/src/hooks/viewTablePagingModel.ts
+++ b/chat2db-community-client/src/hooks/viewTablePagingModel.ts
@@ -48,6 +48,13 @@ export function createViewTablePagingState(requestSequence: number, params: IExe
   return { requestSequence, params } satisfies ViewTablePagingState;
 }
 
+export function normalizeViewTablePageResults(
+  results: IManageResultData[],
+  params: IExecuteSqlParams,
+) {
+  return processResultDataList(results, params);
+}
+
 export function reduceViewTablePagingEvent(
   state: ViewTablePagingState,
   event: SqlExecutionEvent,
@@ -57,7 +64,7 @@ export function reduceViewTablePagingEvent(
     return { state };
   }
 
-  const eventResult = processResultDataList([event.message], state.params)[0];
+  const eventResult = normalizeViewTablePageResults([event.message], state.params)[0];
   if (!eventResult) {
     return { state };
   }

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
@@ -1020,16 +1020,9 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
   };
 
   const handleResultPagingChange = useCallback(
-    (resultData: IManageResultData, paging: { pageNo: number; pageSize: number }) => {
-      resultPageSizeRef.current = paging.pageSize;
-      if (!resultData.executeSqlParams) {
-        return;
-      }
-      return handleExecuteSQL({
-        ...resultData.executeSqlParams,
-        ...paging,
-        sql: resultData.originalSql || resultData.executeSqlParams.sql,
-      });
+    (_resultData: IManageResultData, executeSqlParams: IExecuteSqlParams) => {
+      resultPageSizeRef.current = executeSqlParams.pageSize;
+      return handleExecuteSQL(executeSqlParams);
     },
     [handleExecuteSQL],
   );

--- a/chat2db-community-client/src/utils/database.ts
+++ b/chat2db-community-client/src/utils/database.ts
@@ -1,9 +1,8 @@
 import { DatabaseTypeCode, NoSQLDataBaseType } from '@/constants/common';
 import { SqlTypeEnum } from '@/typings/sqlParser';
 import { TreeNodeType } from '@/constants';
-import { v4 as uuidv4 } from 'uuid';
-import { IManageResultData, IExecuteSqlParams } from '@/typings';
 import { getDatabaseSupport as getDatabaseJudgmentSupport, quoteOpenTableIdentifier } from './databaseJudgments';
+export { processResultDataList } from './resultData';
 
 /**
  * Compatible with processing database names
@@ -72,24 +71,4 @@ export const resultAndTreeNodeMap = (sqlType: SqlTypeEnum, databaseType: Databas
       break;
   }
   return treeNodeType;
-};
-
-// Perform initial processing on the execution results given by the backend. Add uuid and execution parameters
-export const processResultDataList = (
-  res: IManageResultData[],
-  executeSqlParams: Omit<IExecuteSqlParams, 'sql'> & { sql?: string },
-) => {
-  return res.map((item) => {
-    return {
-      ...item,
-      uuid: uuidv4(),
-      executeSqlParams: {
-        ...executeSqlParams,
-        // Remove single-line execution and error continuation parameters
-        single: undefined,
-        resultSetId: item.resultSetId,
-        sql: item.originalSql,
-      },
-    };
-  });
 };

--- a/chat2db-community-client/src/utils/monaco.test.ts
+++ b/chat2db-community-client/src/utils/monaco.test.ts
@@ -51,6 +51,19 @@ const run = async () => {
   assert.equal(enterCount, 1, 'Enter executes even when Monaco has no suggest controller');
   assert.equal(preventDefaultCount, 1);
 
+  shortcutController.deactivate();
+  let latestCallbackCount = 0;
+  let latestCallback = () => undefined;
+  const latestCallbackController = createSingleFileShortcutController(target, () => latestCallback());
+  latestCallbackController.activate({ getContribution: () => null });
+  latestCallback = () => {
+    latestCallbackCount += 1;
+  };
+  dispatchEnter();
+  assert.equal(latestCallbackCount, 1, 'an active editor uses the latest Enter callback without refocusing');
+  latestCallbackController.dispose();
+  shortcutController.activate({ getContribution: () => null });
+
   const visibleSuggestEditor: SuggestEditor = {
     getContribution: () => ({ _widget: { suggestWidgetVisible: { get: () => true } } }),
   };

--- a/chat2db-community-client/src/utils/monaco.test.ts
+++ b/chat2db-community-client/src/utils/monaco.test.ts
@@ -1,11 +1,72 @@
 import assert from 'node:assert/strict';
 import { isMonacoCancellationError, runMonacoDisposalSafely } from './monaco';
+import {
+  createSingleFileShortcutController,
+  isSuggestWidgetVisible,
+  type SuggestEditor,
+} from '@/components/SingleFileMonacoEditor/shortcut';
 
 const run = async () => {
   assert.equal(isMonacoCancellationError('Canceled'), true);
   assert.equal(isMonacoCancellationError({ name: 'Canceled', message: 'Canceled' }), true);
   assert.equal(isMonacoCancellationError(new Error('Canceled')), true);
   assert.equal(isMonacoCancellationError(new Error('boom')), false);
+  assert.equal(isSuggestWidgetVisible(null), false);
+  assert.equal(isSuggestWidgetVisible({ getContribution: () => null }), false);
+  assert.equal(
+    isSuggestWidgetVisible({
+      getContribution: () => ({ _widget: { suggestWidgetVisible: { get: () => true } } }),
+    }),
+    true,
+  );
+
+  const keydownListeners = new Set<(event: KeyboardEvent) => void>();
+  const target = {
+    addEventListener: (_type: 'keydown', listener: (event: KeyboardEvent) => void) => {
+      keydownListeners.add(listener);
+    },
+    removeEventListener: (_type: 'keydown', listener: (event: KeyboardEvent) => void) => {
+      keydownListeners.delete(listener);
+    },
+  };
+  let enterCount = 0;
+  let preventDefaultCount = 0;
+  const shortcutController = createSingleFileShortcutController(target, () => {
+    enterCount += 1;
+  });
+  const dispatchEnter = () => {
+    const event = {
+      key: 'Enter',
+      preventDefault: () => {
+        preventDefaultCount += 1;
+      },
+    } as KeyboardEvent;
+    keydownListeners.forEach((listener) => listener(event));
+  };
+
+  shortcutController.activate({ getContribution: () => null });
+  shortcutController.activate({ getContribution: () => null });
+  assert.equal(keydownListeners.size, 1, 'repeated focus does not register duplicate keydown listeners');
+  dispatchEnter();
+  assert.equal(enterCount, 1, 'Enter executes even when Monaco has no suggest controller');
+  assert.equal(preventDefaultCount, 1);
+
+  const visibleSuggestEditor: SuggestEditor = {
+    getContribution: () => ({ _widget: { suggestWidgetVisible: { get: () => true } } }),
+  };
+  shortcutController.activate(visibleSuggestEditor);
+  dispatchEnter();
+  assert.equal(enterCount, 1, 'Enter is reserved for an open suggestion widget');
+
+  shortcutController.deactivate();
+  assert.equal(keydownListeners.size, 0, 'blur removes the keydown listener');
+  dispatchEnter();
+  assert.equal(enterCount, 1);
+
+  shortcutController.activate({ getContribution: () => null });
+  shortcutController.dispose();
+  shortcutController.dispose();
+  assert.equal(keydownListeners.size, 0, 'unmount cleanup is idempotent');
 
   let synchronousCleanupRan = false;
   runMonacoDisposalSafely(() => {

--- a/chat2db-community-client/src/utils/resultData.ts
+++ b/chat2db-community-client/src/utils/resultData.ts
@@ -1,0 +1,22 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { IExecuteSqlParams, IManageResultData } from '@/typings';
+
+export function processResultDataList(
+  results: IManageResultData[],
+  executeSqlParams: Omit<IExecuteSqlParams, 'sql'> & { sql?: string },
+) {
+  return results.map((item) => {
+    const originalSql = item.originalSql || item.sql || executeSqlParams.sql || '';
+    return {
+      ...item,
+      originalSql,
+      uuid: uuidv4(),
+      executeSqlParams: {
+        ...executeSqlParams,
+        single: undefined,
+        resultSetId: item.resultSetId,
+        sql: originalSql,
+      },
+    };
+  });
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Keep the initial table browse on `/api/rdb/dml/execute_table`, then run subsequent pagination, page-size, WHERE, and ORDER BY queries through the normal SQL execution contract. Community Desktop uses the structured JCEF `sql-execute` stream; Web retains the completed-response `/api/rdb/dml/execute` path.

Buffer desktop row chunks outside React state and publish only on `resultFinished`, reject stale/cancelled requests, and preserve the result UUID so the WHERE/ORDER BY Monaco editors stay mounted. Normalize missing base SQL, harden the single-file Monaco shortcut lifecycle, and share the established result-loading overlay.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn install --frozen-lockfile` passed; no lockfile change.
  - `yarn lint:eslint` passed.
  - `yarn test:result-pagination` passed 9/9, including the initial-response-to-filtered-50,000-row-stream flow, stale events, cancellation, SQL fallback, UUID retention, and ordinary SQL paging.
  - `yarn test:monaco-lifecycle` passed focus, duplicate registration, missing suggestion controller, blur, and unmount cleanup coverage.
  - `yarn test:sql-execution-stream`, `yarn test:sql-execution-request-tracker`, `yarn test:result-set-ui` (35/35), and `yarn test:search-result-query-composer` passed.
  - `yarn build:web:community --app_version=0.0.0` passed the complete Community prebuild suite, Webpack production build, and bundle verification.
  - `git diff --check` passed.
- Manual verification: Earlier local Community JCEF iterations exercised MySQL table browsing at 50,000 and 100,000 rows. The final terminal-only publication and Monaco lifecycle hardening have not had a fresh browser-click regression.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No contract or storage change; existing `/execute_table`, `/execute`, and `sql-execute` contracts are reused.
- Database or driver compatibility: WHERE/ORDER BY SQL remains dialect-owned; automated relational and MongoDB composition tests pass.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Community frontend only. Enterprise consumers receive it only when their pinned Community source advances.
- Backward compatibility: Initial table loading is unchanged. Subsequent Web table paging now uses `/execute`; Desktop uses the existing structured stream.

## Reviewer map

- Start here: `chat2db-community-client/src/hooks/viewTablePagingModel.ts` and `src/blocks/SearchResult/components/ResultSet/viewTablePagingFlow.test.ts`.
- Failure condition: partial/stale rows replace the visible grid, WHERE/ORDER BY loses the base SQL, cancellation publishes partial data, or the single-line Monaco editor crashes/remounts during paging.
- Rollback or disable path: Revert commit `f2c360a31`.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex traced the table-browse and JCEF streaming paths, implemented the isolated state model and lifecycle hardening, and added the reported automated coverage.