### PR TITLE
fix(client): gate workspace initialization and task polling

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -86,7 +86,7 @@
     "test:tree-node-lookup": "tsx src/utils/treeNodeLookup.test.ts",
     "test:data-source-watermark": "tsx src/utils/dataSourceWatermark.test.ts",
     "test:terminal": "tsx src/constants/terminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendNav/quickTerminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/terminalTabPlacement.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/terminalAttachmentLifecycle.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabSelection.test.ts",
-    "test:task-center": "tsx src/store/importExport/taskCenterUtils.test.ts",
+    "test:task-center": "tsx src/store/importExport/taskCenterUtils.test.ts && tsx src/layouts/init/taskCenterPolling.test.ts",
     "test:workspace-tab-drag": "tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabDrop.test.ts",
     "test:verification-code-countdown": "tsx src/utils/verificationCodeCountdown.test.ts && tsx src/utils/latestRequest.test.ts",
     "modify:package:name": "node ./scripts/modify-package-name.js",

--- a/chat2db-community-client/src/client-runtime/index.ts
+++ b/chat2db-community-client/src/client-runtime/index.ts
@@ -20,6 +20,7 @@ export interface ClientRuntime {
   showUpgradeEntry: boolean;
   showDownloadEntry: boolean;
   enableAutoUpdate: boolean;
+  enableTaskCenterAutoPolling: boolean;
   showMcpSetting: boolean;
   showNetworkProxySetting: boolean;
   showLicenseSetting: boolean;
@@ -76,6 +77,7 @@ export const clientRuntime: ClientRuntime = {
   showUpgradeEntry: false,
   showDownloadEntry: false,
   enableAutoUpdate: false,
+  enableTaskCenterAutoPolling: true,
   showMcpSetting: isDesktop,
   showNetworkProxySetting: isDesktop,
   showLicenseSetting: false,

--- a/chat2db-community-client/src/layouts/init/init.tsx
+++ b/chat2db-community-client/src/layouts/init/init.tsx
@@ -17,6 +17,7 @@ import {
   storageItem,
 } from '@/components/ConnectionEdit/config/dataSource';
 import { isDesktop } from '@/utils/env';
+import clientRuntime from '@client-runtime';
 import { initializeDevEnvironmentIcon } from '@/utils/initLocalIcon';
 import queryString from 'query-string';
 import { useEffect, useLayoutEffect } from 'react';
@@ -30,6 +31,7 @@ import useJcef from './useJcef';
 import useOpenFile from './useOpenFile';
 import useApplicationExit from './useApplicationExit';
 import useTaskCenter from './useTaskCenter';
+import { shouldAutoPollTaskCenter } from './taskCenterPolling';
 
 const useInit = () => {
   const { reload } = queryString.parse(location.search);
@@ -67,7 +69,13 @@ const useInit = () => {
   useOpenFile();
   useJavaMessageReceiver();
   useApplicationExit();
-  useTaskCenter(!isDesktop || serviceStatus === ServiceStatus.SUCCESS);
+  useTaskCenter(
+    shouldAutoPollTaskCenter({
+      enabled: clientRuntime.enableTaskCenterAutoPolling,
+      desktop: isDesktop,
+      serviceReady: serviceStatus === ServiceStatus.SUCCESS,
+    }),
+  );
 
   // Check service status
   const checkServiceStatus = () => {

--- a/chat2db-community-client/src/layouts/init/init.tsx
+++ b/chat2db-community-client/src/layouts/init/init.tsx
@@ -4,18 +4,8 @@ import useDocumentListener from '@/hooks/useDocumentListener';
 import useCopyFocusData from '@/hooks/useFocusData';
 import useJavaMessageReceiver from '@/jcef/useProcessJavaPush';
 import miscServices from '@/service/misc';
-import supportedDatabaseService from '@/service/supportedDatabase';
 import { useGlobalStore } from '@/store/global';
 import { clearOlderLocalStorage } from '@/utils';
-import { buildIconSprite, registerDynamicDatabases } from '@/utils/dynamicDatabaseRegistry';
-import { databaseMap, databaseTypeList } from '@/constants/database';
-import {
-  dataSourceFormConfigs,
-  envItem,
-  portItem,
-  sshConfig,
-  storageItem,
-} from '@/components/ConnectionEdit/config/dataSource';
 import { isDesktop } from '@/utils/env';
 import clientRuntime from '@client-runtime';
 import { initializeDevEnvironmentIcon } from '@/utils/initLocalIcon';
@@ -99,28 +89,6 @@ const useInit = () => {
     registerMessage();
     registerNotification();
     initializeMonacoEditor();
-    // Surface backend configuration-only databases without a client rebuild.
-    supportedDatabaseService
-      .listSupported({})
-      .then((summaries) => {
-        const added = registerDynamicDatabases(
-          summaries,
-          { databaseMap, databaseTypeList, dataSourceFormConfigs },
-          { envItem, storageItem, portItem, sshConfig },
-        );
-        if (added.length) {
-          const sprite = buildIconSprite((summaries || []).filter((s) => added.includes(s.dbType)));
-          if (sprite && !document.getElementById('c2d-dynamic-db-icons')) {
-            const host = document.createElement('div');
-            host.id = 'c2d-dynamic-db-icons';
-            host.innerHTML = sprite;
-            document.body.appendChild(host);
-          }
-        }
-      })
-      .catch(() => {
-        // Older backends without the endpoint keep the built-in list.
-      });
   }, [serviceStatus, reload, isDesktop]);
 };
 

--- a/chat2db-community-client/src/layouts/init/taskCenterPolling.test.ts
+++ b/chat2db-community-client/src/layouts/init/taskCenterPolling.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+
+import { shouldAutoPollTaskCenter } from './taskCenterPolling';
+
+assert.equal(shouldAutoPollTaskCenter({ enabled: false, desktop: false, serviceReady: true }), false);
+assert.equal(shouldAutoPollTaskCenter({ enabled: false, desktop: true, serviceReady: true }), false);
+assert.equal(shouldAutoPollTaskCenter({ enabled: true, desktop: true, serviceReady: false }), false);
+assert.equal(shouldAutoPollTaskCenter({ enabled: true, desktop: true, serviceReady: true }), true);
+assert.equal(shouldAutoPollTaskCenter({ enabled: true, desktop: false, serviceReady: false }), true);
+
+console.log('task center polling policy tests passed');

--- a/chat2db-community-client/src/layouts/init/taskCenterPolling.ts
+++ b/chat2db-community-client/src/layouts/init/taskCenterPolling.ts
@@ -1,0 +1,8 @@
+interface TaskCenterPollingOptions {
+  enabled: boolean;
+  desktop: boolean;
+  serviceReady: boolean;
+}
+
+export const shouldAutoPollTaskCenter = ({ enabled, desktop, serviceReady }: TaskCenterPollingOptions): boolean =>
+  enabled && (!desktop || serviceReady);

--- a/chat2db-community-client/src/layouts/init/useGlobalData.tsx
+++ b/chat2db-community-client/src/layouts/init/useGlobalData.tsx
@@ -1,5 +1,14 @@
-// import { useAIStore } from '@/store/ai';
+import {
+  dataSourceFormConfigs,
+  envItem,
+  portItem,
+  sshConfig,
+  storageItem,
+} from '@/components/ConnectionEdit/config/dataSource';
+import { databaseMap, databaseTypeList } from '@/constants/database';
+import supportedDatabaseService from '@/service/supportedDatabase';
 import { useTreeStore } from '@/store/tree';
+import { buildIconSprite, registerDynamicDatabases } from '@/utils/dynamicDatabaseRegistry';
 
 const useGlobalData = () => {
   // const { getModelList } = useAIStore((state) => ({
@@ -11,7 +20,29 @@ const useGlobalData = () => {
   }));
 
   return () => {
-    // getModelList();
+    // Business metadata must not load before the host product grants workspace access.
+    supportedDatabaseService
+      .listSupported({})
+      .then((summaries) => {
+        const added = registerDynamicDatabases(
+          summaries,
+          { databaseMap, databaseTypeList, dataSourceFormConfigs },
+          { envItem, storageItem, portItem, sshConfig },
+        );
+        if (!added.length) {
+          return;
+        }
+        const sprite = buildIconSprite((summaries || []).filter((summary) => added.includes(summary.dbType)));
+        if (sprite && !document.getElementById('c2d-dynamic-db-icons')) {
+          const host = document.createElement('div');
+          host.id = 'c2d-dynamic-db-icons';
+          host.innerHTML = sprite;
+          document.body.appendChild(host);
+        }
+      })
+      .catch(() => {
+        // Older backends without the endpoint keep the built-in list.
+      });
     getTreeData();
   };
 };

--- a/chat2db-community-client/src/store/importExport/index.ts
+++ b/chat2db-community-client/src/store/importExport/index.ts
@@ -12,6 +12,7 @@ import {
   loadMissingTrackedTasks,
   mergeTasks,
   reconcileCompletedTaskNotifications,
+  shouldRetryTaskPolling,
   TASK_CENTER_PAGE_SIZE,
   TaskNotificationCursor,
   TaskStatusById,
@@ -149,9 +150,12 @@ export const createImportExportAction: StateCreator<
           getTaskListTimer: pollDelay === null ? null : setTimeout(() => get().getTaskList(), pollDelay),
         });
       })
-      .catch(() => {
+      .catch((error) => {
         if (requestGeneration !== taskListRequestGeneration) return;
-        set({ getTaskListTimer: setTimeout(() => get().getTaskList(), getTaskPollingDelay(0, true)!) });
+        const retryDelay = shouldRetryTaskPolling(error) ? getTaskPollingDelay(0, true) : null;
+        set({
+          getTaskListTimer: retryDelay === null ? null : setTimeout(() => get().getTaskList(), retryDelay),
+        });
       });
   },
   loadMoreTasks: () => {

--- a/chat2db-community-client/src/store/importExport/taskCenterUtils.test.ts
+++ b/chat2db-community-client/src/store/importExport/taskCenterUtils.test.ts
@@ -9,7 +9,9 @@ import {
   mergeTaskEvents,
   mergeTasks,
   reconcileCompletedTaskNotifications,
+  shouldRetryTaskPolling,
 } from './taskCenterUtils';
+import { ErrorCode } from '@/constants/request';
 
 const event = (sequence: number, message: string): ImportExportTaskEvent => ({
   eventId: sequence,
@@ -112,6 +114,15 @@ function testPollingDelay() {
   assert.equal(getTaskPollingDelay(0, true), FAILED_TASK_POLL_INTERVAL);
 }
 
+function testPollingRetryPolicy() {
+  assert.equal(shouldRetryTaskPolling(new Error('temporary failure')), true);
+  assert.equal(shouldRetryTaskPolling({ errorCode: ErrorCode.NetworkError }), true);
+  assert.equal(shouldRetryTaskPolling({ errorCode: ErrorCode.NeedLoggedIn }), false);
+  assert.equal(shouldRetryTaskPolling({ errorCode: ErrorCode.OfflineInvalidTrial }), false);
+  assert.equal(shouldRetryTaskPolling({ errorCode: ErrorCode.OfflineTrialExpired }), false);
+  assert.equal(shouldRetryTaskPolling({ errorCode: ErrorCode.OfflineLicenseExpired }), false);
+}
+
 function testCompletedTaskNotifications() {
   const historicalTask = task(1, ImportExportTaskStatus.SUCCESS, '2026-08-06T10:00:00Z', 100);
   const baseline = reconcileCompletedTaskNotifications({}, [historicalTask], false);
@@ -161,6 +172,7 @@ void testActiveTaskPagination().then(async () => {
   testTaskMerge();
   testEventMerge();
   testPollingDelay();
+  testPollingRetryPolicy();
   testCompletedTaskNotifications();
   console.log('Task center utility tests passed');
 });

--- a/chat2db-community-client/src/store/importExport/taskCenterUtils.ts
+++ b/chat2db-community-client/src/store/importExport/taskCenterUtils.ts
@@ -1,4 +1,5 @@
 import { ImportExportTaskStatus } from '@/constants/importExport';
+import { ErrorCode } from '@/constants/request';
 import { ImportExportTaskDetails, ImportExportTaskEvent } from '@/typings/importExport';
 
 export const TASK_LIST_PAGE_SIZE = 100;
@@ -19,6 +20,15 @@ const TERMINAL_TASK_STATUSES = new Set([
   ImportExportTaskStatus.SUCCESS,
   ImportExportTaskStatus.FAILED,
   ImportExportTaskStatus.CANCELLED,
+]);
+
+const NON_RETRYABLE_POLLING_ERRORS = new Set<string>([
+  ErrorCode.NeedLoggedIn,
+  ErrorCode.OfflineInvalidTrial,
+  ErrorCode.OfflineInvalidDevice,
+  ErrorCode.OfflineTrialExpired,
+  ErrorCode.OfflineLicenseExpired,
+  ErrorCode.LicenseNotSupported,
 ]);
 
 interface TaskPage {
@@ -137,4 +147,12 @@ export const mergeTaskEvents = (currentEvents: ImportExportTaskEvent[], incoming
 export const getTaskPollingDelay = (activeTaskCount: number, failed = false) => {
   if (failed) return FAILED_TASK_POLL_INTERVAL;
   return activeTaskCount > 0 ? ACTIVE_TASK_POLL_INTERVAL : null;
+};
+
+export const shouldRetryTaskPolling = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null || !('errorCode' in error)) {
+    return true;
+  }
+  const errorCode = (error as { errorCode?: unknown }).errorCode;
+  return typeof errorCode !== 'string' || !NON_RETRYABLE_POLLING_ERRORS.has(errorCode);
 };


### PR DESCRIPTION
## Related issue

Closes #2767

## Summary

- Add an explicit runtime switch for automatic task-center polling.
- Stop retrying task polling after authentication or license authorization failures while preserving retries for transient network failures.
- Move backend-supported database discovery from global application startup into workspace data initialization so host products can gate business requests until workspace access is ready.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:task-center` - passed
  - `yarn test:dynamic-database-registry` - passed
  - targeted ESLint for all changed TypeScript files with `--max-warnings=0` - passed
  - `yarn build:web:community:test --app_version=5.3.5 --print_logs=false` - passed
- Manual verification: verified Local can defer workspace business initialization until its host access state is ready; Community keeps automatic polling enabled by default.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: adds one required client runtime policy field; no API or persisted-data format changes.
- Database or driver compatibility: supported database discovery is unchanged, only deferred to workspace initialization.
- Network, privacy, or security: reduces unauthorized startup traffic and prevents retry loops on terminal authorization failures.
- Community / Local / Pro boundary: Community defaults remain unchanged; host products may explicitly disable polling and control when workspace initialization runs.
- Backward compatibility: network failures still retry; older backends without supported-database discovery continue using the built-in list.

## Reviewer map

- Start here: `chat2db-community-client/src/layouts/init/init.tsx` and `useGlobalData.tsx`
- Failure condition: workspace metadata never loads after the host invokes global data initialization, or Community task polling no longer starts after service readiness.
- Rollback or disable path: revert the two commits; Community's runtime default remains enabled independently.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with implementation, regression tests, and verification.
