### PR TITLE
fix(local): preserve offline core navigation

### DIFF
--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -70,8 +70,7 @@ function CommunityMainPage() {
   const { styles } = useStyles({});
   const { tab: settingTab } = useParams<{ tab: string }>();
 
-  const { networkAbandoned, curUser } = useUserStore((state) => ({
-    networkAbandoned: state.networkAbandoned,
+  const { curUser } = useUserStore((state) => ({
     curUser: state.curUser,
   }));
 
@@ -159,11 +158,6 @@ function CommunityMainPage() {
       nextNavConfig = nextNavConfig.filter((item) => item.key !== 'dashboard');
     }
 
-    if (networkAbandoned) {
-      const filterKeys = ['stream', 'dashboard'];
-      nextNavConfig = nextNavConfig.filter((item) => !filterKeys.includes(item.key));
-    }
-
     setNavConfig(nextNavConfig);
 
     let page = '';
@@ -217,7 +211,7 @@ function CommunityMainPage() {
       navConfigTmp: nextNavConfig,
       isFirst: true,
     });
-  }, [allNavItems, handleChangePageTab, initNavConfig, mainPageActiveTab, networkAbandoned]);
+  }, [allNavItems, handleChangePageTab, initNavConfig, mainPageActiveTab]);
 
   useEffect(() => {
     if (mainPageActiveTab === 'stream') {

--- a/chat2db-community-client/src/pages/main/navigationItems.test.ts
+++ b/chat2db-community-client/src/pages/main/navigationItems.test.ts
@@ -26,5 +26,10 @@ assert.ok(
 const communityMainPage = readFileSync('src/pages/main/CommunityMainPage.tsx', 'utf8');
 assert.match(communityMainPage, /createCoreMainNavItems/);
 assert.doesNotMatch(communityMainPage, /organization|team|upgrade|pricing/i);
+assert.doesNotMatch(
+  communityMainPage,
+  /networkAbandoned/,
+  'shared navigation must not hide local Chat or Dashboard based on commercial activation mode',
+);
 
 console.log('Main navigation item tests passed.');


### PR DESCRIPTION
## Related issue

Closes #2769

## Summary

Keep the shared Stream and Dashboard navigation entries independent of the commercial activation-mode flag. Local offline certificates still use the local Chat and Dashboard implementations; Gateway-only actions are gated in the Studio product layer.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: main-page navigation and navigation-item tests passed through the composed Studio client toolchain; Studio UI composition tests and targeted ESLint passed.
- Manual verification: compared Local online and offline-certificate navigation states from the reported screenshots.
- UI evidence: See #2769.

## Risk and compatibility

- Public API or stored data: No change.
- Database or driver compatibility: No change.
- Network, privacy, or security: Gateway authorization remains enforced by Studio; this only preserves local navigation entries.
- Community / Local / Pro boundary: Community owns local Chat and Dashboard; Studio owns activation-specific Gateway action visibility.
- Backward compatibility: Restores the 5.3.0 Local navigation behavior without changing persistence keys.

## Reviewer map

- Start here: chat2db-community-client/src/pages/main/CommunityMainPage.tsx
- Failure condition: Local offline-certificate activation still removes Stream or Dashboard from the core navigation.
- Rollback or disable path: Revert this PR; no data migration is involved.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with source tracing, implementation, and focused verification.