### PR TITLE
fix(spi): bind syntax plugins to defining classloader

### DIFF
--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/syntax/SqlSyntaxPluginRegistry.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/syntax/SqlSyntaxPluginRegistry.java
@@ -21,9 +21,10 @@ public final class SqlSyntaxPluginRegistry {
     private SqlSyntaxPluginRegistry() {
     }
 
-    private static Map<String, ISqlSyntaxPlugin> load() {
+    static Map<String, ISqlSyntaxPlugin> load() {
         Map<String, ISqlSyntaxPlugin> plugins = new HashMap<>();
-        for (ISqlSyntaxPlugin plugin : ServiceLoader.load(ISqlSyntaxPlugin.class)) {
+        ClassLoader pluginClassLoader = ISqlSyntaxPlugin.class.getClassLoader();
+        for (ISqlSyntaxPlugin plugin : ServiceLoader.load(ISqlSyntaxPlugin.class, pluginClassLoader)) {
             String key = normalize(plugin.getDatabaseType());
             if (key != null) {
                 plugins.putIfAbsent(key, plugin);

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/syntax/SqlSyntaxPluginRegistryTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/spi/syntax/SqlSyntaxPluginRegistryTest.java
@@ -3,12 +3,31 @@ package ai.chat2db.spi.syntax;
 import ai.chat2db.spi.ISqlSyntaxPlugin;
 import org.junit.jupiter.api.Test;
 
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SqlSyntaxPluginRegistryTest {
+
+    @Test
+    void loadsPluginsWithTheServiceTypeClassLoader() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader originalClassLoader = thread.getContextClassLoader();
+        try (URLClassLoader unrelatedClassLoader = new URLClassLoader(
+                new URL[0], ClassLoader.getPlatformClassLoader())) {
+            thread.setContextClassLoader(unrelatedClassLoader);
+
+            Map<String, ISqlSyntaxPlugin> plugins = SqlSyntaxPluginRegistry.load();
+
+            assertTrue(plugins.get("REGISTRY_PROBE") instanceof RegistryProbeSyntaxPlugin);
+        } finally {
+            thread.setContextClassLoader(originalClassLoader);
+        }
+    }
 
     @Test
     void findsServiceLoaderRegisteredPluginByDatabaseType() {


### PR DESCRIPTION
## Related issue

Closes #2772

## Summary

Load ISqlSyntaxPlugin providers with the ClassLoader that defined the service interface instead of the calling thread context ClassLoader. This prevents JCEF worker threads and layered desktop launchers from loading providers as incompatible duplicate types.

Add a regression test that installs an unrelated thread context ClassLoader and verifies service discovery still finds the registered probe plugin.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [x] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `mvn -f chat2db-community-server/pom.xml -pl chat2db-community-spi -am -DskipTests=false -Dmaven.test.skip=false test` - 237 tests passed across tools, domain API, and SPI; 0 failures.
- Manual verification: Reproduced the original desktop exception from runtime logs and verified the regression test uses a deliberately unrelated context ClassLoader.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No change.
- Database or driver compatibility: Bundled syntax providers are unchanged; only their discovery ClassLoader is made deterministic.
- Network, privacy, or security: No change.
- Community / Local / Pro boundary: Shared Community SPI fix applies consistently to all products.
- Backward compatibility: Existing ServiceLoader provider descriptors remain unchanged.

## Reviewer map

- Start here: `SqlSyntaxPluginRegistry.load()`.
- Failure condition: A desktop worker context ClassLoader loads a provider against a different copy of `ISqlSyntaxPlugin`.
- Rollback or disable path: Revert this PR to restore context-ClassLoader discovery.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with root-cause analysis, implementation, and regression testing.