### PR TITLE
fix(tabs): stabilize trackpad scrolling at boundaries

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -78,7 +78,7 @@
     "test:sql-completion-context": "tsx src/components/SQLEditor/core/sqlCompletionContext.test.ts && tsx src/components/SQLEditor/core/sqlCompletionRequestError.test.ts",
     "test:sql-in-clipboard": "tsx src/utils/sqlInClipboard.test.ts && tsx src/components/SQLEditor/helper/sqlInsertValueDefaults.test.ts",
     "test:console-tab-name": "tsx src/store/workspace/utils/consoleTabName.test.ts && tsx src/utils/workspaceObjectTabTitle.test.ts",
-    "test:workspace-tab-scroll": "tsx src/store/workspace/utils/workspaceTabScrollRequest.test.ts && tsx src/components/Tabs/activeTabScroll.test.ts",
+    "test:workspace-tab-scroll": "tsx src/store/workspace/utils/workspaceTabScrollRequest.test.ts && tsx src/components/Tabs/activeTabScroll.test.ts && tsx src/components/Tabs/wheelScroll.test.ts",
     "test:workspace-split-lifecycle": "tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.test.ts",
     "test:tree-title-highlight": "tsx src/blocks/NewTree/components/TitleRender/highlightSearchText.test.ts",
     "test:tree-data-update": "tsx src/store/tree/treeDataUpdate.test.ts",

--- a/chat2db-community-client/src/components/Tabs/index.tsx
+++ b/chat2db-community-client/src/components/Tabs/index.tsx
@@ -32,6 +32,7 @@ import {
   registerCloseActiveResultTabHandler,
 } from '@/service/resultTabShortcut';
 import { shouldProcessTabScrollRequest, type ProcessedTabScrollRequest } from './activeTabScroll';
+import { getTabWheelScrollAmount } from './wheelScroll';
 
 export interface ITabItem {
   prefixIcon?: string | React.ReactNode;
@@ -280,30 +281,19 @@ export default memo<IProps>((props) => {
   }, [items]);
 
   useUpdateEffect(() => {
-    const fn = (e) => {
-      if (e.deltaY) {
-        e.preventDefault();
-  // Use the mouse wheel to scroll tabs horizontally.
-        if (tabListBoxRef.current) {
-          const deltaY = Math.abs(e.deltaY);
-          let scrollAmount = 0;
-          console.log('deltaY', deltaY);
-          if (deltaY < 10) {
-            scrollAmount = e.deltaY;
-          } else if (deltaY < 30) {
-            scrollAmount = e.deltaY * 0.5;
-          } else {
-            scrollAmount = e.deltaY * 0.2;
-          }
-          tabListBoxRef.current.scrollLeft += scrollAmount;
-        }
+    const handleWheel = (event: WheelEvent) => {
+      const scrollAmount = getTabWheelScrollAmount(event.deltaX, event.deltaY);
+      if (scrollAmount === null || !tabListBoxRef.current) {
+        return;
       }
+
+      event.preventDefault();
+      tabListBoxRef.current.scrollLeft += scrollAmount;
     };
     const tabListBoxContent = tabListBoxRef.current;
-    tabListBoxContent?.removeEventListener('wheel', fn);
-    tabListBoxRef.current?.addEventListener('wheel', fn);
+    tabListBoxContent?.addEventListener('wheel', handleWheel, { passive: false });
     return () => {
-      tabListBoxContent?.removeEventListener('wheel', fn);
+      tabListBoxContent?.removeEventListener('wheel', handleWheel);
     };
   }, [internalTabs]);
 

--- a/chat2db-community-client/src/components/Tabs/wheelScroll.test.ts
+++ b/chat2db-community-client/src/components/Tabs/wheelScroll.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { getTabWheelScrollAmount } from './wheelScroll';
+
+assert.equal(
+  getTabWheelScrollAmount(40, -1),
+  null,
+  'cross-axis noise must not reverse a dominant rightward trackpad gesture',
+);
+assert.equal(
+  getTabWheelScrollAmount(-40, 1),
+  null,
+  'cross-axis noise must not reverse a dominant leftward trackpad gesture',
+);
+assert.equal(getTabWheelScrollAmount(20, 0), null, 'pure horizontal gestures use native scrolling');
+assert.equal(getTabWheelScrollAmount(5, 5), null, 'ambiguous diagonal gestures use native scrolling');
+assert.equal(getTabWheelScrollAmount(0, 8), 8, 'small mouse-wheel deltas retain their distance');
+assert.equal(getTabWheelScrollAmount(2, 20), 10, 'medium vertical deltas retain the existing scaling');
+assert.equal(getTabWheelScrollAmount(0, -100), -20, 'large vertical deltas retain their direction and scaling');
+
+console.log('Tab wheel scroll decision tests passed');

--- a/chat2db-community-client/src/components/Tabs/wheelScroll.ts
+++ b/chat2db-community-client/src/components/Tabs/wheelScroll.ts
@@ -1,0 +1,14 @@
+export function getTabWheelScrollAmount(deltaX: number, deltaY: number): number | null {
+  if (!deltaY || Math.abs(deltaX) >= Math.abs(deltaY)) {
+    return null;
+  }
+
+  const deltaMagnitude = Math.abs(deltaY);
+  if (deltaMagnitude < 10) {
+    return deltaY;
+  }
+  if (deltaMagnitude < 30) {
+    return deltaY * 0.5;
+  }
+  return deltaY * 0.2;
+}


### PR DESCRIPTION
## Related issue

Closes #2774

## Summary

- Leave horizontal-dominant trackpad wheel events to the browser's native horizontal scroller.
- Convert only vertical-dominant mouse-wheel input into horizontal tab movement while preserving the existing speed curve.
- Remove the wheel debug log and add regression coverage for mixed-axis gestures that previously reversed or jittered at the boundary.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn install --frozen-lockfile` - passed.
  - `yarn run test:workspace-tab-scroll` - passed, including the new mixed-axis regression cases.
  - `yarn run lint` - passed with zero warnings.
  - `yarn run build:web:community --app_version=0.0.0` - passed, including the Community prebuild test suite and production-bundle verification.
  - `mvn -B clean package -Dmaven.test.skip=true -Dchat2db.finalName=chat2db-community -f chat2db-community-server/pom.xml -pl chat2db-community-start -am` - passed for local runtime preparation; backend tests were explicitly skipped.
- Manual verification: Started the Community macOS JCEF development runtime from this branch with the web frontend on `127.0.0.1:8889` and backend on `127.0.0.1:10825`; the requester reproduced the original trackpad flow and confirmed the fix.
- UI evidence: N/A - manual JCEF verification was completed locally; no recording is attached to this PR.

## Risk and compatibility

- Public API or stored data: N/A - no API or persistence changes.
- Database or driver compatibility: N/A - no database-specific behavior changes.
- Network, privacy, or security: N/A - no network or data-handling changes.
- Community / Local / Pro boundary: Community frontend only; any Studio/Enterprise synchronization remains a separate workflow.
- Backward compatibility: Vertical mouse-wheel scrolling retains the existing scaling thresholds; horizontal trackpad scrolling uses native browser behavior.

## Reviewer map

- Start here: `chat2db-community-client/src/components/Tabs/wheelScroll.ts`, then the listener in `chat2db-community-client/src/components/Tabs/index.tsx`.
- Failure condition: A horizontal-dominant wheel event with small cross-axis `deltaY` changes `scrollLeft`, or vertical mouse-wheel input no longer moves an overflowing tab strip.
- Rollback or disable path: Revert commit `17bc55d6c`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex diagnosed the event-axis bug, implemented the focused fix and tests, ran the reported verification, and prepared this pull request.
