### PR TITLE
fix(desktop): share Windows chrome across editions

### DIFF
--- a/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/DesktopAppMenu.tsx
+++ b/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/DesktopAppMenu.tsx
@@ -13,7 +13,7 @@ import { openWebPage } from '@/utils/url';
 
 import { useStyles } from './style';
 
-const CommunityAppMenu = () => {
+const DesktopAppMenu = () => {
   const { styles } = useStyles();
   const appUrlConfig = useGlobalStore((state) => state.appUrlConfig);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -111,12 +111,12 @@ const CommunityAppMenu = () => {
   };
 
   return (
-    <div ref={menuRef} className={styles.communityMenuContent} onDoubleClick={stopWindowGesture}>
-      <span className={styles.communityMenuLogoSlot}>
-        <ProductLogo className={styles.communityMenuLogo} size={24} />
+    <div ref={menuRef} className={styles.desktopMenuContent} onDoubleClick={stopWindowGesture}>
+      <span className={styles.desktopMenuLogoSlot}>
+        <ProductLogo className={styles.desktopMenuLogo} size={24} />
       </span>
       {expanded ? (
-        <div className={styles.communityMenuBar}>
+        <div className={styles.desktopMenuBar}>
           <Dropdown
             destroyPopupOnHide
             menu={{ items: viewItems }}
@@ -127,7 +127,7 @@ const CommunityAppMenu = () => {
           >
             <button
               type="button"
-              className={styles.communityMenuItem}
+              className={styles.desktopMenuItem}
               onMouseEnter={() => switchOpenMenu('view')}
             >
               {i18n('common.menu.view')}
@@ -143,7 +143,7 @@ const CommunityAppMenu = () => {
           >
             <button
               type="button"
-              className={styles.communityMenuItem}
+              className={styles.desktopMenuItem}
               onMouseEnter={() => switchOpenMenu('help')}
             >
               {i18n('common.menu.help')}
@@ -164,4 +164,4 @@ const CommunityAppMenu = () => {
   );
 };
 
-export default CommunityAppMenu;
+export default DesktopAppMenu;

--- a/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/index.tsx
+++ b/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/index.tsx
@@ -7,9 +7,9 @@ import { history } from 'umi';
 import jcefApi from '@/jcef';
 import { useGlobalStore } from '@/store/global';
 import { isCommunityEnv, isDesktop } from '@/utils/env';
-import CommunityAppMenu from './CommunityAppMenu';
+import DesktopAppMenu from './DesktopAppMenu';
 import { COMMUNITY_TITLE_BAR_HEIGHT } from '@/constants/mainLayout';
-import { resolveTitleBarPlatform } from './platform';
+import { resolveTitleBarPlatform, shouldUseWindowsDesktopChrome } from './platform';
 
 interface AppBarProps {
   className?: string;
@@ -19,6 +19,8 @@ const AppBar = memo<AppBarProps>(({ className }) => {
   const { styles, cx } = useStyles();
   const appTitleBarRightComponent = useGlobalStore((state) => state.appTitleBarRightComponent);
   const { isMac, isWindows } = resolveTitleBarPlatform(window.navigator.os_type, window.navigator.userAgent);
+  const useWindowsDesktopChrome = shouldUseWindowsDesktopChrome(isWindows, isDesktop);
+  const useIntegratedTitleBar = isCommunityEnv || useWindowsDesktopChrome;
   const [isMaximized, setIsMaximized] = useState(false);
 
   const syncWindowMaximized = useCallback(() => {
@@ -29,7 +31,7 @@ const AppBar = memo<AppBarProps>(({ className }) => {
   }, []);
 
   useEffect(() => {
-    if (!isCommunityEnv || !isWindows || !isDesktop) {
+    if (!useWindowsDesktopChrome) {
       return;
     }
 
@@ -45,7 +47,7 @@ const AppBar = memo<AppBarProps>(({ className }) => {
       window.removeEventListener('resize', handleResize);
       window.clearTimeout(resizeTimer);
     };
-  }, [isWindows, syncWindowMaximized]);
+  }, [syncWindowMaximized, useWindowsDesktopChrome]);
 
   const items: MenuProps['items'] = [
     {
@@ -116,7 +118,7 @@ const AppBar = memo<AppBarProps>(({ className }) => {
     jcefApi.closeWindow();
   };
 
-  if (!isMac && !isCommunityEnv) {
+  if (!isMac && !useIntegratedTitleBar) {
     // const showLeftContainer = checkIsSharePage();
     // if (__WEBAPP__ && !isEmbedIframe && !showLeftContainer) {
     //   window._appTitleBarHeight = COMMUNITY_TITLE_BAR_HEIGHT;
@@ -140,7 +142,7 @@ const AppBar = memo<AppBarProps>(({ className }) => {
     return <></>;
   }
 
-  window._appTitleBarHeight = isCommunityEnv ? COMMUNITY_TITLE_BAR_HEIGHT : 30;
+  window._appTitleBarHeight = useIntegratedTitleBar ? COMMUNITY_TITLE_BAR_HEIGHT : 30;
 
   // When testing appBar on the web side, comment out the if else code above and open the comment code below.
   // window._appTitleBarHeight = COMMUNITY_TITLE_BAR_HEIGHT;
@@ -151,36 +153,36 @@ const AppBar = memo<AppBarProps>(({ className }) => {
         styles.appBar,
         {
           [styles.windowsAppBar]: !isMac,
-          [styles.communityAppBar]: isCommunityEnv,
+          [styles.integratedAppBar]: useIntegratedTitleBar,
         },
         className,
       )}
       onDoubleClick={handleDoubleClick}
     >
-      {isCommunityEnv && isWindows && isDesktop && (
-        <div className={styles.communityMenu}>
-          <CommunityAppMenu />
+      {useWindowsDesktopChrome && (
+        <div className={styles.desktopMenu}>
+          <DesktopAppMenu />
         </div>
       )}
       {appTitleBarRightComponent && (
         <div
           className={cx(styles.titleBarActions, {
-            [styles.windowsDesktopTitleBarActions]: isCommunityEnv && isWindows && isDesktop,
+            [styles.windowsDesktopTitleBarActions]: useWindowsDesktopChrome,
           })}
         >
           {appTitleBarRightComponent}
         </div>
       )}
-      <div className={cx(styles.logoContainer, { [styles.communityLogoContainer]: isCommunityEnv })}>
-        {!isMac && !isCommunityEnv ? (
+      <div className={cx(styles.logoContainer, { [styles.integratedLogoContainer]: useIntegratedTitleBar })}>
+        {!isMac && !useIntegratedTitleBar ? (
           <Dropdown destroyPopupOnHide menu={{ items }} trigger={['click']} className={styles.dropdown}>
             <div className={styles.appName}>Chat2DB</div>
           </Dropdown>
         ) : (
-          <div className={cx(styles.appName, { [styles.communityAppName]: isCommunityEnv })}>Chat2DB</div>
+          <div className={cx(styles.appName, { [styles.integratedAppName]: useIntegratedTitleBar })}>Chat2DB</div>
         )}
       </div>
-      {isCommunityEnv && isWindows && isDesktop && (
+      {useWindowsDesktopChrome && (
         <div className={styles.windowsActionBar} onDoubleClick={(event) => event.stopPropagation()}>
           <button
             type="button"

--- a/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/platform.test.ts
+++ b/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/platform.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 
 import { Platform } from '@/constants/os';
-import { resolveTitleBarPlatform } from './platform';
+import { resolveTitleBarPlatform, shouldUseWindowsDesktopChrome } from './platform';
 
 assert.deepEqual(resolveTitleBarPlatform(Platform.Mac, 'Windows NT 10.0'), {
   isMac: true,
@@ -19,5 +19,8 @@ assert.deepEqual(resolveTitleBarPlatform(Platform.Linux, 'Mozilla/5.0 (Macintosh
   isMac: false,
   isWindows: false,
 });
+assert.equal(shouldUseWindowsDesktopChrome(true, true), true);
+assert.equal(shouldUseWindowsDesktopChrome(true, false), false);
+assert.equal(shouldUseWindowsDesktopChrome(false, true), false);
 
 console.log('App title bar platform tests passed.');

--- a/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/platform.ts
+++ b/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/platform.ts
@@ -8,3 +8,7 @@ export function resolveTitleBarPlatform(runtimePlatform: Platform | undefined, u
     isWindows: runtimePlatform === Platform.Windows || (useBrowserPlatform && /Windows/.test(userAgent)),
   };
 }
+
+export function shouldUseWindowsDesktopChrome(isWindows: boolean, isDesktop: boolean) {
+  return isWindows && isDesktop;
+}

--- a/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/style.ts
+++ b/chat2db-community-client/src/layouts/GlobalLayout/AppTitleBar/style.ts
@@ -24,7 +24,7 @@ export const useStyles = createStyles(({ css, token }) => {
     windowsAppBar: css`
       height: 34px;
     `,
-    communityAppBar: css`
+    integratedAppBar: css`
       height: ${COMMUNITY_TITLE_BAR_HEIGHT}px;
     `,
     titleBarActions: css`
@@ -44,7 +44,7 @@ export const useStyles = createStyles(({ css, token }) => {
     windowsDesktopTitleBarActions: css`
       right: 144px;
     `,
-    communityMenu: css`
+    desktopMenu: css`
       position: absolute;
       top: 0;
       left: ${(COMMUNITY_MAIN_ACTION_BAR_WIDTH - COMMUNITY_MAIN_ACTION_BUTTON_SIZE.boxSize) / 2}px;
@@ -54,14 +54,14 @@ export const useStyles = createStyles(({ css, token }) => {
       height: 100%;
       -webkit-app-region: no-drag;
     `,
-    communityMenuContent: css`
+    desktopMenuContent: css`
       display: flex;
       align-items: center;
       gap: 2px;
       height: 100%;
       -webkit-app-region: no-drag;
     `,
-    communityMenuLogoSlot: css`
+    desktopMenuLogoSlot: css`
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -69,20 +69,20 @@ export const useStyles = createStyles(({ css, token }) => {
       height: ${COMMUNITY_MAIN_ACTION_BUTTON_SIZE.boxSize}px;
       flex-shrink: 0;
     `,
-    communityMenuLogo: css`
+    desktopMenuLogo: css`
       display: block;
       width: 20px;
       height: 20px;
       border-radius: 4px;
       object-fit: contain;
     `,
-    communityMenuBar: css`
+    desktopMenuBar: css`
       display: flex;
       align-items: center;
       gap: 2px;
       height: 100%;
     `,
-    communityMenuItem: css`
+    desktopMenuItem: css`
       display: inline-flex;
       align-items: center;
       height: 30px;
@@ -108,7 +108,7 @@ export const useStyles = createStyles(({ css, token }) => {
       padding-left: 12px;
       flex: 1;
     `,
-    communityLogoContainer: css`
+    integratedLogoContainer: css`
       position: absolute;
       inset: 0;
       padding: 0;
@@ -120,7 +120,7 @@ export const useStyles = createStyles(({ css, token }) => {
       text-align: center;
       -webkit-app-region: no-drag;
     `,
-    communityAppName: css`
+    integratedAppName: css`
       font-size: 14px;
       line-height: ${COMMUNITY_TITLE_BAR_HEIGHT}px;
       font-weight: 600;

--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
@@ -372,8 +372,8 @@ public class MainJFrame extends JFrame {
     private void setupGenericPlatformSpecifics(Image appIcon) {
         this.setTitle(appName);
         this.setIconImage(appIcon);
-        if (WindowsCommunityWindowChrome.isEnabled(OS.isWindows(), ConfigUtils.isCommunity())) {
-            WindowsCommunityWindowChrome.configureRootPane(getRootPane());
+        if (WindowsDesktopWindowChrome.isEnabled(OS.isWindows())) {
+            WindowsDesktopWindowChrome.configureRootPane(getRootPane());
         }
         applyTheme(ThemeEnum.DARK);
     }
@@ -764,9 +764,9 @@ public class MainJFrame extends JFrame {
         }
         this.browser_ = this.client_.createBrowser(indexHtmlFile, CefRendering.DEFAULT, false);
         this.browserUI_ = browser_.getUIComponent();
-        if (WindowsCommunityWindowChrome.isEnabled(OS.isWindows(), ConfigUtils.isCommunity())) {
-            WindowsCommunityWindowChrome.configureBrowserComponent(browserUI_);
-            WindowsCommunityWindowChrome.installWindowDragging(this, browserUI_);
+        if (WindowsDesktopWindowChrome.isEnabled(OS.isWindows())) {
+            WindowsDesktopWindowChrome.configureBrowserComponent(browserUI_);
+            WindowsDesktopWindowChrome.installWindowDragging(this, browserUI_);
         }
         this.browserUI_.addMouseListener(new MouseAdapter() {
             @Override

--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/WindowsDesktopWindowChrome.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/WindowsDesktopWindowChrome.java
@@ -13,17 +13,17 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.function.Function;
 
-final class WindowsCommunityWindowChrome {
+final class WindowsDesktopWindowChrome {
 
     static final int TITLE_BAR_HEIGHT = 34;
     private static final int WEB_APP_MENU_RESERVED_WIDTH = 220;
     private static final int WEB_TRAILING_ACTIONS_RESERVED_WIDTH = 320;
 
-    private WindowsCommunityWindowChrome() {
+    private WindowsDesktopWindowChrome() {
     }
 
-    static boolean isEnabled(boolean windows, boolean community) {
-        return windows && community;
+    static boolean isEnabled(boolean windows) {
+        return windows;
     }
 
     static void configureRootPane(JRootPane rootPane) {

--- a/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/WindowsDesktopWindowChromeTest.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/WindowsDesktopWindowChromeTest.java
@@ -13,20 +13,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class WindowsCommunityWindowChromeTest {
+class WindowsDesktopWindowChromeTest {
 
     @Test
-    void shouldOnlyEnableIntegratedChromeForWindowsCommunity() {
-        assertTrue(WindowsCommunityWindowChrome.isEnabled(true, true));
-        assertFalse(WindowsCommunityWindowChrome.isEnabled(true, false));
-        assertFalse(WindowsCommunityWindowChrome.isEnabled(false, true));
+    void shouldEnableIntegratedChromeForEveryWindowsDesktopProduct() {
+        assertTrue(WindowsDesktopWindowChrome.isEnabled(true));
+        assertFalse(WindowsDesktopWindowChrome.isEnabled(false));
     }
 
     @Test
     void shouldConfigureFlatLafFullWindowContent() {
         JRootPane rootPane = new JRootPane();
 
-        WindowsCommunityWindowChrome.configureRootPane(rootPane);
+        WindowsDesktopWindowChrome.configureRootPane(rootPane);
 
         assertEquals(true, rootPane.getClientProperty(FlatClientProperties.FULL_WINDOW_CONTENT));
         assertEquals(false, rootPane.getClientProperty(FlatClientProperties.TITLE_BAR_SHOW_ICON));
@@ -34,9 +33,9 @@ class WindowsCommunityWindowChromeTest {
         assertEquals(false, rootPane.getClientProperty(FlatClientProperties.TITLE_BAR_SHOW_ICONIFFY));
         assertEquals(false, rootPane.getClientProperty(FlatClientProperties.TITLE_BAR_SHOW_MAXIMIZE));
         assertEquals(false, rootPane.getClientProperty(FlatClientProperties.TITLE_BAR_SHOW_CLOSE));
-        assertEquals(34, WindowsCommunityWindowChrome.TITLE_BAR_HEIGHT);
+        assertEquals(34, WindowsDesktopWindowChrome.TITLE_BAR_HEIGHT);
         assertEquals(
-                WindowsCommunityWindowChrome.TITLE_BAR_HEIGHT,
+                WindowsDesktopWindowChrome.TITLE_BAR_HEIGHT,
                 rootPane.getClientProperty(FlatClientProperties.TITLE_BAR_HEIGHT)
         );
     }
@@ -47,7 +46,7 @@ class WindowsCommunityWindowChromeTest {
         JPanel browserComponent = new JPanel();
         browserComponent.setSize(1000, 800);
 
-        WindowsCommunityWindowChrome.configureBrowserComponent(browserComponent);
+        WindowsDesktopWindowChrome.configureBrowserComponent(browserComponent);
 
         Function<Point, Boolean> captionHitTest = (Function<Point, Boolean>) browserComponent.getClientProperty(
                 FlatClientProperties.COMPONENT_TITLE_BAR_CAPTION
@@ -59,19 +58,19 @@ class WindowsCommunityWindowChromeTest {
         assertTrue(captionHitTest.apply(new Point(679, 10)));
         assertFalse(captionHitTest.apply(new Point(680, 10)));
         assertFalse(captionHitTest.apply(new Point(900, 10)));
-        assertFalse(captionHitTest.apply(new Point(500, WindowsCommunityWindowChrome.TITLE_BAR_HEIGHT)));
+        assertFalse(captionHitTest.apply(new Point(500, WindowsDesktopWindowChrome.TITLE_BAR_HEIGHT)));
     }
 
     @Test
     void shouldIgnoreNonSwingBrowserComponents() {
-        WindowsCommunityWindowChrome.configureBrowserComponent(new java.awt.Canvas());
+        WindowsDesktopWindowChrome.configureBrowserComponent(new java.awt.Canvas());
     }
 
     @Test
     void shouldMoveWindowByThePointerDelta() {
         assertEquals(
                 new Point(130, 175),
-                WindowsCommunityWindowChrome.draggedWindowLocation(
+                WindowsDesktopWindowChrome.draggedWindowLocation(
                         new Point(100, 200),
                         new Point(400, 300),
                         new Point(430, 275)


### PR DESCRIPTION
## Related issue

Closes #2777

## Summary

Make the integrated Windows JCEF title bar a desktop capability instead of a Community-only product feature.

The shared renderer now enables the product logo/menu, title-bar workspace actions, and Web window controls for every Windows JCEF desktop edition. The shared JCEF host likewise configures FlatLaf full-window content and caption dragging for every Windows `MainJFrame`. macOS and non-Windows behavior remain unchanged.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:shortcut` — passed.
  - `yarn lint:eslint` — passed with zero warnings.
  - `mvn -pl chat2db-community-jcef -am -Dmaven.test.skip=false -DskipTests=false test` — passed 68 Community tools tests and 65 JCEF tests.
  - Studio `yarn test:composition` — passed.
  - Studio Local `yarn build:web:offline --app_version=5.3.6-beta.1 --app_port=11921` — production build, API contract, and Local composition bundle verification passed.
  - Studio Local `mvn clean package -Dmaven.test.skip=true -Dchat2db.product=local -Pversioned-thin -f chat2db-studio-server/pom.xml` — passed; staged JCEF dependency contains `WindowsDesktopWindowChrome` and not `WindowsCommunityWindowChrome`.
- Manual verification: replaced `runtime/dist`, `runtime/chat2db-studio.jar`, and `runtime/lib/chat2db-community-jcef-5.3.0.jar` in an installed Windows Local 5.3.6-beta.1 thin runtime. The integrated title bar rendered correctly, workspace actions moved to the top, the separate Swing menu row disappeared, and only one terminal launcher remained.
- UI evidence: Runtime-verified; screenshot omitted because it contains local datasource names.

## Risk and compatibility

- Public API or stored data: N/A; no API or persistence changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Windows JCEF chrome is intentionally shared across all three editions; product-resolved logos and extension slots remain unchanged.
- Backward compatibility: macOS, Linux, and non-JCEF Web behavior are unchanged. Renderer and JCEF dependency should be deployed together so the Web title bar and native frame configuration stay aligned.

## Reviewer map

- Start here: `AppTitleBar/index.tsx` for the renderer capability gate and `MainJFrame.java` / `WindowsDesktopWindowChrome.java` for the native host gate.
- Failure condition: Local or Pro on Windows still shows the Swing menu row or vertical workspace fallback, or window dragging/minimize/maximize/close no longer works.
- Rollback or disable path: revert this PR to restore the Community-only gates.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for source analysis, implementation, automated verification, and PR drafting. The Windows runtime behavior was manually verified by the maintainer.