### PR TITLE
fix(frontend): add ordered main action bar slots

### DIFF
--- a/chat2db-community-client/src/client-extension/extension.test.ts
+++ b/chat2db-community-client/src/client-extension/extension.test.ts
@@ -52,6 +52,20 @@ for (const host of ['src/blocks/Setting/index.tsx', 'src/pages/main/CommunityMai
   assert.match(readFileSync(host, 'utf8'), /clientExtension/);
 }
 
+const actionBarSource = readFileSync('src/pages/main/components/CommunityMainActionBar/index.tsx', 'utf8');
+const beforeTerminalIndex = actionBarSource.indexOf('{beforeTerminal}');
+const terminalIndex = actionBarSource.indexOf('{isDesktop &&');
+const afterTerminalIndex = actionBarSource.indexOf('{afterTerminal}');
+const settingsIndex = actionBarSource.indexOf('{!hideSettings &&');
+assert.ok(beforeTerminalIndex >= 0);
+assert.ok(beforeTerminalIndex < terminalIndex);
+assert.ok(terminalIndex < afterTerminalIndex);
+assert.ok(afterTerminalIndex < settingsIndex);
+
+const mainPageSource = readFileSync('src/pages/main/CommunityMainPage.tsx', 'utf8');
+assert.match(mainPageSource, /actionBarBeforeTerminal\s*\?\?\s*\n\s*clientExtension\.mainPage\.slots\?\.actionBarFooter/);
+assert.match(mainPageSource, /afterTerminal=\{clientExtension\.mainPage\.slots\?\.actionBarAfterTerminal\}/);
+
 const configSource = readFileSync('.umirc.ts', 'utf8');
 assert.match(configSource, /'@client-extension':/);
 assert.match(configSource, /'@client-runtime':/);

--- a/chat2db-community-client/src/client-extension/types.ts
+++ b/chat2db-community-client/src/client-extension/types.ts
@@ -22,6 +22,9 @@ export interface ClientNavigationResolutionContext {
 export type ClientMainPageCoreAction = 'settings';
 
 export interface ClientMainPageSlots {
+  actionBarBeforeTerminal?: ReactNode;
+  actionBarAfterTerminal?: ReactNode;
+  /** @deprecated Use actionBarBeforeTerminal. */
   actionBarFooter?: ReactNode;
   titleBarActions?: ReactNode;
 }

--- a/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
+++ b/chat2db-community-client/src/pages/main/CommunityMainPage.tsx
@@ -441,7 +441,11 @@ function CommunityMainPage() {
           hideSettings={
             Boolean(isEmbedIframe) || clientExtension.mainPage.hiddenCoreActions?.includes('settings') === true
           }
-          extras={clientExtension.mainPage.slots?.actionBarFooter}
+          beforeTerminal={
+            clientExtension.mainPage.slots?.actionBarBeforeTerminal ??
+            clientExtension.mainPage.slots?.actionBarFooter
+          }
+          afterTerminal={clientExtension.mainPage.slots?.actionBarAfterTerminal}
           onNavigate={handleNavItemClick}
           onOpenSettings={handleOpenSettings}
         />

--- a/chat2db-community-client/src/pages/main/components/CommunityMainActionBar/index.tsx
+++ b/chat2db-community-client/src/pages/main/components/CommunityMainActionBar/index.tsx
@@ -16,7 +16,8 @@ interface CommunityMainActionBarProps {
   activePage: string;
   settingsActive: boolean;
   hideSettings: boolean;
-  extras?: ReactNode;
+  beforeTerminal?: ReactNode;
+  afterTerminal?: ReactNode;
   onNavigate: (item: INavItem) => void;
   onOpenSettings: () => void;
 }
@@ -26,7 +27,8 @@ const CommunityMainActionBar = ({
   activePage,
   settingsActive,
   hideSettings,
-  extras,
+  beforeTerminal,
+  afterTerminal,
   onNavigate,
   onOpenSettings,
 }: CommunityMainActionBarProps) => {
@@ -38,7 +40,7 @@ const CommunityMainActionBar = ({
       onNavigate(workspaceItem);
     }
   };
-  const showBottomActions = Boolean(extras) || isDesktop || !hideSettings;
+  const showBottomActions = Boolean(beforeTerminal) || isDesktop || Boolean(afterTerminal) || !hideSettings;
 
   return (
     <aside className={styles.actionBar}>
@@ -59,7 +61,7 @@ const CommunityMainActionBar = ({
 
       {showBottomActions && (
         <div className={styles.bottomActions}>
-          {extras}
+          {beforeTerminal}
           {isDesktop && (
             <QuickTerminalButton
               size={COMMUNITY_MAIN_ACTION_BUTTON_SIZE}
@@ -67,6 +69,7 @@ const CommunityMainActionBar = ({
               onBeforeCreate={handleBeforeCreateTerminal}
             />
           )}
+          {afterTerminal}
           {!hideSettings && (
             <IconButton
               type="primary"


### PR DESCRIPTION
## Related issue

Closes #2780

## Summary

- Add explicit main-action-bar slots before and after the Community terminal anchor.
- Preserve the legacy actionBarFooter behavior as a before-terminal fallback.
- Keep Community responsible for core action anchors while allowing product compositions to choose their relative placement.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - yarn test:main-page-navigation: passed
  - yarn eslint src/client-extension/types.ts src/client-extension/extension.test.ts src/pages/main/CommunityMainPage.tsx src/pages/main/components/CommunityMainActionBar/index.tsx --max-warnings=0: passed
  - yarn build:web:community:test --app_version=5.3.5: passed
- Manual verification: source ordering is locked as before-terminal, terminal, after-terminal, settings.
- UI evidence: installed Pro screenshot reproduced the avatar-above-terminal ordering; post-merge Studio replacement acceptance remains pending.

## Risk and compatibility

- Public API or stored data: frontend extension type only; no HTTP or storage change.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Community exposes neutral anchors; commercial content remains outside Community.
- Backward compatibility: actionBarFooter remains supported with its existing before-terminal position.

## Reviewer map

- Start here: chat2db-community-client/src/client-extension/types.ts and CommunityMainActionBar/index.tsx.
- Failure condition: legacy actionBarFooter moves position, or before/after slots render on the wrong side of the terminal.
- Rollback or disable path: revert this PR; the legacy footer contract remains unchanged by consumers until they opt into a new slot.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex traced the shared/commercial composition boundary, implemented the slot contract, and added the source-order regression checks under maintainer direction.
