### PR TITLE
fix(jcef): support request-scoped headers

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -25,6 +25,7 @@
     "lint:style": "stylelint \"src/**/*.{css,less}\" --max-warnings=0",
     "test:i18n": "node ./scripts/validate-i18n.cjs",
     "test:community-boundary": "node ./scripts/verify-community-boundary.cjs",
+    "test:command-line-headers": "tsx src/service/commandLine/commandLineHeaders.test.ts",
     "test:retired-ai": "tsx src/blocks/AI/retiredAiSurface.test.ts && tsx src/blocks/AI/components/AIChatInput/mentionSelection.test.ts && tsx src/blocks/AI/knowledgeSelection.test.ts",
     "test:hot-update": "tsx src/store/global/slices/hotUpdate/action.test.ts",
     "test:result-pagination": "tsx src/blocks/SearchResult/components/ResultSet/pagination.test.ts",

--- a/chat2db-community-client/src/service/base.tsx
+++ b/chat2db-community-client/src/service/base.tsx
@@ -79,6 +79,7 @@ export default function createRequest<P = void, R = void>(url: string, options?:
     params: P,
     restParams?: {
       signal: AbortSignal | DesktopRequestOptions['signal'] | null;
+      headers?: Record<string, string>;
     },
   ) {
     const paramsInUrl: string[] = [];
@@ -140,14 +141,16 @@ export default function createRequest<P = void, R = void>(url: string, options?:
           eventualUrl = params as string;
         }
 
+        const { headers: restHeaders, ...requestRestParams } = restParams || {};
         const requestOptions: any = {
           credentials: 'include', // Whether to bring cookies with the default request
           headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',
+            ...restHeaders,
           },
           [dataName]: params,
-          ...restParams,
+          ...requestRestParams,
         };
 
         if (contentType === 'formData') {

--- a/chat2db-community-client/src/service/commandLine/commandLine.ts
+++ b/chat2db-community-client/src/service/commandLine/commandLine.ts
@@ -5,15 +5,18 @@ import { ErrorCodesWithoutToast } from '@/constants/request';
 import interceptorsResponse from '@/service/interceptorsResponse';
 import { IErrorLevel, PermissionError } from '@/service/base';
 import { staticMessage } from '@chat2db/ui';
+import { buildCommandLineParams } from './commandLineHeaders';
 
 export interface ICommandLineRequest {
   requestUrl: string;
   method: string;
   message: any;
+  headers?: Record<string, string>;
 }
 
 export interface ICommandLineParams extends ICommandLineRequest {
   uuid: string;
+  actionType: string;
 }
 
 export interface DesktopAbortControllerSignalParams {
@@ -23,6 +26,7 @@ export interface DesktopAbortControllerSignalParams {
 
 export interface DesktopRequestOptions {
   signal: (params: DesktopAbortControllerSignalParams) => void;
+  headers?: Record<string, string>;
 }
 
 export interface IOptions {
@@ -54,15 +58,18 @@ export const commandLineRequest = <R>(data: ICommandLineRequest, options: IOptio
   const language = useGlobalStore.getState().baseSetting.language;
   const id = uuidv4();
 
-  const commandLineParams = {
-    actionType: 'execute',
-    headers: {
-      'Accept-Language': language,
-      'Time-Zone': new Intl.DateTimeFormat().resolvedOptions().timeZone,
+  const commandLineParams = buildCommandLineParams(
+    {
+      ...data,
+      headers: {
+        ...data.headers,
+        ...options?.restParams?.headers,
+      },
     },
-    uuid: id,
-    ...data,
-  };
+    id,
+    language,
+    new Intl.DateTimeFormat().resolvedOptions().timeZone,
+  );
   return new Promise<R>((resolve, reject) => {
     const res = JSON.parse(
       JSON.stringify(commandLineParams, (key, value) => {

--- a/chat2db-community-client/src/service/commandLine/commandLineHeaders.test.ts
+++ b/chat2db-community-client/src/service/commandLine/commandLineHeaders.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { buildCommandLineParams } from './commandLineHeaders';
+
+const request = buildCommandLineParams(
+  {
+    requestUrl: '/api/order/list',
+    method: 'get',
+    message: undefined,
+    headers: {
+      'Chat2db-Organization-Id': '42',
+      'Chat2db-Organization-Token': 'personal-token',
+    },
+  },
+  'request-id',
+  'zh-CN',
+  'Asia/Shanghai',
+);
+
+assert.deepEqual(request.headers, {
+  'Accept-Language': 'zh-CN',
+  'Time-Zone': 'Asia/Shanghai',
+  'Chat2db-Organization-Id': '42',
+  'Chat2db-Organization-Token': 'personal-token',
+});
+assert.equal(request.uuid, 'request-id');
+assert.equal(request.requestUrl, '/api/order/list');
+
+console.log('command line request header tests passed');

--- a/chat2db-community-client/src/service/commandLine/commandLineHeaders.test.ts
+++ b/chat2db-community-client/src/service/commandLine/commandLineHeaders.test.ts
@@ -7,6 +7,8 @@ const request = buildCommandLineParams(
     method: 'get',
     message: undefined,
     headers: {
+      'Accept-Language': 'overridden-language',
+      'Time-Zone': 'overridden-time-zone',
       'Chat2db-Organization-Id': '42',
       'Chat2db-Organization-Token': 'personal-token',
     },

--- a/chat2db-community-client/src/service/commandLine/commandLineHeaders.ts
+++ b/chat2db-community-client/src/service/commandLine/commandLineHeaders.ts
@@ -15,8 +15,8 @@ export const buildCommandLineParams = (
   uuid: id,
   ...data,
   headers: {
+    ...data.headers,
     'Accept-Language': language,
     'Time-Zone': timeZone,
-    ...data.headers,
   },
 });

--- a/chat2db-community-client/src/service/commandLine/commandLineHeaders.ts
+++ b/chat2db-community-client/src/service/commandLine/commandLineHeaders.ts
@@ -1,0 +1,22 @@
+interface CommandLineRequest {
+  requestUrl: string;
+  method: string;
+  message: any;
+  headers?: Record<string, string>;
+}
+
+export const buildCommandLineParams = (
+  data: CommandLineRequest,
+  id: string,
+  language: string,
+  timeZone: string,
+) => ({
+  actionType: 'execute',
+  uuid: id,
+  ...data,
+  headers: {
+    'Accept-Language': language,
+    'Time-Zone': timeZone,
+    ...data.headers,
+  },
+});


### PR DESCRIPTION
## Related issue

Closes #2782

## Summary

Allow callers of the shared request factory to attach headers to one request. The web transport merges them with the standard JSON headers, while the JCEF transport merges them with the language and time-zone headers before sending the IPC request.

This enables commercial consumers to select a request-specific organization without changing Community product behavior or persisting application state.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `yarn test:command-line-headers` passed; affected ESLint passed; `yarn build:web:community` and its prebuild regression suite passed.
- Manual verification: Commercial desktop integration is verified in the consuming Studio repository.
- UI evidence: N/A; this PR changes the transport contract only.

## Risk and compatibility

- Public API or stored data: Adds an optional request option; no stored-data change.
- Database or driver compatibility: N/A.
- Network, privacy, or security: Request headers are scoped to the caller and merged without logging their values.
- Community / Local / Pro boundary: Community only exposes generic transport capability; organization behavior remains in Pro.
- Backward compatibility: Existing callers without headers preserve current behavior.

## Reviewer map

- Start here: `chat2db-community-client/src/service/commandLine/commandLine.ts`.
- Failure condition: caller headers replace default language/time-zone headers or persist across later requests.
- Rollback or disable path: revert this PR; existing requests do not depend on the optional field.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with implementation and regression tests; the changes were reviewed and verified locally.