### PR TITLE
fix(client): render first workspace terminal tab

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
@@ -821,6 +821,8 @@ const WorkspaceTabs = memo(() => {
     });
   }, [measurePaneContentBounds]);
 
+  // The split box does not exist in an empty workspace. Re-run when the first
+  // tab mounts even if the normalized split layout remains null.
   useLayoutEffect(() => {
     const container = splitTabBoxRef.current;
     if (!container) {
@@ -838,7 +840,12 @@ const WorkspaceTabs = memo(() => {
         paneContentMeasureFrameRef.current = undefined;
       }
     };
-  }, [measurePaneContentBounds, schedulePaneContentMeasurement, workspaceTabSplitLayout]);
+  }, [
+    measurePaneContentBounds,
+    schedulePaneContentMeasurement,
+    workspaceTabSplitLayout,
+    workspaceTabList?.length,
+  ]);
 
   // Get the currently selected data source.
   const { zoerBoundInfo } = useZoerStore((state) => {


### PR DESCRIPTION
## Related issue

Closes #2788

## Summary

Re-run workspace pane measurement when the workspace tab count changes. An empty workspace does not render the split-box ref, so the initial layout effect exits early. Opening the first terminal keeps the normalized split layout null, which previously prevented the effect from running again and left the terminal body hidden without pane bounds.

The added dependency initializes pane bounds and the resize observer when the first tab mounts. The fix is shared workspace lifecycle behavior and does not add terminal-specific or commercial product branching.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:workspace-split-lifecycle` - passed.
  - `yarn lint` - passed with zero warnings.
  - `yarn run build:web:community --app_version=0.0.0` - passed, including the configured Community prebuild test suite and production bundle verification.
  - `yarn run build:web:desktop --app_version=5.3.5` in Chat2DB Studio - passed; 212 bundled endpoints, 180 normalized paths, 354 backend owners, and the Pro composition bundle were verified.
  - `mvn clean package -f chat2db-studio-server/pom.xml -Dchat2db.product=pro -Pbridge-fat` - passed with Studio Maven tests.
- Manual verification: Replaced the Pro 5.3.0 desktop jar and dist with the rebuilt Pro 5.3.5 bridge-fat artifacts on macOS 27.0. Opening the integrated terminal as the first workspace tab displayed the shell prompt and cursor successfully.
- UI evidence: Before the change the first terminal tab had a blank body; after the replacement build the shell prompt and cursor were visible.

## Risk and compatibility

- Public API or stored data: No API, persistence, or storage changes.
- Database or driver compatibility: N/A; no database or driver code changed.
- Network, privacy, or security: No network or security behavior changed.
- Community / Local / Pro boundary: The fix stays in Community workspace layout lifecycle code. Studio/Pro consume the shared renderer without adding commercial behavior to Community.
- Backward compatibility: Existing tab and split layouts keep the same measurement behavior. Tab-count changes now recreate the observer after cleanup, covering the previously missed empty-to-first-tab transition.

## Reviewer map

- Start here: `chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx`, at the pane-content measurement `useLayoutEffect` dependency list.
- Failure condition: Starting from an empty workspace and opening the first terminal leaves `paneContentBounds` empty, so the active tab body remains hidden.
- Rollback or disable path: Revert commit `38cbb9e3aa02b56e24933b9a39ea324473283f65`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for runtime diagnosis, implementation, and verification.
