### PR TITLE
fix(client): stabilize initial workspace queries

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -78,7 +78,7 @@
     "test:local-file-tree-path": "tsx src/pages/main/workspace/components/LocalSQLFileTree/path.test.ts",
     "test:saved-console-dirty": "tsx src/utils/savedConsoleDirty.test.ts",
     "test:local-file-encoding": "tsx src/utils/localFileEncoding.test.ts && yarn test:local-file-tab-refresh && tsx src/store/workspace/utils/workspaceTabPersistence.test.ts",
-    "test:main-page-navigation": "tsx src/utils/mainPageNavigation.test.ts && tsx src/pages/main/navigationItems.test.ts && tsx src/client-extension/extension.test.ts",
+    "test:main-page-navigation": "tsx src/utils/mainPageNavigation.test.ts && tsx src/pages/main/navigationItems.test.ts && tsx src/client-extension/extension.test.ts && tsx src/layouts/init/initQueryLifecycle.test.tsx",
     "test:monaco-lifecycle": "tsx src/utils/monaco.test.ts && tsx src/components/SingleFileMonacoEditor/refAdapter.test.ts",
     "test:mcp-lifecycle": "tsx src/blocks/Setting/McpSetting/mcpLifecycle.test.ts",
     "test:sql-completion-context": "tsx src/components/SQLEditor/core/sqlCompletionContext.test.ts && tsx src/components/SQLEditor/core/sqlCompletionRequestError.test.ts",

--- a/chat2db-community-client/src/layouts/init/initQuery.ts
+++ b/chat2db-community-client/src/layouts/init/initQuery.ts
@@ -2,7 +2,8 @@ import { useGlobalStore } from '@/store/global';
 import { useOrgStore } from '@/store/workspaceContext';
 import { useUserStore } from '@/store/session';
 import { removeOpenScreenAnimation } from '@/utils/dom';
-import { useLayoutEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
+import { runInitialWorkspaceQuery, useRunOnceWhenReady } from './initQueryLifecycle';
 import useGlobalData from './useGlobalData';
 
 const useInitQuery = () => {
@@ -12,16 +13,13 @@ const useInitQuery = () => {
   const queryCurUser = useUserStore((state) => state.queryCurUser);
   const queryOrgList = useOrgStore((state) => state.queryOrgList);
 
-  useLayoutEffect(() => {
-    if (!isReady) {
-      return;
-    }
+  const initialize = useCallback(() => {
     removeOpenScreenAnimation();
-    Promise.all([queryCurUser(), queryOrgList()])
-      .then(() => getGlobalData())
-      .catch(() => undefined)
+    void runInitialWorkspaceQuery({ queryCurUser, queryOrgList, getGlobalData })
       .finally(() => setInitQueryLoaded(true));
-  }, [getGlobalData, isReady, queryCurUser, queryOrgList]);
+  }, [getGlobalData, queryCurUser, queryOrgList]);
+
+  useRunOnceWhenReady(isReady, initialize);
 
   return { initQueryLoaded };
 };

--- a/chat2db-community-client/src/layouts/init/initQueryLifecycle.test.tsx
+++ b/chat2db-community-client/src/layouts/init/initQueryLifecycle.test.tsx
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { act, StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { runInitialWorkspaceQuery, useRunOnceWhenReady } from './initQueryLifecycle';
+
+const dom = new JSDOM('<div id="root"></div>');
+Object.defineProperties(globalThis, {
+  window: { configurable: true, value: dom.window },
+  document: { configurable: true, value: dom.window.document },
+  navigator: { configurable: true, value: dom.window.navigator },
+  IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+});
+
+const main = async () => {
+  let runCount = 0;
+  const Probe = ({ ready, renderToken }: { ready: boolean; renderToken: number }) => {
+    useRunOnceWhenReady(ready, () => {
+      runCount += 1;
+      void renderToken;
+    });
+    return null;
+  };
+
+  const container = document.getElementById('root');
+  assert.ok(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <StrictMode>
+        <Probe ready={false} renderToken={0} />
+      </StrictMode>,
+    );
+  });
+  assert.equal(runCount, 0, 'initialization must wait for app configuration');
+
+  await act(async () => {
+    root.render(
+      <StrictMode>
+        <Probe ready renderToken={0} />
+      </StrictMode>,
+    );
+  });
+  assert.equal(runCount, 1, 'StrictMode effect replay must still initialize once');
+
+  await act(async () => {
+    root.render(
+      <StrictMode>
+        <Probe ready renderToken={1} />
+      </StrictMode>,
+    );
+  });
+  assert.equal(runCount, 1, 'unrelated rerenders must not repeat initialization');
+
+  await act(async () => root.unmount());
+
+  const successfulCalls: string[] = [];
+  await runInitialWorkspaceQuery({
+    queryCurUser: async () => {
+      successfulCalls.push('user');
+    },
+    queryOrgList: async () => {
+      successfulCalls.push('org');
+    },
+    getGlobalData: () => successfulCalls.push('global'),
+  });
+  assert.deepEqual(successfulCalls, ['user', 'org', 'global']);
+
+  let globalDataCalls = 0;
+  await runInitialWorkspaceQuery({
+    queryCurUser: async () => {
+      throw new Error('identity unavailable');
+    },
+    queryOrgList: async () => undefined,
+    getGlobalData: () => {
+      globalDataCalls += 1;
+    },
+  });
+  assert.equal(globalDataCalls, 0, 'failed identity or organization queries must remain fail-open without partial load');
+
+  console.log('Init query lifecycle tests passed.');
+};
+
+void main();

--- a/chat2db-community-client/src/layouts/init/initQueryLifecycle.ts
+++ b/chat2db-community-client/src/layouts/init/initQueryLifecycle.ts
@@ -1,0 +1,32 @@
+import { useLayoutEffect, useRef } from 'react';
+
+interface InitialWorkspaceQuery {
+  queryCurUser: () => Promise<unknown>;
+  queryOrgList: () => Promise<unknown>;
+  getGlobalData: () => void;
+}
+
+export const runInitialWorkspaceQuery = async ({
+  queryCurUser,
+  queryOrgList,
+  getGlobalData,
+}: InitialWorkspaceQuery): Promise<void> => {
+  try {
+    await Promise.all([queryCurUser(), queryOrgList()]);
+    getGlobalData();
+  } catch {
+    // Initialization is fail-open so the application can render its recovery UI.
+  }
+};
+
+export const useRunOnceWhenReady = (isReady: boolean, run: () => void): void => {
+  const initializationStartedRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (!isReady || initializationStartedRef.current) {
+      return;
+    }
+    initializationStartedRef.current = true;
+    run();
+  }, [isReady, run]);
+};

--- a/chat2db-community-client/src/layouts/init/useGlobalData.tsx
+++ b/chat2db-community-client/src/layouts/init/useGlobalData.tsx
@@ -9,6 +9,7 @@ import { databaseMap, databaseTypeList } from '@/constants/database';
 import supportedDatabaseService from '@/service/supportedDatabase';
 import { useTreeStore } from '@/store/tree';
 import { buildIconSprite, registerDynamicDatabases } from '@/utils/dynamicDatabaseRegistry';
+import { useCallback } from 'react';
 
 const useGlobalData = () => {
   // const { getModelList } = useAIStore((state) => ({
@@ -19,7 +20,7 @@ const useGlobalData = () => {
     getTreeData: state.getTreeData,
   }));
 
-  return () => {
+  return useCallback(() => {
     // Business metadata must not load before the host product grants workspace access.
     supportedDatabaseService
       .listSupported({})
@@ -44,7 +45,7 @@ const useGlobalData = () => {
         // Older backends without the endpoint keep the built-in list.
       });
     getTreeData();
-  };
+  }, [getTreeData]);
 };
 
 export default useGlobalData;


### PR DESCRIPTION
Stabilizes the global-data callback and guards workspace initialization so StrictMode and unrelated rerenders cannot repeat identity, organization, database discovery, and tree requests. Adds StrictMode/rerender and success/failure lifecycle coverage.

Verification update: rebased to current main; main-page/init lifecycle tests and targeted ESLint passed. Playwright observed one supported/tree/environment initialization request per load, no repeats across workspace rerenders, and fail-open rendering without a retry loop when the tree request returned 500. Current head: `8c780e169`.
