### PR TITLE
fix(policy): enforce SQL and metadata boundaries

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbDlTemplateServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbDlTemplateServiceImpl.java
@@ -159,8 +159,12 @@ public class DbDlTemplateServiceImpl implements IDbDlTemplateService {
                 param.getDatabaseName(), connectInfo == null ? null : connectInfo.getSchemaName(),
                 param.getTableName(), sql));
         sql = executionPlan.getSql();
-        String dataBaseType = Chat2DBContext.getConnectInfo().getDbType();
-        if (DataSourceTypeEnum.MONGODB.getCode().equals(dataBaseType)) {
+        sqlExecutionPolicyManager.beforeExecute(executionPlan);
+        String dataBaseType = connectInfo.getDbType();
+        if (DataSourceTypeEnum.MONGODB.getCode().equalsIgnoreCase(dataBaseType)) {
+            if (!Objects.equals(param.getSql(), sql)) {
+                throw new IllegalStateException("SQL rewrite is not supported for MONGODB counts");
+            }
             ICommandExecutor executor = Chat2DBContext.getDbMetaData().getCommandExecutor();
             return sqlExecutionPolicyManager.limitCount(executionPlan,
                     getCountOfMongodb(param.getTableName(), executor));

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbTableServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbTableServiceImpl.java
@@ -489,23 +489,41 @@ public class DbTableServiceImpl implements IDbTableService {
     }
 
     private PageResponse<Table> pageQueryForRedis(DbTablePageQueryRequest param, TableSelector selector) {
-        Connection connection = Chat2DBContext.getConnection();
-        IDbMetaData metaData = Chat2DBContext.getDbMetaData();
-        TablesPageResponse page = metaData.tables(connection,
-                new TablesPageRequest(param.getDatabaseName(), param.getSchemaName(), param.getSearchKey(),
-                        param.getPageNo(), param.getPageSize()));
-        return filterExternalPage(param,
-                PageResponse.of(page.getData(), page.getTotal(), page.getPageNo(), page.getPageSize()));
+        return pageQueryForExternalMetadata(param);
     }
 
     private PageResponse<Table> pageQueryForMongodb(DbTablePageQueryRequest param) {
+        return pageQueryForExternalMetadata(param);
+    }
+
+    private PageResponse<Table> pageQueryForExternalMetadata(DbTablePageQueryRequest param) {
         Connection connection = Chat2DBContext.getConnection();
         IDbMetaData metaData = Chat2DBContext.getDbMetaData();
+        if (!metadataAccessPolicyManager.isEmpty()) {
+            List<Table> candidates = metaData.tables(connection,
+                    new TablesRequest(param.getDatabaseName(), param.getSchemaName(), param.getSearchKey()));
+            if (CollectionUtils.isEmpty(candidates)) {
+                return PageResponse.empty(param.getPageNo(), param.getPageSize());
+            }
+            candidates = new ArrayList<>(getQueryTables(candidates, param));
+            candidates.sort(Comparator.comparing(Table::getName, String.CASE_INSENSITIVE_ORDER));
+            return paginateVisibleTables(param, visibleTables(param, candidates));
+        }
         TablesPageResponse page = metaData.tables(connection,
                 new TablesPageRequest(param.getDatabaseName(), param.getSchemaName(), param.getSearchKey(),
                         param.getPageNo(), param.getPageSize()));
-        return filterExternalPage(param,
-                PageResponse.of(page.getData(), page.getTotal(), page.getPageNo(), page.getPageSize()));
+        return PageResponse.of(page.getData(), page.getTotal(), page.getPageNo(), page.getPageSize());
+    }
+
+    private PageResponse<Table> paginateVisibleTables(DbTablePageQueryRequest request, List<Table> visible) {
+        long total = visible.size();
+        long start = (long) (request.getPageNo() - 1) * request.getPageSize();
+        if (start >= total) {
+            return PageResponse.of(List.of(), total, request.getPageNo(), request.getPageSize());
+        }
+        int fromIndex = Math.toIntExact(start);
+        int toIndex = (int) Math.min(start + request.getPageSize(), total);
+        return PageResponse.of(visible.subList(fromIndex, toIndex), total, request.getPageNo(), request.getPageSize());
     }
 
     private List<Table> getAllTables(DbTablePageQueryRequest param) {
@@ -633,13 +651,6 @@ public class DbTableServiceImpl implements IDbTableService {
 
     }
 
-    private PageResponse<Table> filterExternalPage(DbTablePageQueryRequest request, PageResponse<Table> page) {
-        List<Table> original = page.getData();
-        List<Table> visible = visibleTables(request, original);
-        long safeTotal = visible.size() == original.size() ? page.getTotal() : visible.size();
-        return PageResponse.of(visible, safeTotal, page.getPageNo(), page.getPageSize());
-    }
-
     private List<Table> visibleTables(DbTablePageQueryRequest request, List<Table> tables) {
         return metadataAccessPolicyManager.filter(tables,
                 table -> resource(request.getDataSourceId(), request.getDatabaseName(), request.getSchemaName(),
@@ -728,16 +739,15 @@ public class DbTableServiceImpl implements IDbTableService {
             if (index == null || CollectionUtils.isEmpty(index.getColumnList())) {
                 continue;
             }
-            List<TableIndexColumn> columns = index.getColumnList().stream()
-                    .filter(Objects::nonNull)
-                    .filter(column -> StringUtils.isNotBlank(column.getColumnName()))
-                    .filter(column -> visibleColumnNames.contains(column.getColumnName().toLowerCase(Locale.ROOT)))
-                    .toList();
-            if (columns.isEmpty()) {
+            boolean allColumnsVisible = index.getColumnList().stream()
+                    .allMatch(column -> column != null
+                            && StringUtils.isNotBlank(column.getColumnName())
+                            && visibleColumnNames.contains(column.getColumnName().toLowerCase(Locale.ROOT)));
+            if (!allColumnsVisible) {
                 continue;
             }
             TableIndex copy = copyIndex(index);
-            copy.setColumnList(columns);
+            copy.setColumnList(List.copyOf(index.getColumnList()));
             copy.setForeignColumnNamelist(List.of());
             visible.add(copy);
         }

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/DbDlTemplateServicePolicyTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/DbDlTemplateServicePolicyTest.java
@@ -39,6 +39,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DbDlTemplateServicePolicyTest {
@@ -164,6 +166,50 @@ class DbDlTemplateServicePolicyTest {
 
         assertEquals(2L, count);
         assertTrue(capturedDirectSql.get().contains("tenant_id = 7"));
+    }
+
+    @Test
+    void countRunsTheAuthorizationHookBeforeAccessingTheDatabase() {
+        AtomicInteger beforeExecuteCalls = new AtomicInteger();
+        DbDlTemplateServiceImpl service = service(new ISqlExecutionPolicy() {
+            @Override
+            public void beforeExecute(SqlExecutionPlan plan) {
+                beforeExecuteCalls.incrementAndGet();
+                throw new IllegalStateException("count denied");
+            }
+        });
+        DbDlCountRequest request = new DbDlCountRequest();
+        request.setSql("SELECT * FROM orders");
+        request.setDataSourceId(7L);
+        request.setDatabaseName("shop");
+        request.setTableName("orders");
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> service.count(request));
+
+        assertEquals("count denied", error.getMessage());
+        assertEquals(1, beforeExecuteCalls.get());
+        assertNull(capturedDirectSql.get());
+    }
+
+    @Test
+    void countRejectsMongoRewritesThatTheLegacyCountPathCannotApply() {
+        Chat2DBContext.getConnectInfo().setDbType("MONGODB");
+        DbDlTemplateServiceImpl service = service(new ISqlExecutionPolicy() {
+            @Override
+            public String rewriteSql(SqlExecutionContext context, String sql) {
+                return sql + ".filter({tenantId: 7})";
+            }
+        });
+        DbDlCountRequest request = new DbDlCountRequest();
+        request.setSql("db.orders.find({})");
+        request.setDataSourceId(7L);
+        request.setDatabaseName("shop");
+        request.setTableName("orders");
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> service.count(request));
+
+        assertEquals("SQL rewrite is not supported for MONGODB counts", error.getMessage());
+        assertNull(capturedDirectSql.get());
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/DbMetadataAccessPolicyTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/DbMetadataAccessPolicyTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import ai.chat2db.community.domain.api.config.DBConfig;
@@ -13,6 +14,8 @@ import ai.chat2db.community.domain.api.config.DriverConfig;
 import ai.chat2db.community.domain.api.model.PageResponse;
 import ai.chat2db.community.domain.api.model.metadata.Table;
 import ai.chat2db.community.domain.api.model.metadata.TableColumn;
+import ai.chat2db.community.domain.api.model.metadata.TableIndex;
+import ai.chat2db.community.domain.api.model.metadata.TableIndexColumn;
 import ai.chat2db.community.domain.api.model.request.db.DbTablePageQueryRequest;
 import ai.chat2db.community.domain.api.model.request.db.DbTableQueryRequest;
 import ai.chat2db.community.domain.core.cache.MemoryCacheManage;
@@ -22,6 +25,7 @@ import ai.chat2db.spi.IDbMetaData;
 import ai.chat2db.spi.IPlugin;
 import ai.chat2db.spi.model.datasource.ConnectInfo;
 import ai.chat2db.spi.model.request.TableMetadataRequest;
+import ai.chat2db.spi.model.request.TablesRequest;
 import ai.chat2db.spi.sql.Chat2DBContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +39,8 @@ class DbMetadataAccessPolicyTest {
     private static final String SCHEMA = "public";
 
     private IPlugin previousPlugin;
+    private List<Table> externalTables = List.of();
+    private List<TableIndex> tableIndexes = List.of();
 
     @BeforeEach
     void setUp() {
@@ -45,6 +51,16 @@ class DbMetadataAccessPolicyTest {
             @Override
             public List<TableColumn> columns(Connection connection, TableMetadataRequest request) {
                 return List.of(column("id"), column("secret_value"));
+            }
+
+            @Override
+            public List<Table> tables(Connection connection, TablesRequest request) {
+                return externalTables;
+            }
+
+            @Override
+            public List<TableIndex> indexes(Connection connection, TableMetadataRequest request) {
+                return new ArrayList<>(tableIndexes);
             }
         };
         previousPlugin = Chat2DBContext.PLUGIN_MAP.put(DB_TYPE, new IPlugin() {
@@ -103,6 +119,57 @@ class DbMetadataAccessPolicyTest {
         assertEquals(List.of("id"), columns.stream().map(TableColumn::getName).toList());
     }
 
+    @Test
+    void externalMetadataFiltersBeforePaginationAndReportsTheAuthorizedTotal() {
+        externalTables = List.of(table("restricted"), table("orders"), table("forbidden"));
+
+        for (String dbType : List.of("REDIS", "MONGODB")) {
+            assertExternalMetadataPage(dbType);
+        }
+    }
+
+    @Test
+    void compositeIndexWithAHiddenColumnIsHiddenInsteadOfBeingShrunk() {
+        tableIndexes = List.of(
+                index("idx_orders_id", false, "id"),
+                index("uq_orders_id_secret", true, "id", "secret_value"));
+        DbTableQueryRequest request = DbTableQueryRequest.builder()
+                .dataSourceId(DATA_SOURCE_ID).databaseName(DATABASE).schemaName(SCHEMA)
+                .tableName("orders").refresh(true).build();
+
+        List<TableIndex> indexes = service().queryIndexes(request);
+
+        assertEquals(List.of("idx_orders_id"), indexes.stream().map(TableIndex::getName).toList());
+        assertEquals(List.of("id"), indexes.get(0).getColumnList().stream()
+                .map(TableIndexColumn::getColumnName).toList());
+    }
+
+    private void assertExternalMetadataPage(String dbType) {
+        IPlugin plugin = Chat2DBContext.PLUGIN_MAP.get(DB_TYPE);
+        IPlugin previousExternalPlugin = Chat2DBContext.PLUGIN_MAP.put(dbType, plugin);
+        ConnectInfo connectInfo = Chat2DBContext.getConnectInfo();
+        String previousDbType = connectInfo.getDbType();
+        connectInfo.setDbType(dbType);
+        try {
+            DbTablePageQueryRequest request = DbTablePageQueryRequest.builder()
+                    .dataSourceId(DATA_SOURCE_ID).databaseName(DATABASE).schemaName(SCHEMA)
+                    .searchKey("r").pageNo(1).pageSize(1).build();
+
+            PageResponse<Table> page = service().pageQuery(request, null);
+
+            assertEquals(1L, page.getTotal(), dbType);
+            assertEquals(List.of("orders"), page.getData().stream().map(Table::getName).toList(), dbType);
+            assertEquals(false, page.getHasNextPage(), dbType);
+        } finally {
+            connectInfo.setDbType(previousDbType);
+            if (previousExternalPlugin == null) {
+                Chat2DBContext.PLUGIN_MAP.remove(dbType);
+            } else {
+                Chat2DBContext.PLUGIN_MAP.put(dbType, previousExternalPlugin);
+            }
+        }
+    }
+
     private DbTableServiceImpl service() {
         MetadataAccessPolicyManager manager = new MetadataAccessPolicyManager(List.of(resources -> resources.stream()
                 .map(resource -> resource.getColumnName() == null
@@ -119,6 +186,16 @@ class DbMetadataAccessPolicyTest {
     private TableColumn column(String name) {
         return TableColumn.builder().name(name).tableName("orders").databaseName(DATABASE)
                 .schemaName(SCHEMA).build();
+    }
+
+    private TableIndex index(String name, boolean unique, String... columnNames) {
+        List<TableIndexColumn> columns = Arrays.stream(columnNames).map(columnName -> {
+            TableIndexColumn column = new TableIndexColumn();
+            column.setColumnName(columnName);
+            return column;
+        }).toList();
+        return TableIndex.builder().name(name).tableName("orders").databaseName(DATABASE).schemaName(SCHEMA)
+                .unique(unique).columnList(columns).build();
     }
 
     private Connection connection() {


### PR DESCRIPTION
Runs count authorization hooks before database access, fails closed when Mongo cannot apply rewritten count SQL, filters Redis/Mongo metadata before pagination, and hides composite indexes containing restricted columns. Includes focused policy tests.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head a13aca6db.
- Full domain-core module: 230/230 passed.