### PR TITLE
fix(workspace): synchronize pane state

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -85,7 +85,7 @@
     "test:sql-in-clipboard": "tsx src/utils/sqlInClipboard.test.ts && tsx src/components/SQLEditor/helper/sqlInsertValueDefaults.test.ts",
     "test:console-tab-name": "tsx src/store/workspace/utils/consoleTabName.test.ts && tsx src/utils/workspaceObjectTabTitle.test.ts",
     "test:workspace-tab-scroll": "tsx src/store/workspace/utils/workspaceTabScrollRequest.test.ts && tsx src/components/Tabs/activeTabScroll.test.ts && tsx src/components/Tabs/wheelScroll.test.ts && tsx src/components/Tabs/tabAccentColor.test.ts",
-    "test:workspace-split-lifecycle": "tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabLayout.test.ts",
+    "test:workspace-split-lifecycle": "tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabLayout.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentInteraction.test.ts",
     "test:tree-title-highlight": "tsx src/blocks/NewTree/components/TitleRender/highlightSearchText.test.ts",
     "test:tree-search-lifecycle": "tsx src/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle.test.ts && tsx src/pages/main/workspace/components/WorkspaceTreeSearch/refresh.test.ts",
     "test:tree-data-update": "tsx src/store/tree/treeDataUpdate.test.ts",

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
@@ -102,9 +102,11 @@ import {
 import {
   areWorkspacePaneContentBoundsEqual,
   resolveActiveWorkspaceTabPaneIds,
+  resolveWorkspaceTabContentActivation,
   resolveWorkspacePaneContentBounds,
   type WorkspacePaneContentBoundsMap,
 } from './workspaceTabContentLayout';
+import { WorkspaceTabContentInteraction } from './workspaceTabContentInteraction';
 
 const SplitPaneAny = SplitPane as any;
 const MAIN_WORKSPACE_TAB_PANE: WorkspaceTabPaneId = 'main';
@@ -1990,7 +1992,7 @@ const WorkspaceTabs = memo(() => {
   // Tab list.
   const workspaceTabItems = useMemo(() => {
     return getWorkspaceTabItems(workspaceTabList || []);
-  }, [workspaceTabList, activeConsoleId, dataSourceList]);
+  }, [workspaceTabList, activeConsoleId, dataSourceList, runtimeAvailabilityByDataSourceId]);
   const workspaceTabItemMap = useMemo(
     () => new Map(workspaceTabItems.map((item) => [item.key, item])),
     [workspaceTabItems],
@@ -2202,11 +2204,28 @@ const WorkspaceTabs = memo(() => {
           if (item.destroyOnHide && !isActive) {
             return null;
           }
+          const activateWorkspaceTabContent = () => {
+            const activation = resolveWorkspaceTabContentActivation({
+              paneId,
+              tabId: item.key,
+              activePaneId: workspaceTabSplitLayout?.activePane || MAIN_WORKSPACE_TAB_PANE,
+              activeConsoleId,
+            });
+            if (activation) {
+              onPaneTabChange(activation.paneId, activation.tabId);
+            }
+          };
           return (
-            <div
+            <WorkspaceTabContentInteraction
               key={item.key}
               aria-hidden={!isVisible}
               className={`${styles.workspaceTabContentItem} ${isVisible ? styles.workspaceTabContentItemActive : ''}`}
+              isActive={
+                paneId === (workspaceTabSplitLayout?.activePane || MAIN_WORKSPACE_TAB_PANE) &&
+                item.key === activeConsoleId
+              }
+              isVisible={isVisible}
+              onActivate={activateWorkspaceTabContent}
               style={
                 fillsSinglePane
                   ? {
@@ -2226,7 +2245,7 @@ const WorkspaceTabs = memo(() => {
               }
             >
               {item.children}
-            </div>
+            </WorkspaceTabContentInteraction>
           );
         })}
       </div>

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentInteraction.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentInteraction.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  pretendToBeVisual: true,
+  url: 'http://localhost',
+});
+const domWindow = dom.window;
+
+Object.defineProperties(globalThis, {
+  window: { configurable: true, value: domWindow },
+  document: { configurable: true, value: domWindow.document },
+  navigator: { configurable: true, value: domWindow.navigator },
+  Node: { configurable: true, value: domWindow.Node },
+  Element: { configurable: true, value: domWindow.Element },
+  HTMLElement: { configurable: true, value: domWindow.HTMLElement },
+  HTMLIFrameElement: { configurable: true, value: domWindow.HTMLIFrameElement },
+  Event: { configurable: true, value: domWindow.Event },
+  FocusEvent: { configurable: true, value: domWindow.FocusEvent },
+  MouseEvent: { configurable: true, value: domWindow.MouseEvent },
+  PointerEvent: { configurable: true, value: domWindow.MouseEvent },
+  IS_REACT_ACT_ENVIRONMENT: { configurable: true, value: true },
+});
+
+async function main() {
+  const [{ default: React, act }, { createRoot }, { createStore }, { WorkspaceTabContentInteraction }] =
+    await Promise.all([
+      import('react'),
+      import('react-dom/client'),
+      import('zustand/vanilla'),
+      import('./workspaceTabContentInteraction'),
+    ]);
+
+  const activeTabStore = createStore(() => ({ activePane: 'main', activeTabId: 'tab-a' }));
+  let activationCalls = 0;
+  const activateSplitTab = () => {
+    activationCalls += 1;
+    activeTabStore.setState({ activePane: 'pane-right', activeTabId: 'tab-b' });
+  };
+  const resetActiveTab = () => activeTabStore.setState({ activePane: 'main', activeTabId: 'tab-a' });
+  let pointerTargetPane: string | undefined;
+  let shortcutPane: string | undefined;
+
+  const outsideFocusTarget = document.createElement('button');
+  const container = document.createElement('div');
+  document.body.append(outsideFocusTarget, container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      React.createElement(
+        WorkspaceTabContentInteraction,
+        { isActive: false, isVisible: true, onActivate: activateSplitTab },
+        React.createElement('button', {
+          'data-testid': 'editor-control',
+          onKeyDown: () => {
+            shortcutPane = activeTabStore.getState().activePane;
+          },
+          onPointerDown: () => {
+            pointerTargetPane = activeTabStore.getState().activePane;
+          },
+        }),
+        React.createElement('iframe', { title: 'embedded editor', tabIndex: 0 }),
+      ),
+    );
+  });
+
+  const editorControl = container.querySelector<HTMLButtonElement>('[data-testid="editor-control"]');
+  const embeddedEditor = container.querySelector<HTMLIFrameElement>('iframe');
+  assert.ok(editorControl);
+  assert.ok(embeddedEditor);
+
+  resetActiveTab();
+  activationCalls = 0;
+  outsideFocusTarget.focus();
+  await act(async () => {
+    editorControl.dispatchEvent(new domWindow.MouseEvent('pointerdown', { bubbles: true, cancelable: true }));
+    editorControl.focus();
+  });
+  assert.equal(pointerTargetPane, 'pane-right', 'capture activation must precede the target pointer handler');
+  assert.equal(activationCalls, 1, 'the focus following a pointer activation must not activate the tab twice');
+
+  await act(async () => {
+    root.render(
+      React.createElement(
+        WorkspaceTabContentInteraction,
+        { isActive: false, isVisible: true, onActivate: activateSplitTab },
+        React.createElement('button', {
+          'data-testid': 'editor-control',
+          onKeyDown: () => {
+            shortcutPane = activeTabStore.getState().activePane;
+          },
+        }),
+        React.createElement('iframe', { title: 'embedded editor', tabIndex: 0 }),
+      ),
+    );
+  });
+
+  const rerenderedEditorControl = container.querySelector<HTMLButtonElement>('[data-testid="editor-control"]');
+  const rerenderedEmbeddedEditor = container.querySelector<HTMLIFrameElement>('iframe');
+  assert.ok(rerenderedEditorControl);
+  assert.ok(rerenderedEmbeddedEditor);
+
+  resetActiveTab();
+  outsideFocusTarget.focus();
+  await act(async () => rerenderedEditorControl.focus());
+  assert.deepEqual(
+    activeTabStore.getState(),
+    { activePane: 'pane-right', activeTabId: 'tab-b' },
+    'keyboard or programmatic focus should activate the owning pane and tab',
+  );
+  await act(async () => {
+    rerenderedEditorControl.dispatchEvent(new domWindow.KeyboardEvent('keydown', { bubbles: true, key: 'w' }));
+  });
+  assert.equal(shortcutPane, 'pane-right', 'shortcut handlers must observe the focused pane as active');
+
+  await act(async () => {
+    root.render(
+      React.createElement(
+        WorkspaceTabContentInteraction,
+        { isActive: false, isVisible: true, onActivate: activateSplitTab },
+        React.createElement('iframe', { title: 'embedded editor', tabIndex: 0 }),
+      ),
+    );
+  });
+  const innerFocusedFrame = container.querySelector<HTMLIFrameElement>('iframe');
+  assert.ok(innerFocusedFrame?.contentDocument);
+  const embeddedControl = innerFocusedFrame.contentDocument.createElement('button');
+  innerFocusedFrame.contentDocument.body.append(embeddedControl);
+
+  resetActiveTab();
+  activationCalls = 0;
+  outsideFocusTarget.focus();
+  await act(async () => embeddedControl.focus());
+  assert.equal(innerFocusedFrame.contentDocument.activeElement, embeddedControl);
+  assert.equal(document.activeElement, innerFocusedFrame);
+  assert.equal(
+    activeTabStore.getState().activePane,
+    'pane-right',
+    'focus inside an embedded document should activate its owning pane',
+  );
+  assert.equal(activationCalls, 1, 'an embedded focus transition should activate its owner once');
+
+  await act(async () => {
+    root.render(
+      React.createElement(
+        WorkspaceTabContentInteraction,
+        { isActive: false, isVisible: true, onActivate: activateSplitTab },
+        React.createElement('iframe', { title: 'embedded editor', tabIndex: 0 }),
+      ),
+    );
+  });
+  resetActiveTab();
+  activationCalls = 0;
+  await act(async () => {
+    domWindow.dispatchEvent(new domWindow.Event('blur'));
+    await new Promise((resolve) => domWindow.setTimeout(resolve, 0));
+  });
+  assert.equal(
+    activeTabStore.getState().activePane,
+    'pane-right',
+    'parent window focus transitions should recover activation for embedded documents',
+  );
+  assert.equal(activationCalls, 1, 'the parent focus bridge should activate the embedded owner once');
+
+  outsideFocusTarget.focus();
+  const callsBeforeUnmount = activationCalls;
+  await act(async () => root.unmount());
+  embeddedControl.focus();
+  assert.equal(activationCalls, callsBeforeUnmount, 'unmount must detach embedded document listeners');
+  outsideFocusTarget.remove();
+  container.remove();
+  domWindow.close();
+  console.log('Workspace tab content interaction tests passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  domWindow.close();
+  process.exit(1);
+});

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentInteraction.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentInteraction.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useRef, type ComponentPropsWithoutRef } from 'react';
+
+const EMBEDDED_CONTENT_SELECTOR = 'iframe, object, embed';
+
+function getEmbeddedContentDocument(host: Element): Document | null {
+  if (host.tagName !== 'IFRAME' && host.tagName !== 'OBJECT') {
+    return null;
+  }
+  try {
+    return (host as HTMLIFrameElement | HTMLObjectElement).contentDocument;
+  } catch {
+    return null;
+  }
+}
+
+type WorkspaceTabContentInteractionProps = Omit<
+  ComponentPropsWithoutRef<'div'>,
+  'onFocusCapture' | 'onPointerDownCapture'
+> & {
+  isActive: boolean;
+  isVisible: boolean;
+  onActivate: () => void;
+};
+
+export function WorkspaceTabContentInteraction({
+  isActive,
+  isVisible,
+  onActivate,
+  ...props
+}: WorkspaceTabContentInteractionProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef(isActive);
+  const onActivateRef = useRef(onActivate);
+  activeRef.current = isActive;
+  onActivateRef.current = onActivate;
+
+  const activate = useCallback(() => {
+    if (activeRef.current) {
+      return;
+    }
+    onActivateRef.current();
+    activeRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!isVisible) {
+      return;
+    }
+    const container = containerRef.current;
+    const ownerDocument = container?.ownerDocument;
+    const ownerWindow = ownerDocument?.defaultView;
+    if (!container || !ownerDocument || !ownerWindow) {
+      return;
+    }
+
+    const hostCleanups = new Map<Element, () => void>();
+    let focusCheckTimer: number | undefined;
+
+    const attachEmbeddedHost = (host: Element) => {
+      let detachDocumentListeners = () => undefined;
+      const attachDocumentListeners = () => {
+        detachDocumentListeners();
+        const embeddedDocument = getEmbeddedContentDocument(host);
+        if (!embeddedDocument) {
+          detachDocumentListeners = () => undefined;
+          return;
+        }
+        embeddedDocument.addEventListener('focusin', activate, true);
+        embeddedDocument.addEventListener('pointerdown', activate, true);
+        detachDocumentListeners = () => {
+          embeddedDocument.removeEventListener('focusin', activate, true);
+          embeddedDocument.removeEventListener('pointerdown', activate, true);
+        };
+      };
+
+      host.addEventListener('load', attachDocumentListeners);
+      attachDocumentListeners();
+      return () => {
+        host.removeEventListener('load', attachDocumentListeners);
+        detachDocumentListeners();
+      };
+    };
+
+    const collectEmbeddedHosts = (node: Node) => {
+      const hosts: Element[] = [];
+      if (node.nodeType === 1) {
+        const element = node as Element;
+        if (element.matches(EMBEDDED_CONTENT_SELECTOR)) {
+          hosts.push(element);
+        }
+        hosts.push(...element.querySelectorAll(EMBEDDED_CONTENT_SELECTOR));
+      }
+      return hosts;
+    };
+    const addEmbeddedHosts = (node: Node) => {
+      collectEmbeddedHosts(node).forEach((host) => {
+        if (!hostCleanups.has(host)) {
+          hostCleanups.set(host, attachEmbeddedHost(host));
+        }
+      });
+    };
+    const removeEmbeddedHosts = (node: Node) => {
+      if (node.nodeType !== 1) {
+        return;
+      }
+      const removedRoot = node as Element;
+      hostCleanups.forEach((cleanup, host) => {
+        if (host === removedRoot || removedRoot.contains(host)) {
+          cleanup();
+          hostCleanups.delete(host);
+        }
+      });
+    };
+
+    const checkEmbeddedActiveElement = () => {
+      focusCheckTimer = undefined;
+      const activeElement = ownerDocument.activeElement;
+      if (
+        activeElement &&
+        container.contains(activeElement) &&
+        activeElement.matches(EMBEDDED_CONTENT_SELECTOR)
+      ) {
+        activate();
+      }
+    };
+    const scheduleEmbeddedActiveElementCheck = () => {
+      if (focusCheckTimer !== undefined) {
+        ownerWindow.clearTimeout(focusCheckTimer);
+      }
+      focusCheckTimer = ownerWindow.setTimeout(checkEmbeddedActiveElement, 0);
+    };
+
+    addEmbeddedHosts(container);
+    const observer = new ownerWindow.MutationObserver((records) => {
+      records.forEach((record) => {
+        record.removedNodes.forEach(removeEmbeddedHosts);
+        record.addedNodes.forEach(addEmbeddedHosts);
+      });
+    });
+    observer.observe(container, { childList: true, subtree: true });
+    ownerWindow.addEventListener('blur', scheduleEmbeddedActiveElementCheck);
+    ownerWindow.addEventListener('focus', scheduleEmbeddedActiveElementCheck);
+    ownerDocument.addEventListener('visibilitychange', scheduleEmbeddedActiveElementCheck);
+
+    return () => {
+      observer.disconnect();
+      ownerWindow.removeEventListener('blur', scheduleEmbeddedActiveElementCheck);
+      ownerWindow.removeEventListener('focus', scheduleEmbeddedActiveElementCheck);
+      ownerDocument.removeEventListener('visibilitychange', scheduleEmbeddedActiveElementCheck);
+      if (focusCheckTimer !== undefined) {
+        ownerWindow.clearTimeout(focusCheckTimer);
+      }
+      hostCleanups.forEach((cleanup) => cleanup());
+      hostCleanups.clear();
+    };
+  }, [activate, isVisible]);
+
+  return <div {...props} ref={containerRef} onFocusCapture={activate} onPointerDownCapture={activate} />;
+}

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.test.ts
@@ -2,8 +2,40 @@ import assert from 'node:assert/strict';
 import {
   areWorkspacePaneContentBoundsEqual,
   resolveActiveWorkspaceTabPaneIds,
+  resolveWorkspaceTabContentActivation,
   resolveWorkspacePaneContentBounds,
 } from './workspaceTabContentLayout';
+
+assert.deepEqual(
+  resolveWorkspaceTabContentActivation({
+    paneId: 'pane-right',
+    tabId: 'tab-b',
+    activePaneId: 'main',
+    activeConsoleId: 'tab-a',
+  }),
+  { paneId: 'pane-right', tabId: 'tab-b' },
+  'pressing a sibling pane body should activate its visible tab before shortcuts run',
+);
+assert.equal(
+  resolveWorkspaceTabContentActivation({
+    paneId: 'main',
+    tabId: 'tab-a',
+    activePaneId: 'main',
+    activeConsoleId: 'tab-a',
+  }),
+  null,
+  'pressing the already active pane body should not repeat the selection update',
+);
+assert.equal(
+  resolveWorkspaceTabContentActivation({
+    paneId: undefined,
+    tabId: 'tab-hidden',
+    activePaneId: 'main',
+    activeConsoleId: 'tab-a',
+  }),
+  null,
+  'a hidden tab body cannot change the active pane',
+);
 
 assert.deepEqual(
   Array.from(

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.ts
@@ -7,6 +7,19 @@ export interface WorkspacePaneContentBounds {
 
 export type WorkspacePaneContentBoundsMap = Record<string, WorkspacePaneContentBounds>;
 
+export function resolveWorkspaceTabContentActivation(params: {
+  paneId: string | undefined;
+  tabId: string | number;
+  activePaneId: string;
+  activeConsoleId: string | number | null | undefined;
+}) {
+  const { paneId, tabId, activePaneId, activeConsoleId } = params;
+  if (!paneId || (paneId === activePaneId && tabId === activeConsoleId)) {
+    return null;
+  }
+  return { paneId, tabId };
+}
+
 export function resolveActiveWorkspaceTabPaneIds(params: {
   activeConsoleId: string | number | null | undefined;
   paneActiveTabIds?: Record<string, string | number | null>;


### PR DESCRIPTION
Activates the owning workspace pane for pointer, focus, and embedded-document interactions before global shortcuts run, and recomputes tab bodies when runtime datasource availability changes. Includes React/JSDOM ordering, iframe bridge, cleanup, and datasource lifecycle tests.

Verification update: rebased to current main while preserving its single-pane visibility semantics. Workspace split/layout/interaction JSDOM tests and targeted ESLint passed. Playwright dragged a second console into a right pane, verified editor pointer focus switched activePane/activeConsoleId left→right, then focused the left editor and Ctrl+W closed the left tab and collapsed the split. Current head: `03be722d5`.
