### PR TITLE
fix(jdbc): harden uploaded driver boundaries

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/JdbcDriverManagementPolicy.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/JdbcDriverManagementPolicy.java
@@ -3,10 +3,13 @@ package ai.chat2db.community.domain.core.impl.db;
 import ai.chat2db.community.tools.exception.BusinessException;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileSystemException;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -14,7 +17,7 @@ import java.util.regex.Pattern;
 
 final class JdbcDriverManagementPolicy {
 
-    private static final Pattern UPLOAD_TOKEN = Pattern.compile("^([0-9a-f]{32}):([^/:\\\\]+\\.jar)$",
+    private static final Pattern UPLOAD_TOKEN = Pattern.compile("^([0-9a-f]{32}):([^,/:\\\\]+\\.jar)$",
             Pattern.CASE_INSENSITIVE);
 
     record PromotedDrivers(String jdbcDriver, List<Path> files) {
@@ -53,14 +56,26 @@ final class JdbcDriverManagementPolicy {
                 }
                 String uploadId = matcher.group(1);
                 String driverName = matcher.group(2);
+                String driverBaseName = driverName.substring(0, driverName.length() - ".jar".length());
+                if (uploadId.contains("/") || uploadId.contains("\\")
+                        || driverName.contains("/") || driverName.contains("\\")
+                        || ".".equals(uploadId) || "..".equals(uploadId)
+                        || ".".equals(driverBaseName) || "..".equals(driverBaseName)) {
+                    throw uploadFailure("invalid driver upload token");
+                }
                 Path stagedFile = normalizedStagingDirectory.resolve(uploadId + ".upload").normalize();
                 Path driverFile = normalizedDirectory.resolve(driverName).normalize();
-                targets.add(new UploadTarget(driverName, stagedFile, driverFile));
-                if (!normalizedStagingDirectory.equals(stagedFile.getParent()) || !Files.isRegularFile(stagedFile)
+                if (!stagedFile.startsWith(normalizedStagingDirectory)
+                        || !driverFile.startsWith(normalizedDirectory)
+                        || !normalizedStagingDirectory.equals(stagedFile.getParent())
                         || !normalizedDirectory.equals(driverFile.getParent())) {
                     throw uploadFailure("uploaded driver file is unavailable");
                 }
-                if (Files.exists(driverFile)) {
+                targets.add(new UploadTarget(driverName, stagedFile, driverFile));
+                if (!Files.isRegularFile(stagedFile, LinkOption.NOFOLLOW_LINKS)) {
+                    throw uploadFailure("uploaded driver file is unavailable");
+                }
+                if (Files.exists(driverFile, LinkOption.NOFOLLOW_LINKS)) {
                     throw uploadFailure("a managed driver with the same file name already exists");
                 }
             }
@@ -92,17 +107,7 @@ final class JdbcDriverManagementPolicy {
     }
 
     static void moveWithoutReplacement(Path source, Path target) throws Exception {
-        moveWithoutReplacement(source, target, (link, existing) -> Files.createLink(link, existing));
-    }
-
-    static void moveWithoutReplacement(Path source, Path target, LinkCreator linkCreator) throws Exception {
-        try {
-            linkCreator.create(target, source);
-        } catch (FileAlreadyExistsException exception) {
-            throw exception;
-        } catch (UnsupportedOperationException | FileSystemException ignored) {
-            Files.copy(source, target);
-        }
+        copyRegularFileWithoutReplacement(source, target);
         try {
             Files.delete(source);
         } catch (Exception exception) {
@@ -110,6 +115,29 @@ final class JdbcDriverManagementPolicy {
                 Files.deleteIfExists(target);
             } catch (Exception cleanupFailure) {
                 exception.addSuppressed(cleanupFailure);
+            }
+            throw exception;
+        }
+    }
+
+    private static void copyRegularFileWithoutReplacement(Path source, Path target) throws IOException {
+        if (!Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("uploaded driver file is not a regular file");
+        }
+        boolean targetCreated = false;
+        try (InputStream input = Files.newInputStream(
+                source, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+             OutputStream output = Files.newOutputStream(
+                     target, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+            targetCreated = true;
+            input.transferTo(output);
+        } catch (IOException | RuntimeException exception) {
+            if (targetCreated) {
+                try {
+                    Files.deleteIfExists(target);
+                } catch (Exception cleanupFailure) {
+                    exception.addSuppressed(cleanupFailure);
+                }
             }
             throw exception;
         }
@@ -126,11 +154,6 @@ final class JdbcDriverManagementPolicy {
     }
 
     private record UploadTarget(String driverName, Path stagedFile, Path driverFile) {
-    }
-
-    @FunctionalInterface
-    interface LinkCreator {
-        void create(Path link, Path existing) throws Exception;
     }
 
     private static BusinessException uploadFailure(String reason) {

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/JdbcDriverManagementPolicyTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/JdbcDriverManagementPolicyTest.java
@@ -4,13 +4,16 @@ import ai.chat2db.community.tools.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.FileSystemException;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -71,7 +74,68 @@ class JdbcDriverManagementPolicyTest {
         assertUploadFailure(List.of("../outside.jar"), stagingDirectory, driverDirectory);
         assertUploadFailure(List.of("0123456789abcdef0123456789abcdef:driver.txt"),
                 stagingDirectory, driverDirectory);
+        BusinessException traversalFailure = assertUploadFailure(
+                List.of("0123456789abcdef0123456789abcdef:...jar"),
+                stagingDirectory, driverDirectory);
+        assertEquals("invalid driver upload token", traversalFailure.getArgs()[0]);
         assertUploadFailure(List.of(), stagingDirectory, driverDirectory);
+    }
+
+    @Test
+    void acceptsSafeDottedUnicodeAndLiteralEncodedSeparatorNames() throws Exception {
+        Path stagingDirectory = Files.createDirectories(tempDirectory.resolve("staging"));
+        Path driverDirectory = Files.createDirectories(tempDirectory.resolve("drivers"));
+        String firstId = "0123456789abcdef0123456789abcdef";
+        String secondId = "123456789abcdef0123456789abcdef0";
+        String thirdId = "23456789abcdef0123456789abcdef01";
+        String unicodeName = "\u9a71\u52a8-1.2.jar";
+        Files.writeString(stagingDirectory.resolve(firstId + ".upload"), "dotted");
+        Files.writeString(stagingDirectory.resolve(secondId + ".upload"), "unicode");
+        Files.writeString(stagingDirectory.resolve(thirdId + ".upload"), "encoded");
+
+        JdbcDriverManagementPolicy.PromotedDrivers promoted =
+                JdbcDriverManagementPolicy.promoteUploadedDrivers(
+                        List.of(firstId + ":driver..jar", secondId + ":" + unicodeName,
+                                thirdId + ":literal%2F.jar"),
+                        stagingDirectory, driverDirectory);
+
+        assertEquals("driver..jar," + unicodeName + ",literal%2F.jar", promoted.jdbcDriver());
+        assertEquals("dotted", Files.readString(driverDirectory.resolve("driver..jar")));
+        assertEquals("unicode", Files.readString(driverDirectory.resolve(unicodeName)));
+        assertEquals("encoded", Files.readString(driverDirectory.resolve("literal%2F.jar")));
+    }
+
+    @Test
+    void rejectsCommaDelimitedDriverNameEvenWhenTheStagedFileExists() throws Exception {
+        Path stagingDirectory = Files.createDirectories(tempDirectory.resolve("staging"));
+        Path driverDirectory = Files.createDirectories(tempDirectory.resolve("drivers"));
+        String uploadId = "0123456789abcdef0123456789abcdef";
+        Files.writeString(stagingDirectory.resolve(uploadId + ".upload"), "driver");
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> JdbcDriverManagementPolicy.promoteUploadedDrivers(
+                        List.of(uploadId + ":first,second.jar"), stagingDirectory, driverDirectory));
+
+        assertEquals("jdbc.driver.uploadFailed", exception.getCode());
+        assertEquals("invalid driver upload token", exception.getArgs()[0]);
+        assertFalse(Files.exists(driverDirectory.resolve("first,second.jar")));
+    }
+
+    @Test
+    void rejectsSymlinkedStagedUploadWithoutPublishingItsTarget() throws Exception {
+        assumeSymbolicLinksAreAvailable();
+        Path stagingDirectory = Files.createDirectories(tempDirectory.resolve("staging"));
+        Path driverDirectory = Files.createDirectories(tempDirectory.resolve("drivers"));
+        Path outsideFile = Files.writeString(tempDirectory.resolve("outside.jar"), "outside");
+        String uploadId = "0123456789abcdef0123456789abcdef";
+        Path stagedFile = stagingDirectory.resolve(uploadId + ".upload");
+        Files.createSymbolicLink(stagedFile, outsideFile);
+
+        assertUploadFailure(List.of(uploadId + ":mysql.jar"), stagingDirectory, driverDirectory);
+
+        assertEquals("outside", Files.readString(outsideFile));
+        assertFalse(Files.exists(stagedFile, LinkOption.NOFOLLOW_LINKS));
+        assertFalse(Files.exists(driverDirectory.resolve("mysql.jar"), LinkOption.NOFOLLOW_LINKS));
     }
 
     @Test
@@ -104,17 +168,33 @@ class JdbcDriverManagementPolicyTest {
     }
 
     @Test
-    void fallsBackToCreateNewCopyWhenHardLinksAreUnavailable() throws Exception {
+    void copiesRegularFileAndRemovesTheStagingEntry() throws Exception {
         Path source = tempDirectory.resolve("staged.upload");
         Path target = tempDirectory.resolve("driver.jar");
         Files.writeString(source, "driver");
 
-        JdbcDriverManagementPolicy.moveWithoutReplacement(source, target, (link, existing) -> {
-            throw new FileSystemException(link.toString(), existing.toString(), "hard links unavailable");
-        });
+        JdbcDriverManagementPolicy.moveWithoutReplacement(source, target);
 
         assertEquals("driver", Files.readString(target));
         assertFalse(Files.exists(source));
+    }
+
+    @Test
+    void rejectsSymlinkSubstitutedBetweenValidationAndPublication() throws Exception {
+        assumeSymbolicLinksAreAvailable();
+        Path source = tempDirectory.resolve("staged.upload");
+        Path target = tempDirectory.resolve("driver.jar");
+        Path outsideFile = Files.writeString(tempDirectory.resolve("outside.jar"), "outside");
+        Files.writeString(source, "driver");
+        assertTrue(Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS));
+        Files.delete(source);
+        Files.createSymbolicLink(source, outsideFile);
+
+        assertThrows(IOException.class,
+                () -> JdbcDriverManagementPolicy.moveWithoutReplacement(source, target));
+
+        assertEquals("outside", Files.readString(outsideFile));
+        assertFalse(Files.exists(target, LinkOption.NOFOLLOW_LINKS));
     }
 
     private Object promoteAfter(CountDownLatch start, String uploadId, Path stagingDirectory,
@@ -128,10 +208,25 @@ class JdbcDriverManagementPolicyTest {
         }
     }
 
-    private void assertUploadFailure(List<String> uploadTokens, Path stagingDirectory, Path driverDirectory) {
+    private BusinessException assertUploadFailure(List<String> uploadTokens, Path stagingDirectory,
+                                                  Path driverDirectory) {
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> JdbcDriverManagementPolicy.promoteUploadedDrivers(
                         uploadTokens, stagingDirectory, driverDirectory));
         assertEquals("jdbc.driver.uploadFailed", exception.getCode());
+        return exception;
+    }
+
+    private void assumeSymbolicLinksAreAvailable() throws Exception {
+        Path target = Files.writeString(tempDirectory.resolve("symlink-probe-target"), "probe");
+        Path link = tempDirectory.resolve("symlink-probe");
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | FileSystemException exception) {
+            assumeTrue(false, "Symbolic links are unavailable: " + exception.getMessage());
+        } finally {
+            Files.deleteIfExists(link);
+            Files.deleteIfExists(target);
+        }
     }
 }

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/db/JdbcDriverUploadSizeFilter.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/db/JdbcDriverUploadSizeFilter.java
@@ -37,7 +37,9 @@ public class JdbcDriverUploadSizeFilter extends OncePerRequestFilter {
 
     static boolean isDriverUploadPath(String requestUri, String contextPath) {
         String normalizedContextPath = contextPath == null ? "" : contextPath;
-        return requestUri != null && requestUri.equals(normalizedContextPath + DRIVER_UPLOAD_PATH);
+        return requestUri != null
+                && stripPathParameters(requestUri).equals(stripPathParameters(normalizedContextPath)
+                + DRIVER_UPLOAD_PATH);
     }
 
     static boolean isDriverUploadRequest(String method, String requestUri, String contextPath) {
@@ -46,5 +48,22 @@ public class JdbcDriverUploadSizeFilter extends OncePerRequestFilter {
 
     static boolean isAllowedContentLength(long contentLength) {
         return contentLength >= 0 && contentLength <= MAX_DRIVER_UPLOAD_REQUEST_BYTES;
+    }
+
+    private static String stripPathParameters(String path) {
+        StringBuilder stripped = new StringBuilder(path.length());
+        boolean inPathParameters = false;
+        for (int index = 0; index < path.length(); index++) {
+            char character = path.charAt(index);
+            if (character == ';') {
+                inPathParameters = true;
+            } else if (character == '/') {
+                inPathParameters = false;
+                stripped.append(character);
+            } else if (!inPathParameters) {
+                stripped.append(character);
+            }
+        }
+        return stripped.toString();
     }
 }

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/db/MultipartJdbcDriverUploadAdapter.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/db/MultipartJdbcDriverUploadAdapter.java
@@ -62,6 +62,7 @@ public class MultipartJdbcDriverUploadAdapter implements IDbJdbcDriverUploadServ
         for (MultipartFile file : files) {
             String originalFilename = FilenameUtils.getName(file.getOriginalFilename());
             if (file.isEmpty() || originalFilename == null || originalFilename.isBlank()
+                    || originalFilename.indexOf(',') >= 0
                     || !"jar".equalsIgnoreCase(FilenameUtils.getExtension(originalFilename))) {
                 throw new IOException("Only non-empty JDBC driver JAR files can be uploaded");
             }

--- a/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/adapter/db/JdbcDriverUploadSizeFilterTest.java
+++ b/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/adapter/db/JdbcDriverUploadSizeFilterTest.java
@@ -13,8 +13,14 @@ class JdbcDriverUploadSizeFilterTest {
                 "POST", "/api/jdbc/driver/upload", ""));
         assertTrue(JdbcDriverUploadSizeFilter.isDriverUploadRequest(
                 "POST", "/chat2db/api/jdbc/driver/upload", "/chat2db"));
+        assertTrue(JdbcDriverUploadSizeFilter.isDriverUploadRequest(
+                "POST", "/api/jdbc/driver/upload;x=y", ""));
+        assertTrue(JdbcDriverUploadSizeFilter.isDriverUploadRequest(
+                "POST", "/chat2db/api;v=1/jdbc/driver/upload;x=y", "/chat2db"));
         assertFalse(JdbcDriverUploadSizeFilter.isDriverUploadRequest(
                 "POST", "/api/converter/upload", ""));
+        assertFalse(JdbcDriverUploadSizeFilter.isDriverUploadRequest(
+                "POST", "/api/jdbc/driver/upload;x=y/extra", ""));
         assertFalse(JdbcDriverUploadSizeFilter.isDriverUploadRequest(
                 "OPTIONS", "/api/jdbc/driver/upload", ""));
     }

--- a/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/adapter/db/MultipartJdbcDriverUploadAdapterTest.java
+++ b/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/adapter/db/MultipartJdbcDriverUploadAdapterTest.java
@@ -42,6 +42,9 @@ class MultipartJdbcDriverUploadAdapterTest {
                         new MultipartFile[]{file("driver.txt", "not a jar")}, driverDirectory));
         assertThrows(IOException.class,
                 () -> MultipartJdbcDriverUploadAdapter.store(
+                        new MultipartFile[]{file("first,second.jar", "driver")}, driverDirectory));
+        assertThrows(IOException.class,
+                () -> MultipartJdbcDriverUploadAdapter.store(
                         new MultipartFile[]{file(null, "driver")}, driverDirectory));
         assertThrows(IOException.class,
                 () -> MultipartJdbcDriverUploadAdapter.store(


### PR DESCRIPTION
Covers matrix-parameter upload routes with the request-size filter, rejects comma-delimited driver names, and publishes staged uploads through NOFOLLOW/CREATE_NEW handling so symlinks and replacement races cannot escape validation. Includes focused web and domain tests.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head ef11232df.
- Full domain-core module: 230/230 passed.
- Full web module: 79/79 passed.