### PR TITLE
fix(sql): preserve result context during paging

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/index.tsx
@@ -63,6 +63,7 @@ import {
 import { resolveResultInspectorActiveCell } from '../ResultSetTable/selectionState';
 import { areResultCellValuesEquivalent } from './inspectorState';
 import SqlExecutionLoading from '@/components/SqlExecutionLoading';
+import { getMatchingResultReplacement } from '../../resultTabPinning';
 
 interface IProps {
   resultData: IManageResultData;
@@ -255,7 +256,13 @@ export default memo<IProps>(
           void runResultPagingRequest(
             () => onResultPagingChange(resultData, executeSqlParams),
             {
-              onSuccess: () => setExecuteErrorMessage(null),
+              onSuccess: (completedResult) => {
+                setExecuteErrorMessage(null);
+                const replacementResult = getMatchingResultReplacement(completedResult, resultData);
+                if (replacementResult) {
+                  setResultData(replacementResult);
+                }
+              },
               onError: (message) => {
                 setExecuteErrorMessage(message);
                 setResultData((current) => ({ ...current }));

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.test.ts
@@ -2,12 +2,14 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { MAX_RESULT_PAGE_SIZE } from '@/constants/pagination';
 import { SqlExecutionBusyError } from '@/service/sqlExecutionRequestTracker';
+import { getMatchingResultReplacement } from '../../resultTabPinning';
 import {
   buildResultPageExecuteParams,
   resolveResultPaging,
   runResultPagingRequest,
 } from './pagination';
 import './viewTablePagingFlow.test';
+import '@/pages/main/workspace/components/SQLExecute/sqlResultPagingModel.test';
 
 test('matches the Java Integer transport boundary without restoring the old product cap', () => {
   assert.equal(MAX_RESULT_PAGE_SIZE, 2_147_483_647);
@@ -64,4 +66,26 @@ test('a rejected paging request is handled and restores the confirmed pagination
   assert.equal(errorMessage, 'SQL execution is already in progress');
   assert.deepEqual(visiblePaging, confirmedPaging);
   assert.deepEqual(unhandledRejections, []);
+});
+
+test('a cancelled SQL paging request restores the confirmed toolbar page', async () => {
+  const confirmedResult = { uuid: 'result-1', pageNo: 2, pageSize: 1000 };
+  let visiblePaging = { pageNo: 3, pageSize: 50_000 };
+
+  await runResultPagingRequest(
+    () => Promise.resolve({ ...confirmedResult }),
+    {
+      onSuccess: (completedResult) => {
+        const replacementResult = getMatchingResultReplacement(completedResult, confirmedResult);
+        assert.ok(replacementResult);
+        visiblePaging = {
+          pageNo: replacementResult.pageNo,
+          pageSize: replacementResult.pageSize,
+        };
+      },
+      onError: (message) => assert.fail(message),
+    },
+  );
+
+  assert.deepEqual(visiblePaging, { pageNo: 2, pageSize: 1000 });
 });

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/pagination.ts
@@ -45,16 +45,16 @@ export function getResultPagingErrorMessage(error: unknown) {
   return '';
 }
 
-export async function runResultPagingRequest(
-  request: () => Promise<unknown> | unknown,
+export async function runResultPagingRequest<T>(
+  request: () => Promise<T> | T,
   callbacks: {
-    onSuccess?: () => void;
+    onSuccess?: (result: T) => void;
     onError: (message: string) => void;
   },
 ) {
   try {
-    await request();
-    callbacks.onSuccess?.();
+    const result = await request();
+    callbacks.onSuccess?.(result);
   } catch (error) {
     callbacks.onError(getResultPagingErrorMessage(error));
   }

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
@@ -4,7 +4,7 @@ import test from 'node:test';
 import { getHeaderMetadataRows } from '../ResultSetTable/headerMetadata';
 import { getResultColumnTitle } from '../ResultSetTable/utils/columnTitle';
 import { createResultHeaderCustomRender } from '../ResultSetTable/headerRender';
-import { retainPinnedResults } from '../../resultTabPinning';
+import { replaceRetainedResult, retainPinnedResults } from '../../resultTabPinning';
 import {
   applyResultSearchVisibilityAction,
   getResultSearchVisibility,
@@ -337,6 +337,28 @@ test('incoming result replaces a pinned result with the same key', () => {
   const updatedResult = { uuid: 'same', value: 'updated result' };
 
   assert.deepEqual(retainPinnedResults([updatedResult], [oldResult], new Set(['same'])), [updatedResult]);
+});
+
+test('paging updates a pinned result retained outside the parent result list', () => {
+  const pinnedResult = { uuid: 'pinned', value: 'page 1' };
+  const parentResult = { uuid: 'next', value: 'new execution' };
+  const parentResults = [parentResult];
+  const retainedResults = retainPinnedResults(
+    parentResults,
+    [pinnedResult],
+    new Set(['pinned']),
+  );
+  const pagedResult = { uuid: 'pinned', value: 'page 2' };
+
+  assert.equal(
+    parentResults.some((result) => result.uuid === pinnedResult.uuid),
+    false,
+    'the parent no longer owns the pinned tab',
+  );
+  assert.deepEqual(replaceRetainedResult(retainedResults, pinnedResult, pagedResult), [
+    pagedResult,
+    parentResult,
+  ]);
 });
 
 test('pinned result already moved into incoming history is not retained in current results', () => {

--- a/chat2db-community-client/src/blocks/SearchResult/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/index.tsx
@@ -47,7 +47,11 @@ import {
 } from './tabSelection';
 import { ShortcutAction } from '@/constants/shortcut';
 import { useGlobalStore } from '@/store/global';
-import { retainPinnedResults } from './resultTabPinning';
+import {
+  getMatchingResultReplacement,
+  replaceRetainedResult,
+  retainPinnedResults,
+} from './resultTabPinning';
 import { useTreeStore } from '@/store/tree';
 import { resolveDataSourceIdentityColor } from '@/utils/dataSourceIdentity';
 import type { DataSourceExecutionTarget } from '@/service/dataSourceExecutionSnapshot';
@@ -255,6 +259,22 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
     [consoleMode],
   );
 
+  const handleResultPagingChange = useCallback(
+    async (targetResult: IManageResultData, params: IExecuteSqlParams) => {
+      const completedResult = await props.onResultPagingChange?.(targetResult, params);
+      const replacementResult = getMatchingResultReplacement(completedResult, targetResult);
+      if (!replacementResult) {
+        return completedResult;
+      }
+      setResultDataList((current) =>
+        current ? replaceRetainedResult(current, targetResult, replacementResult) : current,
+      );
+      setHistoryResultDataList((current) => replaceRetainedResult(current, targetResult, replacementResult));
+      return replacementResult;
+    },
+    [props.onResultPagingChange],
+  );
+
   const tabsList = useMemo(() => {
     const visibleResultDataList = consoleMode
       ? orderedConsoleResultDataList
@@ -307,7 +327,7 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
               active={activeTabId === queryResultData.uuid}
               viewTable={viewTable || queryResultData.canEdit}
               resultData={queryResultData}
-              onResultPagingChange={props.onResultPagingChange}
+              onResultPagingChange={props.onResultPagingChange ? handleResultPagingChange : undefined}
             />
           ),
         };
@@ -323,6 +343,7 @@ const SearchResult = forwardRef((props: IProps, ref: ForwardedRef<ISearchResultR
     orderedConsoleResultDataList,
     dataSourceList,
     props.showExecutionResultCoordinates,
+    handleResultPagingChange,
     props.onResultPagingChange,
     styles.resultTabIcon,
     viewTable,

--- a/chat2db-community-client/src/blocks/SearchResult/resultTabPinning.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/resultTabPinning.ts
@@ -2,6 +2,19 @@ interface PinnableResult {
   uuid?: string;
 }
 
+export function getMatchingResultReplacement<T extends PinnableResult>(value: unknown, targetResult: T) {
+  if (
+    !value ||
+    Array.isArray(value) ||
+    typeof value !== 'object' ||
+    !('uuid' in value) ||
+    value.uuid !== targetResult.uuid
+  ) {
+    return undefined;
+  }
+  return value as T;
+}
+
 export function retainPinnedResults<T extends PinnableResult>(
   incomingResults: T[],
   existingResults: T[],
@@ -24,4 +37,24 @@ export function retainPinnedResults<T extends PinnableResult>(
   });
 
   return [...retainedResults, ...incomingResults];
+}
+
+export function replaceRetainedResult<T extends PinnableResult>(
+  currentResults: T[],
+  targetResult: T,
+  replacementResult: T,
+) {
+  const targetKey = targetResult.uuid;
+  if (!targetKey) {
+    return currentResults;
+  }
+  let replaced = false;
+  const nextResults = currentResults.map((result) => {
+    if (replaced || result.uuid !== targetKey) {
+      return result;
+    }
+    replaced = true;
+    return replacementResult;
+  });
+  return replaced ? nextResults : currentResults;
 }

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/index.tsx
@@ -102,8 +102,19 @@ import {
   rethrowNonCancellationSqlExecutionError,
   SqlExecutionLogContext,
 } from '@/service/sqlExecutionLog';
+import { SqlExecutionBusyError } from '@/service/sqlExecutionRequestTracker';
 import { isDesktop } from '@/utils/env';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  buildSqlResultPagingExecuteParams,
+  createSqlResultPagingCancellationResult,
+  createSqlResultPagingState,
+  reduceSqlResultPagingEvent,
+  replaceSqlResultPage,
+  resolveSqlResultPagingCompletion,
+  type SqlResultPagingRequest,
+  type SqlResultPagingState,
+} from './sqlResultPagingModel';
 import { buildStreamResultExecuteSqlParams } from './streamResultExecutionParams';
 
 const SplitPaneAny = SplitPane as any;
@@ -134,6 +145,13 @@ interface IProps {
 interface DesktopExecutionCallbackState {
   databaseInfo: IDatabaseBaseInfo;
   data: IManageResultData[];
+}
+
+interface ActiveSqlResultPagingRequest extends SqlResultPagingRequest {
+  cancelled?: boolean;
+  completedResult?: IManageResultData;
+  failed?: boolean;
+  errorMessage?: string;
 }
 
 export interface SQLExecuteRef {
@@ -245,6 +263,8 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
   );
   const [resultDataList, setResultDataList] = useState<IManageResultData[]>([]);
   const resultPageSizeRef = useRef<number>();
+  const resultPagingRequestRef = useRef<ActiveSqlResultPagingRequest>();
+  const resultPagingStateRef = useRef<SqlResultPagingState>();
   const pendingRowsRef = useRef<PendingSqlExecutionRows>(new Map());
   const pendingRowsFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closedSqlExecutionResultsRef = useRef<ClosedSqlExecutionResults>(new Map());
@@ -700,7 +720,12 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
       restoreDataSourceRuntimeAvailability,
     ],
   );
-  const { executing, canExecuteSQL, executeSQL, stopExecuteSQL } = useSqlExecutor({
+  const {
+    executing: sqlExecuting,
+    canExecuteSQL,
+    executeSQL,
+    stopExecuteSQL,
+  } = useSqlExecutor({
     onExecutionRequestStart: handleSqlExecutionRequestStart,
     onExecutionRequestStartError: handleSqlExecutionRequestStartError,
     onExecutionEvent: handleSqlExecutionEvent,
@@ -708,6 +733,45 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
       staticMessage.error(i18n('common.text.cancelRequestFailed'));
     },
   });
+  const handleResultPagingRequestStart = useCallback((requestSequence: number) => {
+    if (resultPagingRequestRef.current) {
+      resultPagingStateRef.current = createSqlResultPagingState(requestSequence, resultPagingRequestRef.current);
+    }
+  }, []);
+  const handleResultPagingExecutionEvent = useCallback((event: SqlExecutionEvent, requestSequence: number) => {
+    const activeRequest = resultPagingRequestRef.current;
+    if (!resultPagingStateRef.current || !activeRequest) {
+      return;
+    }
+    if (resultPagingStateRef.current.requestSequence !== requestSequence) {
+      return;
+    }
+    if (event.eventType === 'cancelled') {
+      activeRequest.cancelled = true;
+    }
+    const transition = reduceSqlResultPagingEvent(resultPagingStateRef.current, event, requestSequence);
+    resultPagingStateRef.current = transition.state;
+    if (transition.failed) {
+      activeRequest.failed = true;
+      activeRequest.errorMessage = transition.errorMessage || activeRequest.errorMessage;
+    }
+    if (transition.completedResult) {
+      activeRequest.completedResult = transition.completedResult;
+    }
+  }, []);
+  const {
+    executing: resultPagingExecuting,
+    canExecuteSQL: canExecuteResultPagingSQL,
+    executeSQL: executeResultPage,
+    stopExecuteSQL: stopResultPagingSQL,
+  } = useSqlExecutor({
+    onExecutionRequestStart: handleResultPagingRequestStart,
+    onExecutionEvent: handleResultPagingExecutionEvent,
+    onExecutionCancellationError: () => {
+      staticMessage.error(i18n('common.text.cancelRequestFailed'));
+    },
+  });
+  const executing = sqlExecuting || resultPagingExecuting;
 
   // Whether to show the split panel.
   const isSplitPane = useMemo(() => {
@@ -823,7 +887,7 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
       staticMessage.warning(i18n('workspace.dataSourceLifecycle.deleted'));
       return Promise.resolve();
     }
-    if (!canExecuteSQL()) {
+    if (!canExecuteSQL() || !canExecuteResultPagingSQL()) {
       staticMessage.warning(i18n('common.text.currentExecution'));
       return Promise.resolve();
     }
@@ -1022,13 +1086,45 @@ const SQLExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLExecuteRef>) 
   const handleResultPagingChange = useCallback(
     (_resultData: IManageResultData, executeSqlParams: IExecuteSqlParams) => {
       resultPageSizeRef.current = executeSqlParams.pageSize;
-      return handleExecuteSQL(executeSqlParams);
+      if (!canExecuteSQL() || !canExecuteResultPagingSQL()) {
+        return Promise.reject(new SqlExecutionBusyError());
+      }
+      const request: ActiveSqlResultPagingRequest = {
+        targetResult: _resultData,
+        params: buildSqlResultPagingExecuteParams(_resultData, executeSqlParams),
+      };
+      resultPagingRequestRef.current = request;
+      return executeResultPage(request.params)
+        .then((results) => {
+          if (request.cancelled) {
+            const confirmedResult = createSqlResultPagingCancellationResult(request.targetResult);
+            setResultDataList((current) =>
+              replaceSqlResultPage(current, request.targetResult, confirmedResult),
+            );
+            return confirmedResult;
+          }
+          const completedResult = resolveSqlResultPagingCompletion(results, request, {
+            streamedResult: request.completedResult,
+            streamFailed: request.failed,
+            streamedErrorMessage: request.errorMessage,
+            fallbackErrorMessage: i18n('common.text.noData'),
+          });
+          setResultDataList((current) => replaceSqlResultPage(current, request.targetResult, completedResult));
+          return completedResult;
+        })
+        .finally(() => {
+          if (resultPagingRequestRef.current === request) {
+            resultPagingRequestRef.current = undefined;
+            resultPagingStateRef.current = undefined;
+          }
+        });
     },
-    [handleExecuteSQL],
+    [canExecuteResultPagingSQL, canExecuteSQL, executeResultPage],
   );
 
   const stopExecuteSql = () => {
     stopExecuteSQL();
+    stopResultPagingSQL();
   };
 
   useImperativeHandle(ref, () => ({

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/sqlResultPagingModel.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/sqlResultPagingModel.test.ts
@@ -1,0 +1,282 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DatabaseTypeCode } from '@/constants/common';
+import type { SqlExecutionEvent } from '@/service/sqlExecutionStream';
+import type { IExecuteSqlParams, IManageResultData } from '@/typings';
+import {
+  buildSqlResultPagingExecuteParams,
+  createSqlResultPagingCancellationResult,
+  createSqlResultPagingState,
+  normalizeSqlResultPagingResults,
+  reduceSqlResultPagingEvent,
+  replaceSqlResultPage,
+  resolveSqlResultPagingCompletion,
+  type SqlResultPagingRequest,
+} from './sqlResultPagingModel';
+
+function result(uuid: string, overrides: Partial<IManageResultData> = {}): IManageResultData {
+  return {
+    uuid,
+    dataList: [[{ value: uuid }]] as any,
+    headerList: [{ name: '#' }, { name: 'value' }] as any,
+    description: '',
+    sql: 'SELECT 1',
+    originalSql: 'SELECT 1',
+    success: true,
+    sqlType: 'SELECT' as any,
+    refreshTargets: [],
+    resultSetId: 1,
+    statementSequence: 1,
+    pageNo: 1,
+    pageSize: 1000,
+    fuzzyTotal: '1',
+    hasNextPage: false,
+    ...overrides,
+  };
+}
+
+function pagingRequest(targetResult: IManageResultData): SqlResultPagingRequest {
+  return {
+    targetResult,
+    params: {
+      ...targetResult.executeSqlParams,
+      sql: targetResult.executeSqlParams?.sql || targetResult.originalSql || targetResult.sql,
+      pageNo: 2,
+      pageSize: 5000,
+    },
+  };
+}
+
+function event(eventType: SqlExecutionEvent['eventType'], message: IManageResultData): SqlExecutionEvent {
+  return {
+    executionId: 'paging-execution',
+    eventType,
+    message,
+    statementSequence: 1,
+    resultSequence: 1,
+    resultKey: 'paging-execution:1:1',
+  };
+}
+
+test('paging always executes against the clicked result execution target', () => {
+  const targetResult = result('target', {
+    executeSqlParams: {
+      dataSourceId: 11,
+      databaseName: 'source_database',
+      schemaName: 'source_schema',
+      sql: 'SELECT 1',
+    },
+    extra: {
+      executionTarget: {
+        dataSourceId: 11,
+        dataSourceName: 'source',
+        databaseName: 'source_database',
+        schemaName: 'source_schema',
+        databaseType: DatabaseTypeCode.MYSQL,
+      },
+    },
+  });
+  const paramsFromCurrentEditor: IExecuteSqlParams = {
+    ...targetResult.executeSqlParams,
+    sql: targetResult.executeSqlParams?.sql || targetResult.originalSql || targetResult.sql,
+    dataSourceId: 99,
+    dataSourceName: 'current',
+    databaseName: 'current_database',
+    schemaName: 'current_schema',
+    databaseType: DatabaseTypeCode.POSTGRESQL,
+    pageNo: 2,
+  };
+
+  assert.deepEqual(buildSqlResultPagingExecuteParams(targetResult, paramsFromCurrentEditor), {
+    ...paramsFromCurrentEditor,
+    dataSourceId: 11,
+    dataSourceName: 'source',
+    databaseName: 'source_database',
+    schemaName: 'source_schema',
+    databaseType: DatabaseTypeCode.MYSQL,
+  });
+});
+
+test('paging cancellation republishes a new object with the confirmed page', () => {
+  const confirmedResult = result('stable-uuid', { pageNo: 2, pageSize: 1000 });
+  const cancellationResult = createSqlResultPagingCancellationResult(confirmedResult);
+
+  assert.notEqual(cancellationResult, confirmedResult);
+  assert.equal(cancellationResult.uuid, confirmedResult.uuid);
+  assert.equal(cancellationResult.pageNo, 2);
+  assert.equal(cancellationResult.pageSize, 1000);
+});
+
+test('a streamed page replaces the target while preserving its mounted identity', () => {
+  const targetResult = result('stable-uuid', {
+    displayName: '#4-1 SELECT 1',
+    executeSqlParams: { dataSourceId: 11, sql: 'SELECT 1', resultSetId: 1 },
+    extra: {
+      executionId: 'original-execution',
+      executionSequence: 4,
+      resultKey: 'original-execution:1:1',
+      resultSequence: 1,
+      statementSequence: 1,
+      executionTarget: { dataSourceId: 11, databaseName: 'source_database' },
+    },
+  });
+  const request = pagingRequest(targetResult);
+  const requestSequence = 7;
+  let transition = reduceSqlResultPagingEvent(
+    createSqlResultPagingState(requestSequence, request),
+    event('rows', result('backend-chunk', { dataList: [[{ value: 'page-2-row' }]] as any })),
+    requestSequence,
+  );
+  transition = reduceSqlResultPagingEvent(
+    transition.state,
+    event('resultFinished', result('backend-finished', { dataList: [], pageNo: 2, pageSize: 5000 })),
+    requestSequence,
+  );
+
+  assert.equal(transition.completedResult?.uuid, 'stable-uuid');
+  assert.equal(transition.completedResult?.displayName, '#4-1 SELECT 1');
+  assert.equal(transition.completedResult?.extra?.resultKey, 'original-execution:1:1');
+  assert.equal(
+    transition.completedResult?.extra?.executionTarget,
+    targetResult.extra?.executionTarget,
+    'the replacement keeps the original datasource snapshot',
+  );
+  assert.deepEqual(transition.completedResult?.dataList, [[{ value: 'page-2-row' }]]);
+});
+
+test('stream paging filters unrelated results and surfaces failed results without an id', () => {
+  const targetResult = result('target-result', {
+    resultSetId: 2,
+    executeSqlParams: { dataSourceId: 11, sql: 'SELECT 1; SELECT 2', resultSetId: 2 },
+  });
+  const request = pagingRequest(targetResult);
+  const requestSequence = 11;
+  let transition = reduceSqlResultPagingEvent(
+    createSqlResultPagingState(requestSequence, request),
+    event('rows', result('unrelated-row', { resultSetId: 1, dataList: [[{ value: 'wrong' }]] as any })),
+    requestSequence,
+  );
+  transition = reduceSqlResultPagingEvent(
+    transition.state,
+    event('resultFinished', result('unrelated-finish', { resultSetId: 1 })),
+    requestSequence,
+  );
+  transition = reduceSqlResultPagingEvent(
+    transition.state,
+    event('updateCount', result('update-count', { resultSetId: 2, updateCount: 1 })),
+    requestSequence,
+  );
+  assert.equal(transition.state.result, undefined);
+  assert.equal(transition.completedResult, undefined);
+
+  transition = reduceSqlResultPagingEvent(
+    transition.state,
+    event('rows', result('target-row', { resultSetId: 2, dataList: [[{ value: 'right' }]] as any })),
+    requestSequence,
+  );
+  transition = reduceSqlResultPagingEvent(
+    transition.state,
+    event('resultFinished', result('target-finish', { resultSetId: 2, dataList: [] })),
+    requestSequence,
+  );
+  assert.deepEqual(transition.completedResult?.dataList, [[{ value: 'right' }]]);
+  assert.equal(transition.completedResult?.resultSetId, 2);
+
+  const failedTransition = reduceSqlResultPagingEvent(
+    createSqlResultPagingState(requestSequence, request),
+    event(
+      'resultFinished',
+      result('failed-result', { resultSetId: undefined, success: false, message: 'paging failed' }),
+    ),
+    requestSequence,
+  );
+  assert.equal(failedTransition.failed, true);
+  assert.equal(failedTransition.errorMessage, 'paging failed');
+  assert.equal(failedTransition.completedResult, undefined);
+  assert.equal(failedTransition.state.result, undefined);
+});
+
+test('web paging rejects failed and non-matching result responses', () => {
+  const targetResult = result('target-result', {
+    resultSetId: 2,
+    executeSqlParams: { dataSourceId: 11, sql: 'SELECT 1; SELECT 2', resultSetId: 2 },
+  });
+  const request = pagingRequest(targetResult);
+
+  assert.throws(
+    () =>
+      resolveSqlResultPagingCompletion(
+        [result('unrelated-result', { resultSetId: 1 })],
+        request,
+        { fallbackErrorMessage: 'No matching result' },
+      ),
+    /No matching result/,
+  );
+  assert.throws(
+    () =>
+      resolveSqlResultPagingCompletion(
+        [result('failed-result', { resultSetId: undefined, success: false, message: 'backend failed' })],
+        request,
+      ),
+    /backend failed/,
+  );
+  const streamedResult = normalizeSqlResultPagingResults(
+    [result('target-page', { resultSetId: 2 })],
+    request,
+  );
+  assert.throws(
+    () =>
+      resolveSqlResultPagingCompletion([], request, {
+        streamedResult,
+        streamFailed: true,
+        streamedErrorMessage: 'late stream failure',
+      }),
+    /late stream failure/,
+  );
+});
+
+test('replace mode keeps the other results from the same multi-statement execution', () => {
+  const firstStatement = result('statement-1', {
+    extra: { executionSequence: 8, executionId: 'execution-8', statementSequence: 1 },
+  });
+  const secondStatement = result('statement-2', {
+    statementSequence: 2,
+    extra: { executionSequence: 8, executionId: 'execution-8', statementSequence: 2 },
+  });
+  const pagedResult = result('backend-page', { dataList: [[{ value: 'updated' }]] as any, pageNo: 2 });
+
+  const next = replaceSqlResultPage([firstStatement, secondStatement], firstStatement, pagedResult);
+
+  assert.equal(next.length, 2, 'keep-history off still preserves sibling statement results');
+  assert.equal(next[0].uuid, 'statement-1');
+  assert.deepEqual(next[0].dataList, [[{ value: 'updated' }]]);
+  assert.equal(next[1], secondStatement);
+});
+
+test('keep-history mode updates only the clicked result across retained batches', () => {
+  const olderResult = result('older-result', {
+    extra: { executionSequence: 7, executionId: 'execution-7', statementSequence: 1 },
+  });
+  const firstStatement = result('statement-1', {
+    extra: { executionSequence: 8, executionId: 'execution-8', statementSequence: 1 },
+  });
+  const secondStatement = result('statement-2', {
+    statementSequence: 2,
+    extra: { executionSequence: 8, executionId: 'execution-8', statementSequence: 2 },
+  });
+  const request = pagingRequest(secondStatement);
+  const pagedResult = normalizeSqlResultPagingResults(
+    [result('backend-page', { dataList: [[{ value: 'updated' }]] as any, pageNo: 2 })],
+    request,
+  )!;
+
+  const next = replaceSqlResultPage([olderResult, firstStatement, secondStatement], secondStatement, pagedResult);
+
+  assert.deepEqual(
+    next.map((item) => item.uuid),
+    ['older-result', 'statement-1', 'statement-2'],
+  );
+  assert.equal(next[0], olderResult);
+  assert.equal(next[1], firstStatement);
+  assert.deepEqual(next[2].dataList, [[{ value: 'updated' }]]);
+});

--- a/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/sqlResultPagingModel.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/SQLExecute/sqlResultPagingModel.ts
@@ -1,0 +1,185 @@
+import type { DataSourceExecutionTarget } from '@/service/dataSourceExecutionSnapshot';
+import type { SqlExecutionEvent } from '@/service/sqlExecutionStream';
+import type { IExecuteSqlParams, IManageResultData } from '@/typings';
+import {
+  createViewTablePagingState,
+  normalizeViewTablePageResults,
+  reduceViewTablePagingEvent,
+  type ViewTablePagingState,
+} from '@/hooks/viewTablePagingModel';
+
+export interface SqlResultPagingRequest {
+  targetResult: IManageResultData;
+  params: IExecuteSqlParams;
+}
+
+export interface SqlResultPagingState extends ViewTablePagingState {
+  targetResult: IManageResultData;
+}
+
+export interface SqlResultPagingTransition {
+  state: SqlResultPagingState;
+  completedResult?: IManageResultData;
+  failed?: boolean;
+  errorMessage?: string;
+}
+
+export function getSqlResultPagingExecutionTarget(result: IManageResultData) {
+  return result.extra?.executionTarget as DataSourceExecutionTarget | undefined;
+}
+
+export function buildSqlResultPagingExecuteParams(
+  targetResult: IManageResultData,
+  params: IExecuteSqlParams,
+): IExecuteSqlParams {
+  const executionTarget = getSqlResultPagingExecutionTarget(targetResult);
+  if (!executionTarget) {
+    return { ...params };
+  }
+  return {
+    ...params,
+    dataSourceId: executionTarget.dataSourceId,
+    dataSourceName: executionTarget.dataSourceName,
+    databaseName: executionTarget.databaseName,
+    databaseType: executionTarget.databaseType,
+    schemaName: executionTarget.schemaName,
+  };
+}
+
+export function createSqlResultPagingState(
+  requestSequence: number,
+  request: SqlResultPagingRequest,
+): SqlResultPagingState {
+  return {
+    ...createViewTablePagingState(requestSequence, request.params),
+    targetResult: request.targetResult,
+  };
+}
+
+export function createSqlResultPagingCancellationResult(targetResult: IManageResultData) {
+  return { ...targetResult };
+}
+
+export function normalizeSqlResultPagingResults(results: IManageResultData[], request: SqlResultPagingRequest) {
+  const normalizedResults = normalizeViewTablePageResults(results, request.params);
+  const resultSetId = request.params.resultSetId ?? request.targetResult.resultSetId;
+  const pagedResult =
+    resultSetId === undefined
+      ? normalizedResults[0]
+      : normalizedResults.find((result) => result.resultSetId === resultSetId);
+  return pagedResult ? mergeSqlResultPage(request.targetResult, pagedResult) : undefined;
+}
+
+export function resolveSqlResultPagingCompletion(
+  results: IManageResultData[],
+  request: SqlResultPagingRequest,
+  options: {
+    streamedResult?: IManageResultData;
+    streamFailed?: boolean;
+    streamedErrorMessage?: string;
+    fallbackErrorMessage?: string;
+  } = {},
+) {
+  const completedResult = options.streamedResult || normalizeSqlResultPagingResults(results, request);
+  if (!options.streamFailed && completedResult && completedResult.success !== false) {
+    return completedResult;
+  }
+  const responseError = results.find((result) => result.success === false)?.message;
+  throw new Error(
+    options.streamedErrorMessage ||
+      completedResult?.message ||
+      responseError ||
+      options.fallbackErrorMessage ||
+      'SQL result paging returned no matching result set',
+  );
+}
+
+export function reduceSqlResultPagingEvent(
+  state: SqlResultPagingState,
+  event: SqlExecutionEvent,
+  requestSequence: number,
+): SqlResultPagingTransition {
+  if (state.requestSequence !== requestSequence) {
+    return { state };
+  }
+  if (isFailedPagingEvent(event)) {
+    return {
+      state,
+      failed: true,
+      errorMessage: getPagingEventErrorMessage(event),
+    };
+  }
+  if (!isTargetPagingResultEvent(state, event)) {
+    return { state };
+  }
+  const viewTableTransition = reduceViewTablePagingEvent(state, event, requestSequence);
+  const nextState = {
+    ...viewTableTransition.state,
+    targetResult: state.targetResult,
+  };
+  return {
+    state: nextState,
+    completedResult: viewTableTransition.completedResult
+      ? mergeSqlResultPage(state.targetResult, viewTableTransition.completedResult)
+      : undefined,
+  };
+}
+
+export function replaceSqlResultPage(
+  current: IManageResultData[],
+  targetResult: IManageResultData,
+  pagedResult: IManageResultData,
+) {
+  const targetIdentity = getPagingIdentity(targetResult);
+  if (!targetIdentity) {
+    return current;
+  }
+  let replaced = false;
+  const next = current.map((result) => {
+    if (replaced || getPagingIdentity(result) !== targetIdentity) {
+      return result;
+    }
+    replaced = true;
+    return mergeSqlResultPage(targetResult, pagedResult);
+  });
+  return replaced ? next : current;
+}
+
+function mergeSqlResultPage(targetResult: IManageResultData, pagedResult: IManageResultData) {
+  return {
+    ...targetResult,
+    ...pagedResult,
+    uuid: targetResult.uuid,
+    displayName: targetResult.displayName,
+    statementSequence: targetResult.statementSequence,
+    extra: {
+      ...(pagedResult.extra || {}),
+      ...(targetResult.extra || {}),
+    },
+  };
+}
+
+function getPagingIdentity(result: IManageResultData) {
+  return result.uuid || result.extra?.resultKey;
+}
+
+function isTargetPagingResultEvent(state: SqlResultPagingState, event: SqlExecutionEvent) {
+  if (
+    event.eventType !== 'resultStarted' &&
+    event.eventType !== 'rows' &&
+    event.eventType !== 'resultFinished'
+  ) {
+    return false;
+  }
+  const expectedResultSetId = state.params.resultSetId ?? state.targetResult.resultSetId;
+  return expectedResultSetId !== undefined && event.message?.resultSetId === expectedResultSetId;
+}
+
+function isFailedPagingEvent(event: SqlExecutionEvent) {
+  return event.eventType === 'failed' || event.message?.success === false;
+}
+
+function getPagingEventErrorMessage(event: SqlExecutionEvent) {
+  const message = event.message?.errorMessage || event.message?.message;
+  return typeof message === 'string' && message ? message : undefined;
+}


### PR DESCRIPTION
Runs pagination, filtering, and refresh against the clicked result data source, replaces that result in place without starting a new execution batch, preserves sibling and pinned history tabs, filters mixed stream events by result-set identity, surfaces failed/no-match responses, and rolls back optimistic paging on cancellation. Includes focused web, desktop, history, and cancellation coverage.