### PR TITLE
fix(jcef): clean up canceled renderer operations

### DIFF
--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
@@ -84,6 +84,7 @@ import java.util.*;
 import java.util.List;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -660,7 +661,7 @@ public class MainJFrame extends JFrame {
                                    boolean persistent, CefQueryCallback callback) {
                 CancellableCefQueryCallback guardedCallback = new CancellableCefQueryCallback(callback);
                 activeQueryCallbacks.put(queryId, guardedCallback);
-                executor.submit(() -> {
+                FutureTask<Void> worker = new FutureTask<>(() -> {
                     String action = "unKnow Action";
                     ConsoleMessage wsMessage = new ConsoleMessage();
                     ConsoleResult wsResult;
@@ -706,7 +707,15 @@ public class MainJFrame extends JFrame {
                     } finally {
                         activeQueryCallbacks.remove(queryId, guardedCallback);
                     }
-                });
+                }, null);
+                guardedCallback.attachWorker(worker);
+                try {
+                    executor.execute(worker);
+                } catch (RuntimeException exception) {
+                    activeQueryCallbacks.remove(queryId, guardedCallback);
+                    guardedCallback.cancel();
+                    throw exception;
+                }
                 return true;
             }
             @Override

--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/utils/ApplicationExitCoordinator.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/utils/ApplicationExitCoordinator.java
@@ -14,8 +14,8 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 
@@ -38,7 +38,8 @@ public final class ApplicationExitCoordinator {
     }
 
     private static final AtomicReference<PendingExit> PENDING_EXIT = new AtomicReference<>();
-    private static final AtomicBoolean FRONTEND_READY = new AtomicBoolean();
+    private static final Object FRONTEND_STATE_LOCK = new Object();
+    private static volatile boolean frontendReady;
 
     private ApplicationExitCoordinator() {
     }
@@ -56,19 +57,35 @@ public final class ApplicationExitCoordinator {
 
     static boolean request(String action, String operationId, BooleanSupplier confirmedAction,
             long acknowledgementTimeoutMillis) {
+        return request(action, operationId, confirmedAction, acknowledgementTimeoutMillis,
+                (task, delayMillis) -> ACK_TIMEOUT_EXECUTOR.schedule(task, delayMillis, TimeUnit.MILLISECONDS));
+    }
+
+    static boolean request(String action, String operationId, BooleanSupplier confirmedAction,
+            long acknowledgementTimeoutMillis, AcknowledgementTimeoutScheduler timeoutScheduler) {
         ExitAction validatedAction = requireAction(action);
         String validatedOperationId = requireOperationId(operationId);
         Objects.requireNonNull(confirmedAction, "Confirmed exit action is required");
-        if (!FRONTEND_READY.get()) {
-            return confirmedAction.getAsBoolean();
+        Objects.requireNonNull(timeoutScheduler, "Acknowledgement timeout scheduler is required");
+        CefBrowser browser;
+        PendingExit pendingExit = new PendingExit(validatedOperationId, confirmedAction);
+        synchronized (FRONTEND_STATE_LOCK) {
+            browser = frontendReady ? JcefContext.getInstance().getBrowser_() : null;
+            if (!PENDING_EXIT.compareAndSet(null, pendingExit)) {
+                return false;
+            }
         }
-        CefBrowser browser = JcefContext.getInstance().getBrowser_();
+        PendingExit dispatchedExit = pendingExit;
         if (browser == null) {
-            return confirmedAction.getAsBoolean();
-        }
-        PendingExit pendingExit = new PendingExit(validatedOperationId, confirmedAction, new AtomicBoolean());
-        if (!PENDING_EXIT.compareAndSet(null, pendingExit)) {
-            return false;
+            PendingExit claimedExit = claimPendingExit(dispatchedExit, false);
+            if (claimedExit == null) {
+                return true;
+            }
+            try {
+                return claimedExit.confirmedAction().getAsBoolean();
+            } finally {
+                releasePendingExit(claimedExit);
+            }
         }
         ConsoleResult result = ConsoleResult.builder()
                 .actionType(ActionTypeEnum.APP_EXIT_REQUESTED.getName())
@@ -80,12 +97,26 @@ public final class ApplicationExitCoordinator {
         try {
             CallJsFunctionUtil.callHandleJavaMessage(browser, JSON.toJSONString(result));
         } catch (RuntimeException exception) {
-            PENDING_EXIT.compareAndSet(pendingExit, null);
-            FRONTEND_READY.set(false);
-            return confirmedAction.getAsBoolean();
+            PendingExit claimedExit;
+            synchronized (FRONTEND_STATE_LOCK) {
+                claimedExit = claimPendingExit(dispatchedExit, false);
+                if (claimedExit != null) {
+                    frontendReady = false;
+                }
+            }
+            return claimedExit == null || runFallback(claimedExit);
         }
-        ACK_TIMEOUT_EXECUTOR.schedule(() -> fallbackIfUnacknowledged(pendingExit),
-                Math.max(1L, acknowledgementTimeoutMillis), TimeUnit.MILLISECONDS);
+        try {
+            ScheduledFuture<?> timeoutFuture = timeoutScheduler.schedule(
+                    () -> fallbackIfUnacknowledged(dispatchedExit),
+                    Math.max(1L, acknowledgementTimeoutMillis));
+            dispatchedExit.attachAcknowledgementTimeout(timeoutFuture);
+        } catch (RuntimeException exception) {
+            log.error("Could not schedule application exit acknowledgement timeout for operation {}",
+                    dispatchedExit.operationId(), exception);
+            PendingExit claimedExit = claimPendingExit(dispatchedExit, false);
+            return claimedExit == null || runFallback(claimedExit);
+        }
         return true;
     }
 
@@ -94,7 +125,9 @@ public final class ApplicationExitCoordinator {
         if (pendingExit == null || operationId == null || !operationId.equals(pendingExit.operationId())) {
             return false;
         }
-        pendingExit.acknowledged().set(true);
+        if (!pendingExit.acknowledge()) {
+            return false;
+        }
         return PENDING_EXIT.get() == pendingExit;
     }
 
@@ -103,34 +136,65 @@ public final class ApplicationExitCoordinator {
         if (pendingExit == null) {
             return false;
         }
-        return pendingExit.confirmedAction().getAsBoolean();
+        try {
+            return pendingExit.confirmedAction().getAsBoolean();
+        } finally {
+            releasePendingExit(pendingExit);
+        }
     }
 
     public static boolean cancel(String operationId) {
-        return takePendingExit(operationId) != null;
+        PendingExit pendingExit = takePendingExit(operationId);
+        if (pendingExit == null) {
+            return false;
+        }
+        releasePendingExit(pendingExit);
+        return true;
     }
 
     public static void markFrontendReady() {
-        FRONTEND_READY.set(true);
+        synchronized (FRONTEND_STATE_LOCK) {
+            frontendReady = true;
+        }
     }
 
     public static boolean isFrontendReady() {
-        return FRONTEND_READY.get();
+        return frontendReady;
     }
 
     public static void markFrontendUnavailable() {
-        FRONTEND_READY.set(false);
+        PendingExit pendingExit;
+        synchronized (FRONTEND_STATE_LOCK) {
+            frontendReady = false;
+            PendingExit currentExit = PENDING_EXIT.get();
+            pendingExit = currentExit == null ? null : claimPendingExit(currentExit, false);
+        }
+        if (pendingExit != null) {
+            runFallback(pendingExit);
+        }
     }
 
     private static void fallbackIfUnacknowledged(PendingExit pendingExit) {
-        if (pendingExit.acknowledged().get() || !PENDING_EXIT.compareAndSet(pendingExit, null)) {
-            return;
+        PendingExit claimedExit;
+        synchronized (FRONTEND_STATE_LOCK) {
+            claimedExit = claimPendingExit(pendingExit, true);
+            if (claimedExit != null) {
+                frontendReady = false;
+            }
         }
-        FRONTEND_READY.set(false);
+        if (claimedExit != null) {
+            runFallback(claimedExit);
+        }
+    }
+
+    private static boolean runFallback(PendingExit pendingExit) {
         try {
-            pendingExit.confirmedAction().getAsBoolean();
+            return pendingExit.confirmedAction().getAsBoolean();
         } catch (RuntimeException exception) {
             log.error("Application exit fallback failed for operation {}", pendingExit.operationId(), exception);
+            return false;
+        } finally {
+            releasePendingExit(pendingExit);
         }
     }
 
@@ -138,15 +202,27 @@ public final class ApplicationExitCoordinator {
         if (operationId == null || operationId.isBlank()) {
             return null;
         }
-        while (true) {
-            PendingExit pendingExit = PENDING_EXIT.get();
-            if (pendingExit == null || !pendingExit.operationId().equals(operationId)) {
-                return null;
-            }
-            if (PENDING_EXIT.compareAndSet(pendingExit, null)) {
-                return pendingExit;
-            }
+        PendingExit pendingExit = PENDING_EXIT.get();
+        if (pendingExit == null || !pendingExit.operationId().equals(operationId)) {
+            return null;
         }
+        return claimPendingExit(pendingExit, false);
+    }
+
+    private static PendingExit claimPendingExit(PendingExit pendingExit, boolean onlyIfUnacknowledged) {
+        boolean claimed = onlyIfUnacknowledged
+                ? pendingExit.claimIfUnacknowledged()
+                : pendingExit.claim();
+        if (!claimed || PENDING_EXIT.get() != pendingExit) {
+            return null;
+        }
+        pendingExit.cancelAcknowledgementTimeout();
+        return pendingExit;
+    }
+
+    private static void releasePendingExit(PendingExit pendingExit) {
+        pendingExit.cancelAcknowledgementTimeout();
+        PENDING_EXIT.compareAndSet(pendingExit, null);
     }
 
     private static void execute(String action) {
@@ -181,6 +257,83 @@ public final class ApplicationExitCoordinator {
         return operationId;
     }
 
-    private record PendingExit(String operationId, BooleanSupplier confirmedAction, AtomicBoolean acknowledged) {
+    private enum PendingExitState {
+        AWAITING_ACKNOWLEDGEMENT,
+        ACKNOWLEDGED,
+        CLAIMED
+    }
+
+    private static final class PendingExit {
+        private final String operationId;
+        private final BooleanSupplier confirmedAction;
+        private final AtomicReference<PendingExitState> state =
+                new AtomicReference<>(PendingExitState.AWAITING_ACKNOWLEDGEMENT);
+        private final AtomicReference<ScheduledFuture<?>> acknowledgementTimeout = new AtomicReference<>();
+
+        private PendingExit(String operationId, BooleanSupplier confirmedAction) {
+            this.operationId = operationId;
+            this.confirmedAction = confirmedAction;
+        }
+
+        private String operationId() {
+            return operationId;
+        }
+
+        private BooleanSupplier confirmedAction() {
+            return confirmedAction;
+        }
+
+        private boolean acknowledge() {
+            if (!state.compareAndSet(PendingExitState.AWAITING_ACKNOWLEDGEMENT,
+                    PendingExitState.ACKNOWLEDGED)) {
+                return false;
+            }
+            cancelAcknowledgementTimeout();
+            return true;
+        }
+
+        private boolean claimIfUnacknowledged() {
+            return state.compareAndSet(PendingExitState.AWAITING_ACKNOWLEDGEMENT,
+                    PendingExitState.CLAIMED);
+        }
+
+        private boolean claim() {
+            while (true) {
+                PendingExitState currentState = state.get();
+                if (currentState == PendingExitState.CLAIMED) {
+                    return false;
+                }
+                if (state.compareAndSet(currentState, PendingExitState.CLAIMED)) {
+                    return true;
+                }
+            }
+        }
+
+        private void attachAcknowledgementTimeout(ScheduledFuture<?> timeoutFuture) {
+            Objects.requireNonNull(timeoutFuture, "Acknowledgement timeout future is required");
+            if (!acknowledgementTimeout.compareAndSet(null, timeoutFuture)) {
+                throw new IllegalStateException("Acknowledgement timeout is already attached");
+            }
+            if (state.get() != PendingExitState.AWAITING_ACKNOWLEDGEMENT) {
+                cancelAcknowledgementTimeout();
+            }
+        }
+
+        private void cancelAcknowledgementTimeout() {
+            ScheduledFuture<?> timeoutFuture = acknowledgementTimeout.getAndSet(null);
+            if (timeoutFuture != null) {
+                try {
+                    timeoutFuture.cancel(false);
+                } catch (RuntimeException exception) {
+                    log.warn("Could not cancel application exit acknowledgement timeout for operation {}",
+                            operationId, exception);
+                }
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface AcknowledgementTimeoutScheduler {
+        ScheduledFuture<?> schedule(Runnable task, long delayMillis);
     }
 }

--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/utils/CancellableCefQueryCallback.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/utils/CancellableCefQueryCallback.java
@@ -3,7 +3,7 @@ package ai.chat2db.community.jcef.utils;
 import org.cef.callback.CefQueryCallback;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.Future;
 
 /**
  * Prevents an asynchronous JCEF handler from completing a query after CEF has
@@ -12,26 +12,60 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public final class CancellableCefQueryCallback implements CefQueryCallback {
 
     private final CefQueryCallback delegate;
-    private final AtomicBoolean completed = new AtomicBoolean();
+    private final Object completionLock = new Object();
+    private boolean completed;
+    private boolean cancelled;
+    private Future<?> worker;
 
     public CancellableCefQueryCallback(CefQueryCallback delegate) {
         this.delegate = Objects.requireNonNull(delegate, "delegate");
     }
 
     public void cancel() {
-        completed.set(true);
+        Future<?> workerFuture;
+        synchronized (completionLock) {
+            completed = true;
+            cancelled = true;
+            workerFuture = worker;
+        }
+        if (workerFuture != null) {
+            workerFuture.cancel(true);
+        }
+    }
+
+    public void attachWorker(Future<?> workerFuture) {
+        Objects.requireNonNull(workerFuture, "workerFuture");
+        boolean cancelWorker;
+        synchronized (completionLock) {
+            if (worker != null) {
+                throw new IllegalStateException("A query callback can only track one worker");
+            }
+            worker = workerFuture;
+            cancelWorker = cancelled;
+        }
+        if (cancelWorker) {
+            workerFuture.cancel(true);
+        }
     }
 
     @Override
     public void success(String response) {
-        if (completed.compareAndSet(false, true)) {
+        synchronized (completionLock) {
+            if (completed) {
+                return;
+            }
+            completed = true;
             delegate.success(response);
         }
     }
 
     @Override
     public void failure(int errorCode, String errorMessage) {
-        if (completed.compareAndSet(false, true)) {
+        synchronized (completionLock) {
+            if (completed) {
+                return;
+            }
+            completed = true;
             delegate.failure(errorCode, errorMessage);
         }
     }

--- a/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/utils/ApplicationExitCoordinatorTest.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/utils/ApplicationExitCoordinatorTest.java
@@ -8,8 +8,19 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Proxy;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,30 +44,231 @@ class ApplicationExitCoordinatorTest {
     }
 
     @Test
-    void unacknowledgedDispatchRunsTheNativeFallback() throws Exception {
-        CountDownLatch fallback = new CountDownLatch(1);
+    void unacknowledgedDispatchRunsTheNativeFallback() {
+        AtomicInteger fallbackCount = new AtomicInteger();
+        ManualTimeoutScheduler scheduler = new ManualTimeoutScheduler();
 
         assertTrue(ApplicationExitCoordinator.request("CLOSE", "ack-timeout-test", () -> {
-            fallback.countDown();
+            fallbackCount.incrementAndGet();
             return true;
-        }, 10L));
+        }, 10L, scheduler));
 
-        assertTrue(fallback.await(1, TimeUnit.SECONDS));
+        assertEquals(0, fallbackCount.get());
+        assertEquals(10L, scheduler.delayMillis);
+        scheduler.runScheduledTask();
+        assertEquals(1, fallbackCount.get());
+        assertTrue(scheduler.timeoutFuture.isCancelled());
         assertFalse(ApplicationExitCoordinator.cancel("ack-timeout-test"));
     }
 
     @Test
-    void acknowledgedDispatchWaitsForTheUserDecision() throws Exception {
-        CountDownLatch fallback = new CountDownLatch(1);
+    void acknowledgedDispatchWaitsForTheUserDecision() {
+        AtomicInteger fallbackCount = new AtomicInteger();
+        ManualTimeoutScheduler scheduler = new ManualTimeoutScheduler();
 
         assertTrue(ApplicationExitCoordinator.request("CLOSE", "acknowledged-test", () -> {
-            fallback.countDown();
+            fallbackCount.incrementAndGet();
             return true;
-        }, 20L));
+        }, 20L, scheduler));
+        assertTrue(ApplicationExitCoordinator.acknowledge("acknowledged-test"));
+        assertTrue(scheduler.timeoutFuture.isCancelled());
+
+        scheduler.runScheduledTask();
+        assertEquals(0, fallbackCount.get());
+        assertTrue(ApplicationExitCoordinator.cancel("acknowledged-test"));
+    }
+
+    @Test
+    void rendererUnavailableFallsBackAndReleasesAcknowledgedRequest() {
+        AtomicInteger fallbackCount = new AtomicInteger();
+        ManualTimeoutScheduler scheduler = new ManualTimeoutScheduler();
+
+        assertTrue(ApplicationExitCoordinator.request("CLOSE", "acknowledged-test", () -> {
+            fallbackCount.incrementAndGet();
+            return true;
+        }, 20L, scheduler));
         assertTrue(ApplicationExitCoordinator.acknowledge("acknowledged-test"));
 
-        assertFalse(fallback.await(100, TimeUnit.MILLISECONDS));
-        assertTrue(ApplicationExitCoordinator.cancel("acknowledged-test"));
+        ApplicationExitCoordinator.markFrontendUnavailable();
+        assertTrue(scheduler.timeoutFuture.isCancelled());
+        scheduler.runScheduledTask();
+
+        assertEquals(1, fallbackCount.get());
+        assertFalse(ApplicationExitCoordinator.cancel("acknowledged-test"));
+        assertTrue(ApplicationExitCoordinator.request("CLOSE", "next-test", () -> {
+            fallbackCount.incrementAndGet();
+            return true;
+        }));
+        assertEquals(2, fallbackCount.get());
+    }
+
+    @Test
+    void acknowledgementAndTimeoutHaveOneAtomicWinner() throws Exception {
+        AtomicInteger fallbackCount = new AtomicInteger();
+        ManualTimeoutScheduler scheduler = new ManualTimeoutScheduler();
+        assertTrue(ApplicationExitCoordinator.request("CLOSE", "race-test", () -> {
+            fallbackCount.incrementAndGet();
+            return true;
+        }, 20L, scheduler));
+
+        CyclicBarrier start = new CyclicBarrier(3);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Boolean> acknowledgement = executor.submit(() -> {
+                start.await();
+                return ApplicationExitCoordinator.acknowledge("race-test");
+            });
+            Future<?> timeout = executor.submit(() -> {
+                start.await();
+                scheduler.runScheduledTask();
+                return null;
+            });
+
+            start.await();
+            boolean acknowledged = acknowledgement.get(1, TimeUnit.SECONDS);
+            timeout.get(1, TimeUnit.SECONDS);
+
+            assertEquals(acknowledged ? 0 : 1, fallbackCount.get());
+            assertEquals(acknowledged, ApplicationExitCoordinator.cancel("race-test"));
+        } finally {
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void terminalDecisionsCancelTheAcknowledgementTimeout() {
+        AtomicInteger confirmedCount = new AtomicInteger();
+        ManualTimeoutScheduler confirmScheduler = new ManualTimeoutScheduler();
+        assertTrue(ApplicationExitCoordinator.request("CLOSE", "confirm-test", () -> {
+            confirmedCount.incrementAndGet();
+            return true;
+        }, 20L, confirmScheduler));
+
+        assertTrue(ApplicationExitCoordinator.confirm("confirm-test"));
+        assertTrue(confirmScheduler.timeoutFuture.isCancelled());
+        confirmScheduler.runScheduledTask();
+        assertEquals(1, confirmedCount.get());
+
+        ApplicationExitCoordinator.markFrontendReady();
+        ManualTimeoutScheduler cancelScheduler = new ManualTimeoutScheduler();
+        assertTrue(ApplicationExitCoordinator.request("CLOSE", "cancel-test", () -> {
+            confirmedCount.incrementAndGet();
+            return true;
+        }, 20L, cancelScheduler));
+
+        assertTrue(ApplicationExitCoordinator.cancel("cancel-test"));
+        assertTrue(cancelScheduler.timeoutFuture.isCancelled());
+        cancelScheduler.runScheduledTask();
+        assertEquals(1, confirmedCount.get());
+    }
+
+    @Test
+    void schedulerRejectionClaimsTheDispatchedRequest() {
+        AtomicInteger fallbackCount = new AtomicInteger();
+
+        assertTrue(ApplicationExitCoordinator.request("CLOSE", "rejection-test", () -> {
+            fallbackCount.incrementAndGet();
+            return true;
+        }, 20L, (task, delayMillis) -> {
+            throw new RejectedExecutionException("scheduler stopped");
+        }));
+
+        assertEquals(1, fallbackCount.get());
+        assertFalse(ApplicationExitCoordinator.cancel("rejection-test"));
+    }
+
+    @Test
+    void timeoutCancellationFailureDoesNotBlockExitDecisions() {
+        AtomicInteger confirmedCount = new AtomicInteger();
+        ManualTimeoutScheduler acknowledgementScheduler = new ManualTimeoutScheduler(true);
+        assertTrue(ApplicationExitCoordinator.request("CLOSE", "acknowledged-test", () -> {
+            confirmedCount.incrementAndGet();
+            return true;
+        }, 20L, acknowledgementScheduler));
+
+        assertTrue(ApplicationExitCoordinator.acknowledge("acknowledged-test"));
+        assertTrue(ApplicationExitCoordinator.confirm("acknowledged-test"));
+        assertEquals(1, confirmedCount.get());
+
+        ApplicationExitCoordinator.markFrontendReady();
+        ManualTimeoutScheduler confirmationScheduler = new ManualTimeoutScheduler(true);
+        assertTrue(ApplicationExitCoordinator.request("CLOSE", "confirm-test", () -> {
+            confirmedCount.incrementAndGet();
+            return true;
+        }, 20L, confirmationScheduler));
+
+        assertTrue(ApplicationExitCoordinator.confirm("confirm-test"));
+        assertEquals(2, confirmedCount.get());
+    }
+
+    @Test
+    void browserUnavailableRejectsAConcurrentDirectFallback() throws Exception {
+        setBrowser(null);
+        ApplicationExitCoordinator.markFrontendReady();
+        AtomicInteger fallbackCount = new AtomicInteger();
+        CountDownLatch fallbackStarted = new CountDownLatch(1);
+        CountDownLatch finishFallback = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Boolean> firstRequest = executor.submit(() -> ApplicationExitCoordinator.request(
+                    "CLOSE", "direct-first", () -> {
+                        fallbackCount.incrementAndGet();
+                        fallbackStarted.countDown();
+                        try {
+                            return finishFallback.await(1, TimeUnit.SECONDS);
+                        } catch (InterruptedException exception) {
+                            Thread.currentThread().interrupt();
+                            return false;
+                        }
+                    }));
+
+            assertTrue(fallbackStarted.await(1, TimeUnit.SECONDS));
+            Future<Boolean> overlappingRequest = executor.submit(() -> ApplicationExitCoordinator.request(
+                    "CLOSE", "direct-second", () -> {
+                        fallbackCount.incrementAndGet();
+                        return true;
+                    }));
+
+            assertFalse(overlappingRequest.get(1, TimeUnit.SECONDS));
+            assertEquals(1, fallbackCount.get());
+            finishFallback.countDown();
+            assertTrue(firstRequest.get(1, TimeUnit.SECONDS));
+        } finally {
+            finishFallback.countDown();
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void rendererUnavailableClaimsARequestPublishedBeforeDispatchCompletes() throws Exception {
+        CountDownLatch dispatchStarted = new CountDownLatch(1);
+        CountDownLatch finishDispatch = new CountDownLatch(1);
+        setBrowser(blockingBrowserProxy(dispatchStarted, finishDispatch));
+        AtomicInteger fallbackCount = new AtomicInteger();
+        ManualTimeoutScheduler scheduler = new ManualTimeoutScheduler();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Boolean> request = executor.submit(() -> ApplicationExitCoordinator.request(
+                    "CLOSE", "publish-race-test", () -> {
+                        fallbackCount.incrementAndGet();
+                        return true;
+                    }, 20L, scheduler));
+
+            assertTrue(dispatchStarted.await(1, TimeUnit.SECONDS));
+            ApplicationExitCoordinator.markFrontendUnavailable();
+            finishDispatch.countDown();
+
+            assertTrue(request.get(1, TimeUnit.SECONDS));
+            assertEquals(1, fallbackCount.get());
+            assertTrue(scheduler.timeoutFuture.isCancelled());
+            assertFalse(ApplicationExitCoordinator.cancel("publish-race-test"));
+        } finally {
+            finishDispatch.countDown();
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+        }
     }
 
     @Test
@@ -91,5 +303,103 @@ class ApplicationExitCoordinatorTest {
                     return null;
                 }
         );
+    }
+
+    private CefBrowser blockingBrowserProxy(CountDownLatch dispatchStarted, CountDownLatch finishDispatch) {
+        return (CefBrowser) Proxy.newProxyInstance(
+                CefBrowser.class.getClassLoader(),
+                new Class<?>[]{CefBrowser.class},
+                (proxy, method, args) -> {
+                    if ("executeJavaScript".equals(method.getName())) {
+                        dispatchStarted.countDown();
+                        if (!finishDispatch.await(1, TimeUnit.SECONDS)) {
+                            throw new IllegalStateException("Timed out waiting to finish dispatch");
+                        }
+                    }
+                    if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    if (method.getReturnType().equals(int.class)) {
+                        return 0;
+                    }
+                    if (method.getReturnType().equals(long.class)) {
+                        return 0L;
+                    }
+                    return null;
+                }
+        );
+    }
+
+    private static final class ManualTimeoutScheduler
+            implements ApplicationExitCoordinator.AcknowledgementTimeoutScheduler {
+        private final AtomicReference<Runnable> scheduledTask = new AtomicReference<>();
+        private final ManualScheduledFuture timeoutFuture;
+        private long delayMillis;
+
+        private ManualTimeoutScheduler() {
+            this(false);
+        }
+
+        private ManualTimeoutScheduler(boolean throwOnCancel) {
+            timeoutFuture = new ManualScheduledFuture(throwOnCancel);
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable task, long delayMillis) {
+            assertTrue(scheduledTask.compareAndSet(null, task));
+            this.delayMillis = delayMillis;
+            return timeoutFuture;
+        }
+
+        private void runScheduledTask() {
+            scheduledTask.get().run();
+        }
+    }
+
+    private static final class ManualScheduledFuture implements ScheduledFuture<Object> {
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+        private final boolean throwOnCancel;
+
+        private ManualScheduledFuture(boolean throwOnCancel) {
+            this.throwOnCancel = throwOnCancel;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return 0L;
+        }
+
+        @Override
+        public int compareTo(Delayed other) {
+            return 0;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            if (throwOnCancel) {
+                throw new IllegalStateException("timeout cancellation failed");
+            }
+            return cancelled.compareAndSet(false, true);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled.get();
+        }
+
+        @Override
+        public boolean isDone() {
+            return cancelled.get();
+        }
+
+        @Override
+        public Object get() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/utils/CancellableCefQueryCallbackTest.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/utils/CancellableCefQueryCallbackTest.java
@@ -3,7 +3,19 @@ package ai.chat2db.community.jcef.utils;
 import org.cef.callback.CefQueryCallback;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CancellableCefQueryCallbackTest {
 
@@ -34,9 +46,106 @@ class CancellableCefQueryCallbackTest {
         assertEquals(0, delegate.failureCount);
     }
 
+    @Test
+    void cancellationInterruptsTheAttachedWorker() throws Exception {
+        RecordingCallback delegate = new RecordingCallback();
+        CancellableCefQueryCallback callback = new CancellableCefQueryCallback(delegate);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch interrupted = new CountDownLatch(1);
+        try {
+            Future<?> worker = executor.submit(() -> {
+                started.countDown();
+                try {
+                    new CountDownLatch(1).await();
+                } catch (InterruptedException exception) {
+                    interrupted.countDown();
+                    Thread.currentThread().interrupt();
+                }
+            });
+            callback.attachWorker(worker);
+            assertTrue(started.await(1, TimeUnit.SECONDS));
+
+            callback.cancel();
+
+            assertTrue(interrupted.await(1, TimeUnit.SECONDS));
+            assertTrue(worker.isCancelled());
+        } finally {
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void workerAttachedAfterCancellationIsCancelledImmediately() {
+        RecordingCallback delegate = new RecordingCallback();
+        CancellableCefQueryCallback callback = new CancellableCefQueryCallback(delegate);
+        RecordingFuture worker = new RecordingFuture();
+
+        callback.cancel();
+        callback.attachWorker(worker);
+
+        assertTrue(worker.cancelled);
+        assertTrue(worker.mayInterruptIfRunning);
+    }
+
+    @Test
+    void boundFutureDoesNotRunWhenCancelledBeforeExecutorStartsIt() {
+        RecordingCallback delegate = new RecordingCallback();
+        CancellableCefQueryCallback callback = new CancellableCefQueryCallback(delegate);
+        ControlledExecutor executor = new ControlledExecutor();
+        AtomicInteger runCount = new AtomicInteger();
+        FutureTask<Void> worker = new FutureTask<>(() -> {
+            runCount.incrementAndGet();
+            return null;
+        });
+
+        callback.attachWorker(worker);
+        executor.execute(worker);
+        callback.cancel();
+        executor.runPending();
+
+        assertTrue(worker.isCancelled());
+        assertEquals(0, runCount.get());
+    }
+
+    @Test
+    void cancellationCannotInterleaveWithNativeCallbackInvocation() throws Exception {
+        CountDownLatch callbackEntered = new CountDownLatch(1);
+        CountDownLatch finishCallback = new CountDownLatch(1);
+        CountDownLatch cancellationStarted = new CountDownLatch(1);
+        CountDownLatch cancellationReturned = new CountDownLatch(1);
+        BlockingCallback delegate = new BlockingCallback(callbackEntered, finishCallback);
+        CancellableCefQueryCallback callback = new CancellableCefQueryCallback(delegate);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> completion = executor.submit(() -> callback.success("response"));
+            assertTrue(callbackEntered.await(1, TimeUnit.SECONDS));
+            Future<?> cancellation = executor.submit(() -> {
+                cancellationStarted.countDown();
+                callback.cancel();
+                cancellationReturned.countDown();
+            });
+
+            assertTrue(cancellationStarted.await(1, TimeUnit.SECONDS));
+            assertFalse(cancellationReturned.await(100, TimeUnit.MILLISECONDS));
+            finishCallback.countDown();
+
+            completion.get(1, TimeUnit.SECONDS);
+            cancellation.get(1, TimeUnit.SECONDS);
+            callback.failure(500, "late");
+            assertEquals(1, delegate.successCount);
+            assertEquals(0, delegate.failureCount);
+        } finally {
+            finishCallback.countDown();
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+        }
+    }
+
     private static class RecordingCallback implements CefQueryCallback {
-        private int successCount;
-        private int failureCount;
+        protected int successCount;
+        protected int failureCount;
         private String response;
 
         @Override
@@ -48,6 +157,75 @@ class CancellableCefQueryCallbackTest {
         @Override
         public void failure(int errorCode, String errorMessage) {
             failureCount++;
+        }
+    }
+
+    private static final class BlockingCallback extends RecordingCallback {
+        private final CountDownLatch entered;
+        private final CountDownLatch finish;
+
+        private BlockingCallback(CountDownLatch entered, CountDownLatch finish) {
+            this.entered = entered;
+            this.finish = finish;
+        }
+
+        @Override
+        public void success(String value) {
+            entered.countDown();
+            try {
+                if (!finish.await(1, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to finish callback");
+                }
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Callback interrupted", exception);
+            }
+            super.success(value);
+        }
+    }
+
+    private static final class RecordingFuture implements Future<Object> {
+        private boolean cancelled;
+        private boolean mayInterruptIfRunning;
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            cancelled = true;
+            this.mayInterruptIfRunning = mayInterruptIfRunning;
+            return true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+
+        @Override
+        public boolean isDone() {
+            return cancelled;
+        }
+
+        @Override
+        public Object get() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class ControlledExecutor implements Executor {
+        private final AtomicReference<Runnable> pending = new AtomicReference<>();
+
+        @Override
+        public void execute(Runnable command) {
+            assertTrue(pending.compareAndSet(null, command));
+        }
+
+        private void runPending() {
+            pending.get().run();
         }
     }
 }


### PR DESCRIPTION
Linearizes desktop exit acknowledgement, timeout, renderer-unavailable and direct fallback states; safely owns timeout handles; binds FutureTask before execution; and serializes native callback completion with cancellation. Includes deterministic scheduler, executor, latch, and race tests without GUI dependencies.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head 1acc66ee4.
- Affected ApplicationExitCoordinator and CancellableCefQueryCallback tests: 16/16 passed.
- Full JCEF run on Windows: 85 passed, 2 skipped, with only the unrelated current-main RestartCommandFactory macOS-path assertion failing because Windows resolves /Applications onto the current drive.