### PR TITLE
fix(tree): invalidate collapsed caches during search refresh

### DIFF
--- a/chat2db-community-client/src/blocks/NewTree/components/TitleRender/index.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/components/TitleRender/index.tsx
@@ -13,6 +13,10 @@ import Filtration from '../Filtration';
 import { splitSearchHighlight } from './highlightSearchText';
 import { resolveTreeSwitcherAction } from './switcherAction';
 import { resolveTreeNodeSelection } from '../../utils/treeNodePath';
+import {
+  mergeWorkspaceTreeSearchExpandedKeys,
+  resolveWorkspaceTreeExpandedKeys,
+} from '@/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle';
 
 interface IProps {
   className?: string;
@@ -33,10 +37,12 @@ const TitleRender = (props: IProps) => {
     setEditingTreeNode,
     setTreeData,
     handleLoadData,
-    expandedKeys,
+    persistentExpandedKeys,
+    searchRequiredExpandedKeys,
+    invalidatedTreeNodeKeys,
     selectedKeys,
     setSelectedKeys,
-    setExpandedKeys,
+    setSearchRequiredExpandedKeys,
     setCurrentTreeNode,
     searchBarValue,
     regularSearchBarValue,
@@ -49,10 +55,12 @@ const TitleRender = (props: IProps) => {
     setEditingTreeNode: state.setEditingTreeNode,
     setTreeData: state.setTreeData,
     handleLoadData: state.handleLoadData,
-    expandedKeys: state.expandedKeys,
+    persistentExpandedKeys: state.expandedKeys,
+    searchRequiredExpandedKeys: state.searchRequiredExpandedKeys,
+    invalidatedTreeNodeKeys: state.invalidatedTreeNodeKeys,
     setSelectedKeys: state.setSelectedKeys,
     selectedKeys: state.selectedKeys,
-    setExpandedKeys: state.setExpandedKeys,
+    setSearchRequiredExpandedKeys: state.setSearchRequiredExpandedKeys,
     setCurrentTreeNode: state.setCurrentTreeNode,
     searchBarValue: state.searchBarValue,
     regularSearchBarValue: state.regularSearchBarValue,
@@ -61,6 +69,15 @@ const TitleRender = (props: IProps) => {
     treeData: state.treeData,
     userConfigTree: state.userConfigTree,
   }));
+  const expandedKeys = useMemo(
+    () =>
+      resolveWorkspaceTreeExpandedKeys(
+        persistentExpandedKeys,
+        searchRequiredExpandedKeys,
+        invalidatedTreeNodeKeys,
+      ),
+    [persistentExpandedKeys, searchRequiredExpandedKeys, invalidatedTreeNodeKeys],
+  );
 
   const isExpanded = useMemo(() => expandedKeys.includes(nodeData.key), [expandedKeys, nodeData.key]);
 
@@ -75,7 +92,9 @@ const TitleRender = (props: IProps) => {
     if (searchBarValue && selection.ancestors.length) {
       // Search renders a filtered copy. Keep the search session active while
       // rebinding selection to the source node and its stable ancestor path.
-      setExpandedKeys(Array.from(new Set([...expandedKeys, ...selection.ancestors])));
+      setSearchRequiredExpandedKeys(
+        mergeWorkspaceTreeSearchExpandedKeys(searchRequiredExpandedKeys, selection.ancestors),
+      );
     }
 
     setCurrentTreeNode(selectedNode);
@@ -93,7 +112,7 @@ const TitleRender = (props: IProps) => {
     }
     // Expanded node, collapse
     if (expandedKeys.includes(nodeData.key)) {
-      setExpandedKeys(expandedKeys.filter((key) => key !== nodeData.key));
+      toggleExpandedKeys(nodeData.key);
       return;
     }
     setIsLoading(true);

--- a/chat2db-community-client/src/blocks/NewTree/index.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/index.tsx
@@ -24,6 +24,10 @@ import connectionService from '@/service/connection';
 import { useSize } from 'ahooks';
 import { decorateDataSourceIdentityTree } from './dataSourceIdentity';
 import { measureTreeScrollWidth, resolveNextTreeScrollWidth } from './treeScrollWidth';
+import {
+  maskInvalidatedWorkspaceTreeChildren,
+  resolveWorkspaceTreeExpandedKeys,
+} from '@/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle';
 
 interface IProps extends TreeProps<TreeNodeData> {
   className?: string;
@@ -78,7 +82,9 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
     selectedKeys,
     setSelectedKeys,
     setTreeRef,
-    expandedKeys,
+    persistentExpandedKeys,
+    searchRequiredExpandedKeys,
+    invalidatedTreeNodeKeys,
     scrollTargetKey,
     setScrollTargetKey,
     searchBarValue,
@@ -89,15 +95,33 @@ const NewTree = (props: IProps, ref: React.ForwardedRef<NewTreeRef>) => {
     selectedKeys: state.selectedKeys,
     setSelectedKeys: state.setSelectedKeys,
     setTreeRef: state.setTreeRef,
-    expandedKeys: state.expandedKeys,
+    persistentExpandedKeys: state.expandedKeys,
+    searchRequiredExpandedKeys: state.searchRequiredExpandedKeys,
+    invalidatedTreeNodeKeys: state.invalidatedTreeNodeKeys,
     scrollTargetKey: state.scrollTargetKey,
     setScrollTargetKey: state.setScrollTargetKey,
     searchBarValue: state.searchBarValue,
     dataSourceList: state.dataSourceList,
   }));
+  const expandedKeys = useMemo(
+    () =>
+      resolveWorkspaceTreeExpandedKeys(
+        persistentExpandedKeys,
+        searchRequiredExpandedKeys,
+        invalidatedTreeNodeKeys,
+      ),
+    [persistentExpandedKeys, searchRequiredExpandedKeys, invalidatedTreeNodeKeys],
+  );
+  const renderedTreeData = useMemo(
+    () =>
+      filteredTreeData
+        ? maskInvalidatedWorkspaceTreeChildren(filteredTreeData, invalidatedTreeNodeKeys)
+        : filteredTreeData,
+    [filteredTreeData, invalidatedTreeNodeKeys],
+  );
   const identityTreeData = useMemo(
-    () => decorateDataSourceIdentityTree(filteredTreeData, dataSourceList),
-    [filteredTreeData, dataSourceList],
+    () => decorateDataSourceIdentityTree(renderedTreeData, dataSourceList),
+    [renderedTreeData, dataSourceList],
   );
   const shortcutOverrides = useGlobalStore((state) => state.shortcutOverrides);
   const shortcutConfig = useMemo(

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/loadDatabaseTreePath.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/loadDatabaseTreePath.test.ts
@@ -146,12 +146,46 @@ async function testMissingDescendantLeavesLoadedAncestorAvailableForFallback() {
   assert.deepEqual(expandedKeys, ['dataSource_1']);
 }
 
+async function testInvalidatedLoadedNodeReloadsBeforePathExpansion() {
+  const oldDatabase = node('database_old', []);
+  const newDatabase = node('database_new', []);
+  const dataSource = node('dataSource_1', [oldDatabase]);
+  let treeData = [dataSource];
+  let expandedKeys: Key[] = [];
+  let loadCount = 0;
+  const store = {
+    get treeData() {
+      return treeData;
+    },
+    get expandedKeys() {
+      return expandedKeys;
+    },
+    invalidatedTreeNodeKeys: ['dataSource_1'],
+    async handleLoadData() {
+      loadCount += 1;
+      dataSource.children = [newDatabase];
+      treeData = [dataSource];
+      return { children: [newDatabase], committed: true };
+    },
+    setExpandedKeys(keys: Key[]) {
+      expandedKeys = keys;
+    },
+  };
+
+  const loaded = await loadDatabaseTreePath(['dataSource_1', 'database_new'], () => store, () => true);
+
+  assert.equal(loaded, true);
+  assert.equal(loadCount, 1);
+  assert.deepEqual(expandedKeys, ['dataSource_1', 'database_new']);
+}
+
 Promise.all([
   testSuccessfulPathLoadsSilentlyAndExpandsEachCurrentStep(),
   testCancelledPathDoesNotExpandAfterPendingLoadSettles(),
   testClearedTreeDoesNotReceiveExpansionFromPendingLoad(),
   testSupersededLoadDoesNotExpandOrContinuePath(),
   testMissingDescendantLeavesLoadedAncestorAvailableForFallback(),
+  testInvalidatedLoadedNodeReloadsBeforePathExpansion(),
 ])
   .then(() => {
     console.log('Database tree path loading tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/loadDatabaseTreePath.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/loadDatabaseTreePath.ts
@@ -5,6 +5,7 @@ import type { Key } from 'react';
 interface DatabaseTreePathStore {
   treeData: TreeNodeData[] | null;
   expandedKeys: Key[];
+  invalidatedTreeNodeKeys?: Key[];
   handleLoadData: (node: TreeNodeData, options?: ILoadDataOptions) => Promise<ILoadDataResult>;
   setExpandedKeys: (keys: Key[]) => void;
 }
@@ -42,7 +43,10 @@ export async function loadDatabaseTreePath(
       break;
     }
 
-    if (node.children === undefined && !node.isLeaf) {
+    if (
+      !node.isLeaf &&
+      (node.children === undefined || treeStore.invalidatedTreeNodeKeys?.includes(node.key))
+    ) {
       try {
         const loadResult = await treeStore.handleLoadData(node, {
           closeExpandTreeNode: true,

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/index.tsx
@@ -3,9 +3,8 @@ import { useUpdateEffect } from 'ahooks';
 import { debounce } from 'lodash';
 
 import { useTreeStore } from '@/store/tree';
-import { searchTreeNodes } from '@/utils';
-import { filterTreeNodesForDisplay } from '@/utils/filterTreeNodes';
 import WorkspaceHeaderSearch from '../WorkspaceHeaderSearch';
+import { resolveWorkspaceTreeSearch } from './lifecycle';
 
 const WorkspaceTreeSearch = () => {
   const { searchBarValue, setSearchBarValue, searchResultKeys, hiddenTreeNodeIds } = useTreeStore((state) => ({
@@ -18,6 +17,7 @@ const WorkspaceTreeSearch = () => {
     const treeStore = useTreeStore.getState();
     treeStore.setSearchResult(null);
     treeStore.setSearchResultKeys(null);
+    treeStore.setSearchRequiredExpandedKeys([]);
   }, []);
 
   const debouncedSearch = useCallback(
@@ -27,15 +27,18 @@ const WorkspaceTreeSearch = () => {
       if (!value) {
         treeStore.setSearchResult(null);
         treeStore.setSearchResultKeys(null);
+        treeStore.setSearchRequiredExpandedKeys([]);
         return;
       }
-      const visibleTreeData = filterTreeNodesForDisplay(treeStore.treeData || [], {
-        hiddenTreeNodeIds: treeStore.hiddenTreeNodeIds,
-      });
-      const { matchedNodes, matchedKeys, parentIdsWithMatches } = searchTreeNodes(visibleTreeData, value);
-      treeStore.setSearchResult(matchedNodes);
-      treeStore.setSearchResultKeys(matchedKeys);
-      treeStore.setExpandedKeys([...parentIdsWithMatches, ...treeStore.expandedKeys]);
+      const searchState = resolveWorkspaceTreeSearch(
+        treeStore.treeData || [],
+        value,
+        treeStore.hiddenTreeNodeIds,
+        treeStore.invalidatedTreeNodeKeys,
+      );
+      treeStore.setSearchResult(searchState.matchedNodes);
+      treeStore.setSearchResultKeys(searchState.matchedKeys);
+      treeStore.setSearchRequiredExpandedKeys(searchState.requiredExpandedKeys);
     }, 300),
     [],
   );

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle.test.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import {
   collectExpandedWorkspaceTreeNodeKeys,
+  createWorkspaceTreeSearchQueryState,
   mergeWorkspaceTreeSearchExpandedKeys,
+  resolveWorkspaceTreeSearch,
   transitionWorkspaceTreeSearchQuery,
   type WorkspaceTreeSearchEvent,
 } from './lifecycle';
@@ -33,6 +35,19 @@ assert.equal(transitionWorkspaceTreeSearchQuery(query, { type: 'query-change', v
 assert.equal(transitionWorkspaceTreeSearchQuery(query, { type: 'exit' }), '');
 
 assert.deepEqual(
+  createWorkspaceTreeSearchQueryState('new.query', 4),
+  {
+    searchBarValue: 'new.query',
+    regularSearchBarValue: 'new\\.query',
+    searchResultKeys: null,
+    searchResult: null,
+    searchRequiredExpandedKeys: [],
+    searchRevision: 5,
+  },
+  'a query change must synchronously retire pre-debounce expansion paths and advance its revision',
+);
+
+assert.deepEqual(
   mergeWorkspaceTreeSearchExpandedKeys(
     ['dataSource_1', 'database_app', 'tables', 'table_sms_course_sections'],
     ['dataSource_1', 'database_app', 'tables'],
@@ -44,16 +59,20 @@ assert.deepEqual(
 const tree = [
   {
     key: 'dataSource_1',
+    originalTitle: 'primary',
     children: [
       {
         key: 'database_app',
+        originalTitle: 'app',
         children: [
           {
             key: 'tables',
+            originalTitle: 'tables',
             children: [
               {
                 key: 'table_sms_course_sections',
-                children: [{ key: 'columns', children: [] }],
+                originalTitle: 'sms_course_sections',
+                children: [{ key: 'columns', originalTitle: 'columns', children: [] }],
               },
             ],
           },
@@ -77,6 +96,38 @@ assert.deepEqual(
   mergeWorkspaceTreeSearchExpandedKeys(['dataSource_1'], ['dataSource_1', 'database_app', 'tables']),
   ['dataSource_1', 'database_app', 'tables'],
   'search must add newly required ancestor paths without duplicates',
+);
+
+const currentSearch = resolveWorkspaceTreeSearch(tree, 'smscourses', null);
+assert.deepEqual(
+  currentSearch.requiredExpandedKeys,
+  ['tables', 'database_app', 'dataSource_1'],
+  'required expansion paths must be derived from the current query rather than historical expanded keys',
+);
+assert.deepEqual(
+  resolveWorkspaceTreeSearch(tree, 'smscourses', null, ['tables']),
+  { matchedNodes: [], matchedKeys: [], requiredExpandedKeys: [] },
+  'search must not expose descendants from a logically invalidated cache',
+);
+
+const staleHistoryTree = [
+  {
+    key: 'old-root',
+    children: [{ key: 'old-child', children: [{ key: 'old-grandchild', children: [] }] }],
+  },
+  {
+    key: 'current-root',
+    children: [{ key: 'current-child', children: [] }],
+  },
+] as TreeNodeData[];
+assert.deepEqual(
+  collectExpandedWorkspaceTreeNodeKeys(
+    staleHistoryTree,
+    ['old-child', 'old-grandchild'],
+    ['current-root', 'current-child'],
+  ),
+  ['current-root', 'current-child'],
+  'descendant keys from a collapsed historical branch must not preserve or refresh its caches',
 );
 
 console.log('Workspace tree search lifecycle tests passed');

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle.ts
@@ -1,5 +1,7 @@
 import type { Key } from 'react';
 import type { TreeNodeData } from '@/typings';
+import { filterTreeNodesForDisplay } from '@/utils/filterTreeNodes';
+import { searchTreeNodes } from '@/utils/searchTreeNodes';
 
 export type WorkspaceTreeSearchEvent =
   | { type: 'query-change'; value: string }
@@ -32,16 +34,99 @@ export function mergeWorkspaceTreeSearchExpandedKeys(currentKeys: Key[], require
   return Array.from(new Set([...currentKeys, ...requiredParentKeys]));
 }
 
-export function collectExpandedWorkspaceTreeNodeKeys(treeData: TreeNodeData[], expandedKeys: Key[]) {
-  const expandedKeySet = new Set(expandedKeys);
+export function resolveWorkspaceTreeExpandedKeys(
+  expandedKeys: Key[],
+  searchRequiredExpandedKeys: Key[],
+  invalidatedTreeNodeKeys: Key[] = [],
+) {
+  const invalidatedKeySet = new Set(invalidatedTreeNodeKeys);
+  return mergeWorkspaceTreeSearchExpandedKeys(expandedKeys, searchRequiredExpandedKeys).filter(
+    (key) => !invalidatedKeySet.has(key),
+  );
+}
+
+export function maskInvalidatedWorkspaceTreeChildren(
+  treeData: TreeNodeData[],
+  invalidatedTreeNodeKeys: Key[],
+): TreeNodeData[] {
+  if (!invalidatedTreeNodeKeys.length) {
+    return treeData;
+  }
+  const invalidatedKeySet = new Set(invalidatedTreeNodeKeys);
+  const maskNodes = (nodes: TreeNodeData[]): TreeNodeData[] =>
+    nodes.map((node) => ({
+      ...node,
+      children: invalidatedKeySet.has(node.key)
+        ? undefined
+        : node.children
+          ? maskNodes(node.children)
+          : undefined,
+    }));
+  return maskNodes(treeData);
+}
+
+export function createWorkspaceTreeSearchQueryState(searchBarValue: string, searchRevision: number) {
+  return {
+    searchBarValue,
+    regularSearchBarValue: searchBarValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    searchResultKeys: null,
+    searchResult: null,
+    searchRequiredExpandedKeys: [] as Key[],
+    searchRevision: searchRevision + 1,
+  };
+}
+
+export function resolveWorkspaceTreeSearch(
+  treeData: TreeNodeData[],
+  regularSearchBarValue: string,
+  hiddenTreeNodeIds?: Record<string, string[]> | null,
+  invalidatedTreeNodeKeys: Key[] = [],
+) {
+  if (!regularSearchBarValue) {
+    return {
+      matchedNodes: null,
+      matchedKeys: null,
+      requiredExpandedKeys: [] as Key[],
+    };
+  }
+  const visibleTreeData = filterTreeNodesForDisplay(
+    maskInvalidatedWorkspaceTreeChildren(treeData, invalidatedTreeNodeKeys),
+    {
+    hiddenTreeNodeIds,
+    },
+  );
+  const { matchedNodes, matchedKeys, parentIdsWithMatches } = searchTreeNodes(
+    visibleTreeData,
+    regularSearchBarValue,
+  );
+  return {
+    matchedNodes,
+    matchedKeys,
+    requiredExpandedKeys: parentIdsWithMatches as Key[],
+  };
+}
+
+export function collectExpandedWorkspaceTreeNodeKeys(
+  treeData: TreeNodeData[],
+  expandedKeys: Key[],
+  searchRequiredExpandedKeys: Key[] = [],
+  invalidatedTreeNodeKeys: Key[] = [],
+) {
+  const effectiveExpandedKeys = resolveWorkspaceTreeExpandedKeys(
+    expandedKeys,
+    searchRequiredExpandedKeys,
+    invalidatedTreeNodeKeys,
+  );
+  const expandedKeySet = new Set(effectiveExpandedKeys);
   const refreshTargetKeys: Key[] = [];
 
   const visit = (nodes: TreeNodeData[]) => {
     nodes.forEach((node) => {
-      if (expandedKeySet.has(node.key) && !node.isLeaf && node.children !== undefined) {
+      const expanded = expandedKeySet.has(node.key);
+      if (expanded && !node.isLeaf && node.children !== undefined) {
         refreshTargetKeys.push(node.key);
       }
-      if (node.children) {
+      if (expanded && node.children) {
         visit(node.children);
       }
     });

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/refresh.test.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/refresh.test.ts
@@ -22,7 +22,10 @@ async function testQueryChangeDuringRootRefresh() {
   });
   const state: IWorkspaceTreeRefreshState = {
     expandedKeys: ['old-root'],
+    searchRequiredExpandedKeys: [],
+    invalidatedTreeNodeKeys: [],
     searchBarValue: 'old_query',
+    searchRevision: 1,
     treeData: [node('old-root')],
     treeDataRevision: 1,
   };
@@ -37,7 +40,9 @@ async function testQueryChangeDuringRootRefresh() {
   });
 
   state.searchBarValue = 'new_query';
-  state.expandedKeys = ['dataSource_1', 'database_app', 'tables'];
+  state.searchRevision = 2;
+  state.expandedKeys = [];
+  state.searchRequiredExpandedKeys = ['dataSource_1', 'database_app', 'tables'];
   state.treeData = [node('dataSource_1', [node('database_app', [node('tables')])])];
   state.treeDataRevision = 2;
   resolveRoot(true);
@@ -49,7 +54,10 @@ async function testQueryChangeDuringRootRefresh() {
 async function testNewRootRevisionStopsOlderContinuation() {
   const state: IWorkspaceTreeRefreshState = {
     expandedKeys: ['dataSource_1', 'database_app'],
+    searchRequiredExpandedKeys: [],
+    invalidatedTreeNodeKeys: [],
     searchBarValue: 'orders',
+    searchRevision: 1,
     treeData: [node('dataSource_1', [node('database_app')])],
     treeDataRevision: 7,
   };
@@ -72,7 +80,10 @@ async function testNewRootRevisionStopsOlderContinuation() {
 async function testChildRefreshFailureIsReported() {
   const state: IWorkspaceTreeRefreshState = {
     expandedKeys: ['dataSource_1'],
+    searchRequiredExpandedKeys: [],
+    invalidatedTreeNodeKeys: [],
     searchBarValue: 'orders',
+    searchRevision: 1,
     treeData: [node('dataSource_1')],
     treeDataRevision: 1,
   };
@@ -90,10 +101,39 @@ async function testChildRefreshFailureIsReported() {
   );
 }
 
+async function testQueryChangeStopsTheOlderSearchContinuation() {
+  const state: IWorkspaceTreeRefreshState = {
+    expandedKeys: [],
+    searchRequiredExpandedKeys: ['dataSource_1', 'database_app'],
+    invalidatedTreeNodeKeys: [],
+    searchBarValue: 'old_query',
+    searchRevision: 3,
+    treeData: [node('dataSource_1', [node('database_app')])],
+    treeDataRevision: 5,
+  };
+  const refreshedKeys: Key[] = [];
+
+  const result = await refreshWorkspaceTreeData({
+    findNode,
+    getState: () => state,
+    refreshNode: async (current) => {
+      refreshedKeys.push(current.key);
+      state.searchBarValue = 'new_query';
+      state.searchRequiredExpandedKeys = [];
+      state.searchRevision += 1;
+    },
+    refreshRoot: async () => true,
+  });
+
+  assert.equal(result, true);
+  assert.deepEqual(refreshedKeys, ['dataSource_1']);
+}
+
 async function main() {
   await testQueryChangeDuringRootRefresh();
   await testNewRootRevisionStopsOlderContinuation();
   await testChildRefreshFailureIsReported();
+  await testQueryChangeStopsTheOlderSearchContinuation();
   console.log('Workspace tree refresh lifecycle tests passed');
 }
 

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/refresh.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTreeSearch/refresh.ts
@@ -4,7 +4,10 @@ import { collectExpandedWorkspaceTreeNodeKeys } from './lifecycle';
 
 export interface IWorkspaceTreeRefreshState {
   expandedKeys: Key[];
+  searchRequiredExpandedKeys: Key[];
+  invalidatedTreeNodeKeys: Key[];
   searchBarValue: string;
+  searchRevision: number;
   treeData: TreeNodeData[] | null;
   treeDataRevision: number;
 }
@@ -31,12 +34,18 @@ export async function refreshWorkspaceTreeData({
   const refreshTargetKeys = collectExpandedWorkspaceTreeNodeKeys(
     refreshedState.treeData,
     refreshedState.expandedKeys,
+    refreshedState.searchRequiredExpandedKeys,
+    refreshedState.invalidatedTreeNodeKeys,
   );
   const treeDataRevision = refreshedState.treeDataRevision;
+  const searchRevision = refreshedState.searchRevision;
 
   for (const key of refreshTargetKeys) {
     const currentState = getState();
-    if (currentState.treeDataRevision !== treeDataRevision) {
+    if (
+      currentState.treeDataRevision !== treeDataRevision ||
+      currentState.searchRevision !== searchRevision
+    ) {
       return true;
     }
     if (!currentState.treeData) {

--- a/chat2db-community-client/src/store/tree/index.tsx
+++ b/chat2db-community-client/src/store/tree/index.tsx
@@ -11,8 +11,7 @@ import { dataSourceTreeService } from '@/database';
 import connectionService from '@/service/connection';
 import { IConnectionDetails, IUserConfigTree, TreeNodeData } from '@/typings';
 import { GetTreeNodeKeyParams, UpdatePositionInTree } from '@/typings/tree';
-import { findNode, getParentNode, removeSubkeys, searchTreeNodes } from '@/utils';
-import { filterTreeNodesForDisplay } from '@/utils/filterTreeNodes';
+import { findNode, getParentNode, removeSubkeys } from '@/utils';
 import React from 'react';
 import { PersistOptions, devtools, persist } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
@@ -32,12 +31,16 @@ import { LatestLoadCoordinator, loadNamespaceTree } from './loadNamespaceTree';
 import {
   appendExpandedTreeKey,
   isDataSourceTreeNodeKey,
+  mergeLoadedTreeDataForSearchRefresh,
   removeTreeNodeByKey,
   resolveLoadedTreeData,
+  updateInvalidatedTreeNodeKeys,
 } from './treeDataUpdate';
 import { neatenDataSourceTreeNode, neatenDataSourcesList, neatenTreeData } from './utils';
 import {
-  mergeWorkspaceTreeSearchExpandedKeys,
+  collectExpandedWorkspaceTreeNodeKeys,
+  createWorkspaceTreeSearchQueryState,
+  resolveWorkspaceTreeSearch,
 } from '@/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle';
 import { refreshWorkspaceTreeData } from '@/pages/main/workspace/components/WorkspaceTreeSearch/refresh';
 import {
@@ -74,7 +77,10 @@ export interface TreeState {
   isModalVisible: boolean;
   dataList: { key: React.Key; title: string }[];
   expandedKeys: React.Key[];
+  searchRequiredExpandedKeys: React.Key[];
+  invalidatedTreeNodeKeys: React.Key[];
   searchBarValue: string;
+  searchRevision: number;
   // This value is escaped before tree search so brackets and other special characters remain valid.
   regularSearchBarValue: string;
   searchResultKeys: string[] | null;
@@ -103,7 +109,10 @@ export const initTreeState = {
   isModalVisible: false,
   dataList: [],
   expandedKeys: [],
+  searchRequiredExpandedKeys: [],
+  invalidatedTreeNodeKeys: [],
   searchBarValue: '',
+  searchRevision: 0,
   regularSearchBarValue: '',
   searchResultKeys: null,
   // Search results
@@ -137,6 +146,7 @@ export interface TreeAction {
   setConnectionDetail: (connectionDetail: TreeState['connectionDetail']) => void;
   handleLoadData: (nodeData: TreeNodeData, options?: ILoadDataOptions) => Promise<ILoadDataResult>;
   setExpandedKeys: (expandedKeys: React.Key[]) => void;
+  setSearchRequiredExpandedKeys: (expandedKeys: React.Key[]) => void;
   toggleExpandedKeys: (key: React.Key) => void;
   deleteDataSource: (dataSource: any) => Promise<void>;
   setSearchBarValue: (searchBarValue: string) => void;
@@ -200,6 +210,30 @@ const invalidateTreeRequests = () => {
 };
 
 export type TreeStore = TreeState & TreeAction;
+
+const resolveCurrentSearchRequiredKeys = (state: TreeState, treeData = state.treeData || []) =>
+  resolveWorkspaceTreeSearch(
+    treeData,
+    state.regularSearchBarValue,
+    state.hiddenTreeNodeIds,
+    state.invalidatedTreeNodeKeys,
+  ).requiredExpandedKeys;
+
+const collectSubtreeKeys = (nodes: TreeNodeData[] | undefined): React.Key[] => {
+  const keys: React.Key[] = [];
+  const visit = (currentNodes: TreeNodeData[]) => {
+    currentNodes.forEach((node) => {
+      keys.push(node.key);
+      if (node.children) {
+        visit(node.children);
+      }
+    });
+  };
+  if (nodes) {
+    visit(nodes);
+  }
+  return keys;
+};
 
 export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', never]], [], TreeAction> = (set, get) => ({
   setEditingTreeNode: (editingTreeNode) => {
@@ -272,11 +306,36 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
           set({ currentLoadingTreeNode: null });
         }
         const freshTreeData = neatenTreeData(result.items);
-        const treeData = resolveLoadedTreeData(
-          freshTreeData,
-          get().treeData,
-          refresh && !get().searchBarValue,
-        );
+        const currentState = get();
+        const searchRefresh = refresh && Boolean(currentState.searchBarValue);
+        const searchRequiredExpandedKeys = searchRefresh
+          ? resolveCurrentSearchRequiredKeys(currentState)
+          : [];
+        const preservedKeys = searchRefresh
+          ? new Set(
+              collectExpandedWorkspaceTreeNodeKeys(
+                currentState.treeData || [],
+                currentState.expandedKeys,
+                searchRequiredExpandedKeys,
+                currentState.invalidatedTreeNodeKeys,
+              ),
+            )
+          : undefined;
+        const searchMerge = preservedKeys
+          ? mergeLoadedTreeDataForSearchRefresh(freshTreeData, currentState.treeData, preservedKeys)
+          : null;
+        const treeData = searchMerge?.treeData ||
+          resolveLoadedTreeData(freshTreeData, currentState.treeData, refresh);
+        const invalidatedTreeNodeKeys = searchMerge
+          ? updateInvalidatedTreeNodeKeys(
+              currentState.invalidatedTreeNodeKeys,
+              treeData,
+              searchMerge.invalidatedKeys,
+            )
+          : refresh
+            ? []
+            : updateInvalidatedTreeNodeKeys(currentState.invalidatedTreeNodeKeys, treeData, []);
+        set({ invalidatedTreeNodeKeys });
         get().setTreeData(treeData);
         get().generateDataSourceList(treeData);
         if (refresh || force) {
@@ -307,6 +366,8 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
   handleLoadData: (nodeData, config) => {
     const { refresh = false, closeExpandTreeNode, preserveInteraction = false } = config || {};
     const { key, treeNodeType } = nodeData;
+    const invalidatedCache = get().invalidatedTreeNodeKeys.includes(key);
+    const refreshRequest = refresh || invalidatedCache;
     const currentNode = findNode(key, get().treeData) || nodeData;
     const rootDataSourceId =
       currentNode.treeNodeType === TreeNodeType.DATA_SOURCE
@@ -314,13 +375,13 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
         : undefined;
     const shouldReuseCurrentChildren = shouldReuseTreeNodeChildren({
       children: currentNode.children,
-      refresh,
+      refresh: refreshRequest,
       isDataSourceRoot: rootDataSourceId !== undefined,
       runtimeAvailability:
         rootDataSourceId === undefined ? undefined : get().runtimeAvailabilityByDataSourceId[rootDataSourceId],
     });
     if (shouldReuseCurrentChildren && !treeNodeLoadCoordinator.hasPending(key)) {
-      if (closeExpandTreeNode !== true) {
+      if (!preserveInteraction && closeExpandTreeNode !== true) {
         const expandedKeys = appendExpandedTreeKey(get().expandedKeys, key);
         if (expandedKeys !== get().expandedKeys) {
           get().setExpandedKeys(expandedKeys);
@@ -329,13 +390,13 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
       return Promise.resolve({ children: currentNode.children || [], committed: true });
     }
 
-    const interactionTreeData = preserveInteraction ? null : get().treeData;
+    const interactionTreeData = preserveInteraction || invalidatedCache ? null : get().treeData;
     if (!preserveInteraction) {
       get().setCurrentTreeNode(currentNode);
       get().setSelectedKeys([key]);
     }
 
-    return treeNodeLoadCoordinator.run(key, { supersede: refresh }, async (isCurrent) => {
+    return treeNodeLoadCoordinator.run(key, { supersede: refreshRequest }, async (isCurrent) => {
       const requestNode = findNode(key, get().treeData) || nodeData;
       const requestDataSourceId =
         requestNode.treeNodeType === TreeNodeType.DATA_SOURCE
@@ -343,7 +404,7 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
           : undefined;
       const shouldReuseRequestChildren = shouldReuseTreeNodeChildren({
         children: requestNode.children,
-        refresh,
+        refresh: refreshRequest,
         isDataSourceRoot: requestDataSourceId !== undefined,
         runtimeAvailability:
           requestDataSourceId === undefined
@@ -362,7 +423,7 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
       get().setCurrentLoadingTreeNode(requestNode);
 
       try {
-        const response = await getChildren({ ...requestNode.extraParams, refresh });
+        const response = await getChildren({ ...requestNode.extraParams, refresh: refreshRequest });
         const loadResult = normalizeTreeNodeLoadResult(response);
         if (!isCurrent()) {
           return { children: loadResult.children, committed: false };
@@ -375,15 +436,36 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
         if (requestDataSourceId !== undefined) {
           get().setDataSourceRuntimeAvailability(requestDataSourceId, 'available');
         }
-        const children = resolveLoadedTreeData(
-          loadResult.children,
-          latestNode.children ?? null,
-          refresh && !get().searchBarValue,
-        );
         const currentTreeData = get().treeData;
         if (!currentTreeData) {
-          return { children, committed: false };
+          return { children: loadResult.children, committed: false };
         }
+        const currentState = get();
+        const searchRefresh = refreshRequest && Boolean(currentState.searchBarValue);
+        const searchRequiredExpandedKeys = searchRefresh
+          ? resolveCurrentSearchRequiredKeys(currentState, currentTreeData)
+          : currentState.searchRequiredExpandedKeys;
+        const preservedKeys = invalidatedCache
+          ? new Set([key])
+          : searchRefresh
+            ? new Set(
+              collectExpandedWorkspaceTreeNodeKeys(
+                currentTreeData,
+                currentState.expandedKeys,
+                searchRequiredExpandedKeys,
+                currentState.invalidatedTreeNodeKeys,
+              ),
+            )
+            : undefined;
+        const searchMerge = preservedKeys
+          ? mergeLoadedTreeDataForSearchRefresh(
+              loadResult.children,
+              latestNode.children ?? null,
+              preservedKeys,
+            )
+          : null;
+        const children = searchMerge?.treeData ||
+          resolveLoadedTreeData(loadResult.children, latestNode.children ?? null, refreshRequest);
         const nextTreeData = applyExistingTreeNodeRefresh(currentTreeData, key, {
           children,
           total: loadResult.total,
@@ -391,7 +473,25 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
         if (nextTreeData === currentTreeData) {
           return { children, committed: false };
         }
+        const invalidatedTreeNodeKeys = updateInvalidatedTreeNodeKeys(
+          currentState.invalidatedTreeNodeKeys,
+          nextTreeData,
+          searchMerge?.invalidatedKeys || [],
+          [key, ...collectSubtreeKeys(latestNode.children)],
+        );
+        set({ invalidatedTreeNodeKeys });
         get().setTreeData(nextTreeData);
+        if (invalidatedCache) {
+          set(
+            reconcileTreeStateAfterRefresh(
+              nextTreeData,
+              currentState.selectedKeys,
+              currentState.currentTreeNode,
+              currentState.expandedKeys,
+              currentState.scrollTargetKey,
+            ),
+          );
+        }
         return { children, committed: true };
       } catch (error) {
         if (isCurrent() && requestDataSourceId !== undefined) {
@@ -419,7 +519,7 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
         if (interactionTreeData) {
           expandedKeys = removeSubkeys(expandedKeys, interactionTreeData, key);
         }
-        if (closeExpandTreeNode !== true) {
+        if (!preserveInteraction && closeExpandTreeNode !== true) {
           expandedKeys = appendExpandedTreeKey(expandedKeys, key);
         }
         get().setExpandedKeys(expandedKeys);
@@ -485,30 +585,32 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
       const _treeData = treeData(get().treeData);
       set({ treeData: _treeData });
       if (get().searchBarValue && _treeData) {
-        const visibleTreeData = filterTreeNodesForDisplay(_treeData, {
-          hiddenTreeNodeIds: get().hiddenTreeNodeIds,
-        });
-        const { matchedNodes, matchedKeys, parentIdsWithMatches } = searchTreeNodes(
-          visibleTreeData,
+        const searchState = resolveWorkspaceTreeSearch(
+          _treeData,
           get().regularSearchBarValue,
+          get().hiddenTreeNodeIds,
+          get().invalidatedTreeNodeKeys,
         );
-        get().setSearchResult(matchedNodes);
-        get().setSearchResultKeys(matchedKeys);
-        get().setExpandedKeys(mergeWorkspaceTreeSearchExpandedKeys(get().expandedKeys, parentIdsWithMatches));
+        set({
+          searchResult: searchState.matchedNodes,
+          searchResultKeys: searchState.matchedKeys,
+          searchRequiredExpandedKeys: searchState.requiredExpandedKeys,
+        });
       }
     } else {
       set({ treeData });
       if (get().searchBarValue && treeData) {
-        const visibleTreeData = filterTreeNodesForDisplay(treeData, {
-          hiddenTreeNodeIds: get().hiddenTreeNodeIds,
-        });
-        const { matchedNodes, matchedKeys, parentIdsWithMatches } = searchTreeNodes(
-          visibleTreeData,
+        const searchState = resolveWorkspaceTreeSearch(
+          treeData,
           get().regularSearchBarValue,
+          get().hiddenTreeNodeIds,
+          get().invalidatedTreeNodeKeys,
         );
-        get().setSearchResult(matchedNodes);
-        get().setSearchResultKeys(matchedKeys);
-        get().setExpandedKeys(mergeWorkspaceTreeSearchExpandedKeys(get().expandedKeys, parentIdsWithMatches));
+        set({
+          searchResult: searchState.matchedNodes,
+          searchResultKeys: searchState.matchedKeys,
+          searchRequiredExpandedKeys: searchState.requiredExpandedKeys,
+        });
       }
     }
   },
@@ -635,25 +737,24 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
     const uniqueKeys = Array.from(new Set(expandedKeys));
     set({ expandedKeys: uniqueKeys });
   },
+  setSearchRequiredExpandedKeys: (searchRequiredExpandedKeys) => {
+    set({ searchRequiredExpandedKeys: Array.from(new Set(searchRequiredExpandedKeys)) });
+  },
   // Remove an existing expanded key, or add it when absent.
   toggleExpandedKeys: (key) => {
     const expandedKeys = get().expandedKeys;
-    if (expandedKeys.includes(key)) {
-      set({ expandedKeys: expandedKeys.filter((item) => item !== key) });
+    const searchRequiredExpandedKeys = get().searchRequiredExpandedKeys;
+    if (expandedKeys.includes(key) || searchRequiredExpandedKeys.includes(key)) {
+      set({
+        expandedKeys: expandedKeys.filter((item) => item !== key),
+        searchRequiredExpandedKeys: searchRequiredExpandedKeys.filter((item) => item !== key),
+      });
     } else {
       set({ expandedKeys: [...expandedKeys, key] });
     }
   },
   setSearchBarValue: (searchBarValue) => {
-    function escapeRegExp(string) {
-      return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& represents the matched substring
-    }
-    set({
-      searchBarValue,
-      regularSearchBarValue: escapeRegExp(searchBarValue),
-      searchResultKeys: null,
-      searchResult: null,
-    });
+    set(createWorkspaceTreeSearchQueryState(searchBarValue, get().searchRevision));
   },
   setSearchResultKeys: (searchResultKeys) => {
     set({ searchResultKeys });

--- a/chat2db-community-client/src/store/tree/treeDataUpdate.test.ts
+++ b/chat2db-community-client/src/store/tree/treeDataUpdate.test.ts
@@ -4,9 +4,17 @@ import {
   appendExpandedTreeKey,
   isDataSourceTreeNodeKey,
   mergeLoadedTreeData,
+  mergeLoadedTreeDataForSearchRefresh,
   removeTreeNodeByKey,
   resolveLoadedTreeData,
+  updateInvalidatedTreeNodeKeys,
 } from './treeDataUpdate';
+import { shouldReuseTreeNodeChildren } from './treeNodeLoadState';
+import { reconcileTreeStateAfterRefresh } from './backgroundRefresh';
+import {
+  maskInvalidatedWorkspaceTreeChildren,
+  resolveWorkspaceTreeExpandedKeys,
+} from '../../pages/main/workspace/components/WorkspaceTreeSearch/lifecycle';
 
 const node = (key: string, children?: TreeNodeData[]): TreeNodeData =>
   ({ key, children } as TreeNodeData);
@@ -49,5 +57,137 @@ const movedDataSourceTree = resolveLoadedTreeData(
 );
 assert.deepEqual(movedDataSourceTree[0].children?.[0].children, [loadedDatabase]);
 assert.equal(movedDataSourceTree.some((item) => item.key === 'group_source'), false);
+
+const staleTables = node('tables_public', [node('table_old')]);
+const collapsedSchema = node('schema_archive', [node('tables_archive', [node('table_old_archive')])]);
+const matchingTables = node('tables_search', [node('table_matching_result')]);
+const currentSearchTree = [
+  node('group_default', [
+    node('dataSource_1', [
+      node('database_app', [
+        node('schemas', [
+          node('schema_public', [staleTables]),
+          collapsedSchema,
+          node('schema_search', [matchingTables]),
+        ]),
+      ]),
+    ]),
+  ]),
+];
+const searchExpandedKeys = new Set([
+  'dataSource_1',
+  'database_app',
+  'schemas',
+  'schema_public',
+  'schema_search',
+  'tables_search',
+]);
+const searchRefresh = mergeLoadedTreeDataForSearchRefresh(
+  [node('group_default', [node('dataSource_1')])],
+  currentSearchTree,
+  searchExpandedKeys,
+);
+const refreshedSearchTree = searchRefresh.treeData;
+const refreshedDataSource = refreshedSearchTree[0].children?.[0];
+const refreshedSchemas = refreshedDataSource?.children?.[0].children?.[0].children;
+const refreshedPublicTables = refreshedSchemas?.[0].children?.[0];
+
+assert.deepEqual(
+  refreshedPublicTables?.children,
+  [node('table_old')],
+  'an invalidated Tables cache must remain available for interaction reconciliation until reload',
+);
+assert.deepEqual(
+  searchRefresh.invalidatedKeys,
+  ['tables_public', 'schema_archive'],
+  'only the nearest collapsed loaded cache roots must be invalidated',
+);
+assert.deepEqual(
+  refreshedSchemas?.[2].children?.[0].children,
+  [node('table_matching_result')],
+  'the expanded search target must remain hydrated while its authoritative refresh is pending',
+);
+assert.deepEqual(
+  Array.from(searchExpandedKeys),
+  ['dataSource_1', 'database_app', 'schemas', 'schema_public', 'schema_search', 'tables_search'],
+  'cache invalidation must not change the active search expansion state',
+);
+assert.equal(
+  shouldReuseTreeNodeChildren({
+    children: refreshedPublicTables?.children,
+    refresh: searchRefresh.invalidatedKeys.includes('tables_public'),
+    isDataSourceRoot: false,
+  }),
+  false,
+  're-expanding an invalidated Tables node must reload its children',
+);
+const selectedDescendant = refreshedSchemas?.[1].children?.[0].children?.[0];
+assert.ok(selectedDescendant);
+const interactionState = reconcileTreeStateAfterRefresh(
+  refreshedSearchTree,
+  [selectedDescendant.key],
+  selectedDescendant,
+  ['tables_archive'],
+  selectedDescendant.key,
+);
+assert.deepEqual(interactionState.selectedKeys, [selectedDescendant.key]);
+assert.equal(interactionState.currentTreeNode, selectedDescendant);
+assert.deepEqual(interactionState.expandedKeys, ['tables_archive']);
+assert.equal(interactionState.scrollTargetKey, selectedDescendant.key);
+
+const reloadedTables = resolveLoadedTreeData([node('table_new')], refreshedPublicTables?.children ?? null, true);
+assert.deepEqual(
+  reloadedTables,
+  [node('table_new')],
+  'the reload after search closes must expose the backend mutation',
+);
+assert.deepEqual(
+  updateInvalidatedTreeNodeKeys(
+    searchRefresh.invalidatedKeys,
+    refreshedSearchTree,
+    [],
+    ['tables_public'],
+  ),
+  ['schema_archive'],
+  'a successful reload must clear only the cache root it refreshed',
+);
+
+const nestedReload = mergeLoadedTreeDataForSearchRefresh(
+  [node('tables_archive')],
+  collapsedSchema.children || null,
+  new Set(['schema_archive']),
+);
+const nestedReloadTree = [node('schema_archive', nestedReload.treeData)];
+const nestedInvalidatedKeys = updateInvalidatedTreeNodeKeys(
+  ['schema_archive'],
+  nestedReloadTree,
+  nestedReload.invalidatedKeys,
+  ['schema_archive', 'tables_archive', 'table_old_archive'],
+);
+assert.deepEqual(
+  nestedReload.invalidatedKeys,
+  ['tables_archive'],
+  'an immediate-child response must not validate a historical expanded descendant cache',
+);
+assert.deepEqual(nestedInvalidatedKeys, ['tables_archive']);
+assert.equal(
+  maskInvalidatedWorkspaceTreeChildren(nestedReloadTree, nestedInvalidatedKeys)[0].children?.[0].children,
+  undefined,
+  'stale descendant rows must stay hidden after their ancestor reloads',
+);
+assert.deepEqual(
+  resolveWorkspaceTreeExpandedKeys(['tables_archive'], [], nestedInvalidatedKeys),
+  [],
+  'historical expansion intent must not make an invalidated descendant appear loaded',
+);
+assert.equal(
+  shouldReuseTreeNodeChildren({
+    children: nestedReload.treeData[0].children,
+    refresh: nestedInvalidatedKeys.includes('tables_archive'),
+    isDataSourceRoot: false,
+  }),
+  false,
+  'the next descendant expansion must reload instead of reusing resurrected rows',
+);
 
 console.log('Tree data update tests passed');

--- a/chat2db-community-client/src/store/tree/treeDataUpdate.ts
+++ b/chat2db-community-client/src/store/tree/treeDataUpdate.ts
@@ -92,3 +92,79 @@ export function resolveLoadedTreeData(
 ): TreeNodeData[] {
   return authoritative ? freshTreeData : mergeLoadedTreeData(freshTreeData, currentTreeData);
 }
+
+export function mergeLoadedTreeDataForSearchRefresh(
+  freshTreeData: TreeNodeData[],
+  currentTreeData: TreeNodeData[] | null,
+  preserveLoadedChildrenForKeys: ReadonlySet<Key>,
+): { treeData: TreeNodeData[]; invalidatedKeys: Key[] } {
+  const treeData = mergeLoadedTreeData(freshTreeData, currentTreeData);
+  if (!currentTreeData?.length) {
+    return { treeData, invalidatedKeys: [] };
+  }
+
+  const currentNodesByKey = new Map<Key, TreeNodeData>();
+  const indexCurrentNodes = (nodes: TreeNodeData[]) => {
+    nodes.forEach((node) => {
+      currentNodesByKey.set(node.key, node);
+      if (node.children) {
+        indexCurrentNodes(node.children);
+      }
+    });
+  };
+  indexCurrentNodes(currentTreeData);
+
+  const invalidatedKeys: Key[] = [];
+  const collectCachedNodes = (nodes: TreeNodeData[]) => {
+    nodes.forEach((node) => {
+      if (node.children === undefined || node.isLeaf) {
+        return;
+      }
+      if (!preserveLoadedChildrenForKeys.has(node.key)) {
+        invalidatedKeys.push(node.key);
+        return;
+      }
+      collectCachedNodes(node.children);
+    });
+  };
+  const visitFreshNodes = (nodes: TreeNodeData[]) => {
+    nodes.forEach((node) => {
+      const currentNode = currentNodesByKey.get(node.key);
+      if (node.children !== undefined) {
+        visitFreshNodes(node.children);
+        return;
+      }
+      if (currentNode?.children === undefined) {
+        return;
+      }
+      if (!preserveLoadedChildrenForKeys.has(node.key)) {
+        invalidatedKeys.push(node.key);
+        return;
+      }
+      collectCachedNodes(currentNode.children);
+    });
+  };
+  visitFreshNodes(freshTreeData);
+  return { treeData, invalidatedKeys };
+}
+
+export function updateInvalidatedTreeNodeKeys(
+  currentKeys: Key[],
+  treeData: TreeNodeData[],
+  invalidatedKeys: Key[],
+  refreshedKeys: Iterable<Key> = [],
+): Key[] {
+  const existingKeys = new Set<Key>();
+  const collectKeys = (nodes: TreeNodeData[]) => {
+    nodes.forEach((node) => {
+      existingKeys.add(node.key);
+      if (node.children) {
+        collectKeys(node.children);
+      }
+    });
+  };
+  collectKeys(treeData);
+  const refreshedKeySet = new Set(refreshedKeys);
+  const retainedKeys = currentKeys.filter((key) => !refreshedKeySet.has(key));
+  return Array.from(new Set([...retainedKeys, ...invalidatedKeys])).filter((key) => existingKeys.has(key));
+}


### PR DESCRIPTION
Separates current-search expansion requirements from persistent UI expansion, versions refreshes against query changes, and logically invalidates collapsed cached subtrees while preserving selection/current/scroll state. Search, path loading, and later expansion force deterministic reloads, including nested historical descendants. Includes pure model and lifecycle regression tests.

## Latest-main revalidation (2026-09-04)

- Rebased as one commit onto upstream 144a04ee2; current head 941a2db49.
- Focused tree-search/refresh/loading tests and targeted ESLint passed.
- Full Community prebuild, Umi/Webpack production build, and bundle verifier passed.
- Playwright on this branch exercised Data Source -> Database -> Tables, search refresh, and a rapid orders-to-audit query change. Only the latest result remained, the required path stayed expanded, and the browser console had no errors.