### PR TITLE
fix(pagination): prevent relational row-bound overflow

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-db2/src/main/java/ai/chat2db/plugin/db2/builder/DB2SqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-db2/src/main/java/ai/chat2db/plugin/db2/builder/DB2SqlBuilder.java
@@ -145,8 +145,8 @@ public class DB2SqlBuilder extends DefaultSqlBuilder {
         int offset = request.getOffset();
         int pageNo = request.getPageNo();
         int pageSize = request.getPageSize();
-        int startRow = offset + 1;
-        int endRow = offset + pageSize;
+        long startRow = (long) offset + 1;
+        long endRow = (long) offset + pageSize;
         StringBuilder sqlBuilder = new StringBuilder(sql.length() + 120);
         sqlBuilder.append(SQL_SELECT_SELECT_TMP_PAGE_ROWNUMBER);
         sqlBuilder.append(sql);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-db2/src/test/java/ai/chat2db/plugin/db2/builder/DB2SqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-db2/src/test/java/ai/chat2db/plugin/db2/builder/DB2SqlBuilderTest.java
@@ -1,0 +1,37 @@
+package ai.chat2db.plugin.db2.builder;
+
+import ai.chat2db.spi.model.request.PageLimitRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DB2SqlBuilderTest {
+
+    @Test
+    void shouldKeepNormalPaginationOutput() {
+        String sql = new DB2SqlBuilder().buildPageLimit(request(10, 10));
+
+        assertEquals("SELECT * FROM (SELECT TMP_PAGE.*,ROWNUMBER() OVER() AS CAHT2DB_AUTO_ROW_ID FROM ( \n"
+                + "SELECT ID FROM EMPLOYEE\n"
+                + " ) AS TMP_PAGE) TMP_PAGE WHERE CAHT2DB_AUTO_ROW_ID BETWEEN 11 AND 20", sql);
+    }
+
+    @Test
+    void shouldKeepPaginationBoundsBeyondIntegerRange() {
+        String sql = new DB2SqlBuilder().buildPageLimit(request(2_147_483_600, 100));
+
+        assertEquals("SELECT * FROM (SELECT TMP_PAGE.*,ROWNUMBER() OVER() AS CAHT2DB_AUTO_ROW_ID FROM ( \n"
+                + "SELECT ID FROM EMPLOYEE\n"
+                + " ) AS TMP_PAGE) TMP_PAGE WHERE CAHT2DB_AUTO_ROW_ID BETWEEN 2147483601 AND 2147483700",
+                sql);
+    }
+
+    private static PageLimitRequest request(int offset, int pageSize) {
+        return PageLimitRequest.builder()
+                .sql("SELECT ID FROM EMPLOYEE")
+                .offset(offset)
+                .pageNo(2)
+                .pageSize(pageSize)
+                .build();
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilder.java
@@ -229,7 +229,7 @@ public class OracleSqlBuilder extends DefaultSqlBuilder {
         int offset = request.getOffset();
         int pageSize = request.getPageSize();
         int startRow = offset;
-        int endRow = offset + pageSize;
+        long endRow = (long) offset + pageSize;
         StringBuilder sqlBuilder = new StringBuilder(sql.length() + 120);
         sqlBuilder.append(SQL_SELECT);
         if (startRow > 0) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/test/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/test/java/ai/chat2db/plugin/oracle/builder/OracleSqlBuilderTest.java
@@ -43,6 +43,23 @@ class OracleSqlBuilderTest {
     }
 
     @Test
+    void shouldKeepPaginationEndBeyondIntegerRange() {
+        OracleSqlBuilder builder = new OracleSqlBuilder();
+
+        String sql = builder.buildPageLimit(PageLimitRequest.builder()
+                .sql("SELECT ID, NAME FROM EMPLOYEE")
+                .offset(2_147_483_600)
+                .pageNo(2)
+                .pageSize(100)
+                .build());
+
+        assertEquals("SELECT * FROM (  SELECT TMP_PAGE.*, ROWNUM CAHT2DB_AUTO_ROW_ID FROM ( \n"
+                        + "SELECT ID, NAME FROM EMPLOYEE\n"
+                        + " ) TMP_PAGE WHERE ROWNUM <= 2147483700 ) WHERE CAHT2DB_AUTO_ROW_ID > 2147483600",
+                sql);
+    }
+
+    @Test
     void shouldBuildQualifiedAndEscapedViewComment() {
         OracleSqlBuilder builder = new OracleSqlBuilder();
         ModifyView view = view("SA\"LES", "ACTIVE\"USERS", "Owner\\team's active users");

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oscar/src/main/java/ai/chat2db/plugin/oscar/builder/OscarSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oscar/src/main/java/ai/chat2db/plugin/oscar/builder/OscarSqlBuilder.java
@@ -113,7 +113,7 @@ public class OscarSqlBuilder extends OscarBaseSqlBuilder {
         String sql = request.getSql();
         int startRow = request.getOffset();
         int pageSize = request.getPageSize();
-        int endRow = startRow + pageSize;
+        long endRow = (long) startRow + pageSize;
         StringBuilder sqlBuilder = new StringBuilder(sql.length() + 120);
         sqlBuilder.append(OscarConstants.PAGE_OUTER_SELECT_PREFIX);
         if (startRow > 0) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oscar/src/test/java/ai/chat2db/plugin/oscar/builder/OscarSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oscar/src/test/java/ai/chat2db/plugin/oscar/builder/OscarSqlBuilderTest.java
@@ -39,4 +39,21 @@ class OscarSqlBuilderTest {
                         + " ) TMP_PAGE WHERE ROWNUM <= 20 ) WHERE CHAT2DB_AUTO_ROW_ID > 10",
                 sql);
     }
+
+    @Test
+    void shouldKeepPaginationEndBeyondIntegerRange() {
+        OscarSqlBuilder builder = new OscarSqlBuilder();
+
+        String sql = builder.buildPageLimit(PageLimitRequest.builder()
+                .sql("SELECT ID, NAME FROM EMPLOYEE")
+                .offset(2_147_483_600)
+                .pageNo(2)
+                .pageSize(100)
+                .build());
+
+        assertEquals("SELECT * FROM (  SELECT TMP_PAGE.*, ROWNUM CHAT2DB_AUTO_ROW_ID FROM ( \n"
+                        + "SELECT ID, NAME FROM EMPLOYEE\n"
+                        + " ) TMP_PAGE WHERE ROWNUM <= 2147483700 ) WHERE CHAT2DB_AUTO_ROW_ID > 2147483600",
+                sql);
+    }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilder.java
@@ -298,8 +298,8 @@ public class SqlServerSqlBuilder extends DefaultSqlBuilder {
             }
         }
         // SQL Server < 2012: use ROW_NUMBER() window function
-        int startRow = offset + 1;
-        int endRow = offset + pageSize;
+        long startRow = (long) offset + 1;
+        long endRow = (long) offset + pageSize;
         StringBuilder sqlBuilder = new StringBuilder(sql.length() + 120);
         sqlBuilder.append(SQL_ROW_NUMBER_PREFIX);
         sqlBuilder.append(sql);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/builder/SqlServerSqlBuilderTest.java
@@ -9,6 +9,7 @@ import ai.chat2db.plugin.sqlserver.SqlServerPlugin;
 import ai.chat2db.spi.IPlugin;
 import ai.chat2db.spi.constant.SQLConstants;
 import ai.chat2db.spi.model.datasource.ConnectInfo;
+import ai.chat2db.spi.model.request.PageLimitRequest;
 import ai.chat2db.spi.sql.Chat2DBContext;
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +20,24 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SqlServerSqlBuilderTest {
+
+    @Test
+    void shouldKeepNormalLegacyPaginationOutput() {
+        assertEquals("SELECT * FROM (SELECT TMP_PAGE.*, ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) "
+                        + "AS CAHT2DB_AUTO_ROW_ID FROM (\n"
+                        + "SELECT ID FROM EMPLOYEE\n"
+                        + ") TMP_PAGE) TMP_PAGE WHERE CAHT2DB_AUTO_ROW_ID BETWEEN 11 AND 20",
+                buildLegacyPageLimit(10, 10));
+    }
+
+    @Test
+    void shouldKeepLegacyPaginationBoundsBeyondIntegerRange() {
+        assertEquals("SELECT * FROM (SELECT TMP_PAGE.*, ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) "
+                        + "AS CAHT2DB_AUTO_ROW_ID FROM (\n"
+                        + "SELECT ID FROM EMPLOYEE\n"
+                        + ") TMP_PAGE) TMP_PAGE WHERE CAHT2DB_AUTO_ROW_ID BETWEEN 2147483601 AND 2147483700",
+                buildLegacyPageLimit(2_147_483_600, 100));
+    }
 
     @Test
     void shouldKeepGoDelimiterForShowplanXmlBatch() {
@@ -157,6 +176,24 @@ class SqlServerSqlBuilderTest {
             } else {
                 Chat2DBContext.PLUGIN_MAP.put("SQLSERVER", previousPlugin);
             }
+        }
+    }
+
+    private static String buildLegacyPageLimit(int offset, int pageSize) {
+        ConnectInfo connectInfo = new ConnectInfo();
+        connectInfo.setDriverConfig(new DriverConfig());
+        connectInfo.setDbVersion("10.0");
+        Chat2DBContext.putContext(connectInfo);
+
+        try {
+            return new SqlServerSqlBuilder().buildPageLimit(PageLimitRequest.builder()
+                    .sql("SELECT ID FROM EMPLOYEE")
+                    .offset(offset)
+                    .pageNo(2)
+                    .pageSize(pageSize)
+                    .build());
+        } finally {
+            Chat2DBContext.removeContext();
         }
     }
 


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

DB2, Oracle, Oscar, and the pre-2012 SQL Server paging builders added pageSize to a valid near-Integer.MAX_VALUE offset using int arithmetic. The upper row bound wrapped negative. This change promotes only the derived row-bound arithmetic to long and preserves normal-page SQL and modern SQL Server behavior.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Focused DB2, Oracle, Oscar, and SQL Server builder tests: 24 tests passed.
  - Four plugin reactor packages: 12 reactor modules succeeded.
  - git diff --check origin/main...HEAD: passed.
- Manual verification: N/A - tests invoke each real builder at normal and overflow boundaries.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or storage changes.
- Database or driver compatibility: Only generated row-bound numerals change for pages whose derived upper bound exceeds Integer.MAX_VALUE.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community database plugins.
- Backward compatibility: Exact normal-page SQL snapshots remain unchanged.

## Reviewer map

- Start here: buildPageLimit in DB2SqlBuilder, OracleSqlBuilder, OscarSqlBuilder, and SqlServerSqlBuilder.
- Failure condition: offset 2147483600 with pageSize 100 produces a negative upper bound, or normal paging SQL changes.
- Rollback or disable path: Revert commit 9c292e741; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.

## Latest-main revalidation (2026-09-04)

- Rebased as one commit onto upstream 144a04ee2; current head 9c292e741.
- Focused four-dialect boundary tests: 24/24 passed.
- Full modules passed: DB2 31/31, Oracle 49/49, SQL Server 81/81, Oscar 28/28.