### PR TITLE
fix(sundb): handle comments on added columns

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/main/java/ai/chat2db/plugin/sundb/builder/SUNDBSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/main/java/ai/chat2db/plugin/sundb/builder/SUNDBSqlBuilder.java
@@ -145,7 +145,8 @@ public class SUNDBSqlBuilder extends DefaultSqlBuilder {
 
                 if (StringUtils.isNotBlank(tableColumn.getComment())
                         && !Objects.equals(EditStatusEnum.DELETE.toString(), editStatus)
-                        && !tableColumn.getComment().equals(tableColumn.getOldColumn().getComment())) {
+                        && (tableColumn.getOldColumn() == null
+                        || !tableColumn.getComment().equals(tableColumn.getOldColumn().getComment()))) {
                     script.append(SQLConstants.LINE_SEPARATOR).append(buildComment(tableColumn)).append(SQLConstants.SEMICOLON_LINE_SEPARATOR);
                 }
             }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/test/java/ai/chat2db/plugin/sundb/builder/SUNDBSqlBuilderTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/test/java/ai/chat2db/plugin/sundb/builder/SUNDBSqlBuilderTest.java
@@ -1,0 +1,83 @@
+package ai.chat2db.plugin.sundb.builder;
+
+import ai.chat2db.community.domain.api.enums.plugin.EditStatusEnum;
+import ai.chat2db.community.domain.api.model.metadata.Table;
+import ai.chat2db.community.domain.api.model.metadata.TableColumn;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers comment handling in {@link SUNDBSqlBuilder#buildAlterTable(Table, Table)}.
+ * Columns added from the table editor never carry an oldColumn snapshot
+ * (DbTableServiceImpl.initOldTable skips ADD columns), so the comment diff
+ * must tolerate a null oldColumn instead of throwing a NullPointerException.
+ */
+class SUNDBSqlBuilderTest {
+
+    @Test
+    void buildAlterTableAddedColumnWithCommentDoesNotThrowAndEmitsComment() {
+        Table oldTable = table();
+        Table newTable = table();
+        TableColumn added = column(EditStatusEnum.ADD.name(), "user id");
+        added.setColumnSize(20);
+        newTable.setColumnList(List.of(added));
+
+        String sql = assertDoesNotThrow(() -> new SUNDBSqlBuilder().buildAlterTable(oldTable, newTable));
+
+        assertTrue(sql.contains("ALTER TABLE \"SCH\".\"T1\" ADD (\"C1\" VARCHAR(20)"), sql);
+        assertTrue(sql.contains("COMMENT ON COLUMN \"SCH\".\"T1\".\"C1\" IS 'user id'"), sql);
+    }
+
+    @Test
+    void buildAlterTableModifiedColumnStillEmitsCommentWhenItChanges() {
+        Table oldTable = table();
+        Table newTable = table();
+        TableColumn modified = column(EditStatusEnum.MODIFY.name(), "new comment");
+        modified.setOldName("C1");
+        modified.setOldColumn(column(null, "old comment"));
+        newTable.setColumnList(List.of(modified));
+
+        String sql = new SUNDBSqlBuilder().buildAlterTable(oldTable, newTable);
+
+        assertTrue(sql.contains("COMMENT ON COLUMN \"SCH\".\"T1\".\"C1\" IS 'new comment'"), sql);
+    }
+
+    @Test
+    void buildAlterTableModifiedColumnWithUnchangedCommentEmitsNoComment() {
+        Table oldTable = table();
+        Table newTable = table();
+        TableColumn modified = column(EditStatusEnum.MODIFY.name(), "same comment");
+        modified.setOldName("C1");
+        modified.setOldColumn(column(null, "same comment"));
+        newTable.setColumnList(List.of(modified));
+
+        String sql = new SUNDBSqlBuilder().buildAlterTable(oldTable, newTable);
+
+        assertFalse(sql.contains("COMMENT ON COLUMN"), sql);
+    }
+
+    private static Table table() {
+        Table table = new Table();
+        table.setSchemaName("SCH");
+        table.setName("T1");
+        table.setColumnList(List.of());
+        table.setIndexList(List.of());
+        return table;
+    }
+
+    private static TableColumn column(String editStatus, String comment) {
+        TableColumn column = new TableColumn();
+        column.setSchemaName("SCH");
+        column.setTableName("T1");
+        column.setName("C1");
+        column.setColumnType("VARCHAR");
+        column.setEditStatus(editStatus);
+        column.setComment(comment);
+        return column;
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

SUNDB table alteration dereferenced oldColumn while adding a new commented column, even though ADD columns intentionally have no old model. This change treats a missing old column as a changed comment, emits the existing COMMENT statement for ADD, and preserves MODIFY and DELETE behavior.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Focused SUNDBSqlBuilderTest run: 3 tests passed, 0 failures/errors.
  - SUNDB plugin reactor package: succeeded.
  - git diff --check origin/main...HEAD: passed.
- Manual verification: N/A - the builder behavior is deterministic and covered with model-level tests.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or storage-format changes.
- Database or driver compatibility: SUNDB only; generated ADD/MODIFY/DELETE SQL behavior is covered.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community SUNDB plugin only.
- Backward compatibility: Existing MODIFY and DELETE comment behavior is unchanged.

## Reviewer map

- Start here: SUNDBSqlBuilder.buildAlterTable and SUNDBSqlBuilderTest.
- Failure condition: Adding a commented column throws because oldColumn is null, or DELETE emits a comment statement.
- Rollback or disable path: Revert commit bc0563fab; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.

## Latest-main revalidation (2026-09-04)

- Rebased as one commit onto upstream 144a04ee2; current head bc0563fab.
- Focused SUNDB builder tests: 3/3 passed.
- Full SUNDB plugin module: 28/28 passed.