### PR TITLE
fix(sundb): return distinct procedure records

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/main/java/ai/chat2db/plugin/sundb/SUNDBMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/main/java/ai/chat2db/plugin/sundb/SUNDBMetaData.java
@@ -258,8 +258,8 @@ public class SUNDBMetaData extends DefaultMetaService implements IDbMetaData {
         String sql = String.format(ALL_PROCEDURES_SQL, getSQLIdentifierProcessor().escapeString(userName), getSQLIdentifierProcessor().escapeString(schemaName), SUNDBObjectTypeEnum.PROCEDURE.getObjectType());
         return DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> {
             ArrayList<Procedure> procedures = new ArrayList<>();
-            Procedure procedure = new Procedure();
             while (resultSet.next()) {
+                Procedure procedure = new Procedure();
                 procedure.setProcedureName(resultSet.getString("OBJECT_NAME"));
                 procedures.add(procedure);
             }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/test/java/ai/chat2db/plugin/sundb/SUNDBMetaDataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/test/java/ai/chat2db/plugin/sundb/SUNDBMetaDataTest.java
@@ -1,0 +1,81 @@
+package ai.chat2db.plugin.sundb;
+
+import ai.chat2db.community.domain.api.model.metadata.Procedure;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SUNDBMetaDataTest {
+
+    /**
+     * Every result row must be mapped to its own {@link Procedure} instance;
+     * a single shared instance would make all list entries carry the last
+     * procedure name.
+     */
+    @Test
+    void proceduresMapsEachRowToItsOwnInstance() {
+        List<Procedure> procedures = new SUNDBMetaData()
+                .procedures(proceduresConnection("P1", "P2"), "db", "SCH");
+
+        assertEquals(2, procedures.size());
+        assertEquals("P1", procedures.get(0).getProcedureName());
+        assertEquals("P2", procedures.get(1).getProcedureName());
+    }
+
+    private static Connection proceduresConnection(String... objectNames) {
+        ResultSet resultSet = objectNameResultSet(objectNames);
+        PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                SUNDBMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "execute" -> true;
+                    case "getResultSet" -> resultSet;
+                    default -> defaultValue(method.getReturnType());
+                });
+        DatabaseMetaData databaseMetaData = (DatabaseMetaData) Proxy.newProxyInstance(
+                SUNDBMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{DatabaseMetaData.class},
+                (proxy, method, args) -> "getUserName".equals(method.getName())
+                        ? "TESTER" : defaultValue(method.getReturnType()));
+        return (Connection) Proxy.newProxyInstance(
+                SUNDBMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "prepareStatement" -> statement;
+                    case "getMetaData" -> databaseMetaData;
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static ResultSet objectNameResultSet(String... objectNames) {
+        int[] row = {-1};
+        return (ResultSet) Proxy.newProxyInstance(
+                SUNDBMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{ResultSet.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "next" -> ++row[0] < objectNames.length;
+                    case "getString" -> "OBJECT_NAME".equals(args[0]) ? objectNames[row[0]] : null;
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

SUNDB procedure listing allocated one Procedure object outside the ResultSet loop, so every returned list entry aliased the same object and ended with the final row's name. This change creates one model per row.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Focused SUNDBMetaDataTest run: 1 test passed, 0 failures/errors.
  - SUNDB plugin reactor package: succeeded.
  - git diff --check origin/main...HEAD: passed.
- Manual verification: N/A - a JDBC proxy covers multiple metadata rows and object identity.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or storage-format changes.
- Database or driver compatibility: SUNDB procedure metadata only.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community SUNDB plugin only.
- Backward compatibility: Procedure names and list ordering are preserved; object identity is corrected.

## Reviewer map

- Start here: SUNDBMetaData.procedures and SUNDBMetaDataTest.
- Failure condition: Two metadata rows return the same Procedure instance or both expose the final row name.
- Rollback or disable path: Revert commit ba72cbd24; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.

## Latest-main revalidation (2026-09-04)

- Rebased as one commit onto upstream 144a04ee2; current head ba72cbd24.
- Focused SUNDB procedure identity test: 1/1 passed.
- Full SUNDB plugin module: 26/26 passed.