### PR TITLE
fix(sqlserver): preserve NVARCHAR(MAX) metadata size

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/SqlServerMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/SqlServerMetaData.java
@@ -506,7 +506,10 @@ public class SqlServerMetaData extends DefaultMetaService implements IDbMetaData
                 int columnSize = resultSet.getInt("COLUMN_SIZE");
                 if (StringUtils.equalsAny(dataType, SqlServerColumnTypeEnum.NCHAR.name(), SqlServerColumnTypeEnum.NVARCHAR.name())) {
                     if (columnSize == -1) {
-                        column.setColumnSize(2147483647);
+                        // Only NVARCHAR supports MAX; keeping its -1 sentinel renders NVARCHAR(MAX).
+                        if (StringUtils.equals(dataType, SqlServerColumnTypeEnum.NVARCHAR.name())) {
+                            column.setColumnSize(columnSize);
+                        }
                     } else if (columnSize > 0) {
                         if (columnSize == 1) {
                             column.setColumnSize(columnSize);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/SqlServerMetaDataColumnSizeTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/SqlServerMetaDataColumnSizeTest.java
@@ -1,0 +1,114 @@
+package ai.chat2db.plugin.sqlserver;
+
+import ai.chat2db.community.domain.api.model.metadata.TableColumn;
+import ai.chat2db.plugin.sqlserver.enums.type.SqlServerColumnTypeEnum;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the NCHAR/NVARCHAR size mapping in {@link SqlServerMetaData#columns}.
+ * JDBC reports MAX columns with COLUMN_SIZE = -1 and
+ * {@link SqlServerColumnTypeEnum} renders the -1 sentinel as {@code (MAX)},
+ * so columns() must keep -1 instead of normalizing it to Integer.MAX_VALUE.
+ */
+class SqlServerMetaDataColumnSizeTest {
+
+    @Test
+    void shouldMapUnicodeColumnSizesWithoutLosingMaxSentinel() {
+        List<TableColumn> columns = new SqlServerMetaData().columns(
+                columnsConnection(), "catalog", "dbo", "orders");
+
+        assertEquals(6, columns.size());
+        assertNull(columns.get(0).getColumnSize());
+        assertEquals(-1, columns.get(1).getColumnSize());
+        assertEquals(100, columns.get(2).getColumnSize());
+        assertEquals(10, columns.get(3).getColumnSize());
+        assertEquals(1, columns.get(4).getColumnSize());
+        assertNull(columns.get(5).getColumnSize());
+    }
+
+    @Test
+    void nvarcharMaxSentinelRoundTripsIntoMaxKeyword() {
+        TableColumn column = new TableColumn();
+        column.setName("payload");
+        column.setColumnType("NVARCHAR");
+        column.setColumnSize(-1);
+
+        String sql = SqlServerColumnTypeEnum.NVARCHAR.buildCreateColumnSql(column);
+
+        assertTrue(sql.contains("NVARCHAR(MAX)"), sql);
+    }
+
+    private static Connection columnsConnection() {
+        ResultSet resultSet = columnsResultSet();
+        PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                SqlServerMetaDataColumnSizeTest.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "execute" -> true;
+                    case "getResultSet" -> resultSet;
+                    default -> defaultValue(method.getReturnType());
+                });
+        return (Connection) Proxy.newProxyInstance(
+                SqlServerMetaDataColumnSizeTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> "prepareStatement".equals(method.getName())
+                        ? statement : defaultValue(method.getReturnType()));
+    }
+
+    private static ResultSet columnsResultSet() {
+        String[] names = {
+                "nchar_max", "nvarchar_max", "nchar_100", "nvarchar_10", "nchar_1", "unknown_size"
+        };
+        String[] types = {
+                "nchar", "nvarchar", "nchar", "nvarchar", "nchar", "nvarchar"
+        };
+        Integer[] sizes = {-1, -1, 200, 20, 2, null};
+        int[] row = {-1};
+        boolean[] wasNull = {false};
+        return (ResultSet) Proxy.newProxyInstance(
+                SqlServerMetaDataColumnSizeTest.class.getClassLoader(),
+                new Class<?>[]{ResultSet.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "next" -> ++row[0] < names.length;
+                    case "getString" -> switch ((String) args[0]) {
+                        case "COLUMN_NAME" -> names[row[0]];
+                        case "DATA_TYPE" -> types[row[0]];
+                        default -> null;
+                    };
+                    case "getInt" -> {
+                        Integer value = switch ((String) args[0]) {
+                            case "COLUMN_SIZE" -> sizes[row[0]];
+                            case "ORDINAL_POSITION" -> row[0] + 1;
+                            default -> 0;
+                        };
+                        wasNull[0] = value == null;
+                        yield value == null ? 0 : value;
+                    }
+                    case "wasNull" -> wasNull[0];
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

SQL Server sys.columns reports max_length=-1 for NVARCHAR(MAX). Metadata conversion replaced that sentinel with Integer.MAX_VALUE, while the DDL builder only recognizes -1 as MAX, producing NVARCHAR(2147483647). This change preserves -1 for NVARCHAR and keeps finite Unicode byte-length conversion unchanged.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - SqlServerMetaDataColumnSizeTest: 2 tests passed, 0 failures/errors.
  - SQL Server plugin reactor package: 8 reactor modules succeeded with tests enabled.
  - git diff --check origin/main...HEAD: passed.
- Manual verification: N/A - JDBC proxy rows cover NVARCHAR(MAX), finite NCHAR/NVARCHAR sizes, and DDL round-trip.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or storage changes.
- Database or driver compatibility: SQL Server metadata only; NCHAR(MAX) is not a valid server type and is not introduced.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community SQL Server plugin.
- Backward compatibility: Finite Unicode lengths continue converting from bytes to characters.

## Reviewer map

- Start here: SqlServerMetaData.columns and SqlServerMetaDataColumnSizeTest.
- Failure condition: NVARCHAR max_length=-1 becomes Integer.MAX_VALUE or generated DDL is not NVARCHAR(MAX).
- Rollback or disable path: Revert commit a5426ae8c; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.

## Latest-main revalidation (2026-09-04)

- Rebased as one commit onto upstream 144a04ee2; current head a5426ae8c.
- Focused SQL Server metadata tests: 2/2 passed.
- Full SQL Server plugin module: 81/81 passed.