### PR TITLE
fix(ai): block unclassified CTE auto-execution

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiToolServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiToolServiceImpl.java
@@ -42,6 +42,11 @@ import ai.chat2db.community.domain.api.model.metadata.Table;
 import ai.chat2db.community.domain.api.model.metadata.TableColumn;
 import ai.chat2db.community.domain.api.model.metadata.TableIndex;
 import ai.chat2db.community.domain.api.model.metadata.TableIndexColumn;
+import ai.chat2db.spi.util.JdbcUtils;
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.parser.Lexer;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.Token;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,11 +56,14 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -82,6 +90,8 @@ public class AiToolServiceImpl implements IAiToolService {
     private static final int MAX_SQL_PAGE_SIZE = 500;
     private static final int MAX_SQL_RESULT_ROWS = 50;
     private static final int MAX_GLOBAL_DATASOURCES = 200;
+    private static final Pattern SQL_SERVER_GO_BATCH_PATTERN = Pattern.compile(
+            "(?mi)(?:^[ \\t]*|(?<=;)[ \\t]*)(go)(?:[ \\t]+[0-9]+)?[ \\t]*;?[ \\t]*(?:--.*)?(?=\\r?\\n|$)");
     public String listAllDataSources(AiToolContextRequest toolContext) {
         DbDataSourcePageQueryRequest queryRequest = new DbDataSourcePageQueryRequest();
         queryRequest.setPageNo(1);
@@ -651,8 +661,76 @@ public class AiToolServiceImpl implements IAiToolService {
         } catch (Exception e) { // impl-contract: fallback - keyword matching is used when parser cannot classify SQL.
             log.debug("resolve sql type failed, fallback to keyword match", e);
         }
-        String fallbackType = fallbackSqlType(sql);
+        String fallbackType = isSingleFallbackStatement(sql, profile.getDbType())
+                ? fallbackSqlType(sql) : SqlTypeEnum.OTHER.name();
         return StringUtils.isBlank(fallbackType) ? Collections.emptyList() : List.of(fallbackType);
+    }
+
+    private boolean isSingleFallbackStatement(String sql, String dbType) {
+        try {
+            DbType druidDbType = JdbcUtils.parse2DruidDbType(dbType);
+            if (druidDbType == null) {
+                return false;
+            }
+            String statementSql = sql;
+            if (DbType.sqlserver.equals(druidDbType)) {
+                statementSql = normalizeSingleSqlServerBatch(sql);
+                if (statementSql == null) {
+                    return false;
+                }
+            }
+            return SQLParserUtils.split(statementSql, druidDbType).stream()
+                    .filter(StringUtils::isNotBlank)
+                    .limit(2)
+                    .count() == 1;
+        } catch (Exception e) {
+            log.debug("fallback sql splitting failed", e);
+            return false;
+        }
+    }
+
+    private String normalizeSingleSqlServerBatch(String sql) {
+        Set<Integer> goTokenStarts = sqlServerGoTokenStarts(sql);
+        StringBuilder normalized = new StringBuilder(sql);
+        int batchStart = 0;
+        int batchCount = 0;
+        var matcher = SQL_SERVER_GO_BATCH_PATTERN.matcher(sql);
+        while (matcher.find()) {
+            if (!goTokenStarts.contains(matcher.start(1))) {
+                continue;
+            }
+            if (StringUtils.isNotBlank(sql.substring(batchStart, matcher.start()))) {
+                batchCount++;
+                if (batchCount > 1) {
+                    return null;
+                }
+            }
+            for (int index = matcher.start(); index < matcher.end(); index++) {
+                char character = normalized.charAt(index);
+                if (character != '\r' && character != '\n') {
+                    normalized.setCharAt(index, ' ');
+                }
+            }
+            batchStart = matcher.end();
+        }
+        if (StringUtils.isNotBlank(sql.substring(batchStart)) && ++batchCount > 1) {
+            return null;
+        }
+        return normalized.toString();
+    }
+
+    private Set<Integer> sqlServerGoTokenStarts(String sql) {
+        Set<Integer> starts = new HashSet<>();
+        Lexer lexer = SQLParserUtils.createLexer(sql, DbType.sqlserver);
+        while (true) {
+            lexer.nextToken();
+            if (lexer.token() == Token.EOF) {
+                return starts;
+            }
+            if (lexer.token() == Token.IDENTIFIER && StringUtils.equalsIgnoreCase(lexer.stringVal(), "GO")) {
+                starts.add(lexer.pos() - 2);
+            }
+        }
     }
 
     private String normalizeSqlType(String sqlType, String sql) {
@@ -668,7 +746,9 @@ public class AiToolServiceImpl implements IAiToolService {
         }
         String normalized = sql.stripLeading().toUpperCase(Locale.ROOT);
         if (normalized.startsWith("WITH")) {
-            return SqlTypeEnum.SELECT.name();
+            // A CTE can prefix SELECT, INSERT, UPDATE, or DELETE. Without parser
+            // confirmation, classify it conservatively so DML is never auto-executed.
+            return SqlTypeEnum.OTHER.name();
         }
         if (normalized.startsWith("SELECT")) {
             return SqlTypeEnum.SELECT.name();

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiToolServiceImplTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiToolServiceImplTest.java
@@ -1,0 +1,212 @@
+package ai.chat2db.community.domain.core.impl.ai;
+
+import ai.chat2db.community.domain.api.model.request.ai.AiExecuteSqlRequest;
+import ai.chat2db.community.domain.api.model.runtime.ConnectionProfile;
+import ai.chat2db.community.domain.api.model.sql.SimpleSqlStatement;
+import ai.chat2db.community.domain.api.service.db.IDbConnectionContextService;
+import ai.chat2db.community.domain.api.service.db.IDbDlTemplateService;
+import ai.chat2db.community.domain.api.service.db.IDbSqlService;
+import ai.chat2db.community.domain.api.service.ops.IOpsSqlOperationLogService;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiToolServiceImplTest {
+
+    private static final String CTE_DELETE =
+            "WITH doomed AS (SELECT * FROM users WHERE id = 1) DELETE FROM doomed";
+    private static final String CTE_SELECT =
+            "WITH active AS (SELECT * FROM users) SELECT * FROM active";
+
+    @Test
+    void parserFailureDoesNotAutoExecuteWithPrefixedDml() throws Exception {
+        AtomicInteger executions = new AtomicInteger();
+        AiToolServiceImpl service = service((proxy, method, args) -> {
+            if ("parseStatements".equals(method.getName())) {
+                throw new IllegalStateException("simulated parser failure");
+            }
+            return defaultValue(method.getReturnType());
+        }, executions);
+
+        String result = service.executeSql(request(CTE_DELETE));
+
+        assertEquals(0, executions.get());
+        assertTrue(result.contains("requires manual confirmation"), result);
+    }
+
+    @Test
+    void emptyParserResultDoesNotAutoExecuteWithPrefixedDml() throws Exception {
+        AtomicInteger executions = new AtomicInteger();
+        AiToolServiceImpl service = service((proxy, method, args) ->
+                "parseStatements".equals(method.getName())
+                        ? List.of() : defaultValue(method.getReturnType()), executions);
+
+        String result = service.executeSql(request(CTE_DELETE));
+
+        assertEquals(0, executions.get());
+        assertTrue(result.contains("requires manual confirmation"), result);
+    }
+
+    @Test
+    void parserFailureDoesNotAutoExecuteTrailingStatements() throws Exception {
+        for (String sql : List.of(
+                "SELECT 1; DELETE FROM users",
+                "SHOW TABLES; DROP TABLE users",
+                "DESC users; UPDATE users SET name = 'changed'")) {
+            AtomicInteger executions = new AtomicInteger();
+            AiToolServiceImpl service = parserFailingService(executions);
+
+            String result = service.executeSql(request(sql));
+
+            assertEquals(0, executions.get(), sql);
+            assertTrue(result.contains("requires manual confirmation"), result);
+        }
+    }
+
+    @Test
+    void parserFailureIgnoresSemicolonsInsideLiteralsAndComments() throws Exception {
+        for (String sql : List.of(
+                "SELECT ';' AS marker",
+                "SELECT 1 -- ; DELETE FROM users\n",
+                "SELECT /* ; DELETE FROM users */ 1",
+                "SELECT 1;")) {
+            AtomicInteger executions = new AtomicInteger();
+            AiToolServiceImpl service = parserFailingService(executions);
+
+            String result = service.executeSql(request(sql));
+
+            assertEquals(1, executions.get(), sql);
+            assertTrue(result.contains("executed successfully"), result);
+        }
+    }
+
+    @Test
+    void parserFailureDoesNotAutoExecuteSqlServerGoBatches() throws Exception {
+        for (String sql : List.of(
+                "SELECT 1\nGO\nDELETE FROM users",
+                "SELECT 1;GO\nDELETE FROM users",
+                "SELECT 1\nGO 2\nDELETE FROM users")) {
+            AtomicInteger executions = new AtomicInteger();
+            AiToolServiceImpl service = parserFailingService(executions, "SQLSERVER");
+
+            String result = service.executeSql(request(sql));
+
+            assertEquals(0, executions.get(), sql);
+            assertTrue(result.contains("requires manual confirmation"), result);
+        }
+    }
+
+    @Test
+    void parserFailureIgnoresGoInsideSqlServerLiteralsAndComments() throws Exception {
+        for (String sql : List.of(
+                "SELECT 'first\nGO\nsecond' AS marker",
+                "SELECT 1\n-- GO\n",
+                "SELECT 1\n/*\nGO\n*/",
+                "SELECT 1\nGO\n",
+                "SELECT 1;GO\n")) {
+            AtomicInteger executions = new AtomicInteger();
+            AiToolServiceImpl service = parserFailingService(executions, "SQLSERVER");
+
+            String result = service.executeSql(request(sql));
+
+            assertEquals(1, executions.get(), sql);
+            assertTrue(result.contains("executed successfully"), result);
+        }
+    }
+
+    @Test
+    void parserConfirmedWithSelectRemainsAutoExecutable() throws Exception {
+        AtomicInteger executions = new AtomicInteger();
+        SimpleSqlStatement statement = new SimpleSqlStatement();
+        statement.setSql(CTE_SELECT);
+        statement.setSqlType("SELECT");
+        AiToolServiceImpl service = service((proxy, method, args) ->
+                "parseStatements".equals(method.getName())
+                        ? List.of(statement) : defaultValue(method.getReturnType()), executions);
+
+        String result = service.executeSql(request(CTE_SELECT));
+
+        assertEquals(1, executions.get());
+        assertTrue(result.contains("executed successfully"), result);
+    }
+
+    private static AiToolServiceImpl service(java.lang.reflect.InvocationHandler sqlHandler,
+            AtomicInteger executions) throws Exception {
+        return service(sqlHandler, executions, "MYSQL");
+    }
+
+    private static AiToolServiceImpl service(java.lang.reflect.InvocationHandler sqlHandler,
+            AtomicInteger executions, String dbType) throws Exception {
+        AiToolServiceImpl service = new AiToolServiceImpl();
+        ConnectionProfile profile = new ConnectionProfile();
+        profile.setDataSourceId(7L);
+        profile.setDbType(dbType);
+
+        setField(service, "sqlService", proxy(IDbSqlService.class, sqlHandler));
+        setField(service, "connectionContextService", proxy(IDbConnectionContextService.class,
+                (proxy, method, args) -> "buildProfile".equals(method.getName())
+                        ? profile : defaultValue(method.getReturnType())));
+        setField(service, "dlTemplateService", proxy(IDbDlTemplateService.class,
+                (proxy, method, args) -> {
+                    if ("execute".equals(method.getName())) {
+                        executions.incrementAndGet();
+                        return List.of();
+                    }
+                    return defaultValue(method.getReturnType());
+                }));
+        setField(service, "sqlOperationLogRecorder", proxy(IOpsSqlOperationLogService.class,
+                (proxy, method, args) -> defaultValue(method.getReturnType())));
+        setField(service, "aiSqlAutoExecutionPolicy", new DefaultAiSqlAutoExecutionPolicy());
+        return service;
+    }
+
+    private static AiToolServiceImpl parserFailingService(AtomicInteger executions) throws Exception {
+        return parserFailingService(executions, "MYSQL");
+    }
+
+    private static AiToolServiceImpl parserFailingService(AtomicInteger executions, String dbType) throws Exception {
+        return service((proxy, method, args) -> {
+            if ("parseStatements".equals(method.getName())) {
+                throw new IllegalStateException("simulated parser failure");
+            }
+            return defaultValue(method.getReturnType());
+        }, executions, dbType);
+    }
+
+    private static AiExecuteSqlRequest request(String sql) {
+        AiExecuteSqlRequest request = new AiExecuteSqlRequest();
+        request.setSql(sql);
+        request.setDataSourceId(7L);
+        return request;
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, java.lang.reflect.InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - this defect was found during review of the AI SQL auto-execution policy; no public issue currently tracks it.

## Summary

- Treat parser-fallback `WITH` statements conservatively because a CTE can prefix SELECT or DML.
- Reject parser-fallback multi-statements, including SQL Server `GO` batches, instead of classifying only the leading statement.
- Preserve auto-execution for parser-confirmed query-only CTEs and single fallback query statements.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Focused AI policy tests (`AiToolServiceImplTest` and `DefaultAiSqlAutoExecutionPolicyTest`): 8 passed.
  - Domain-core module tests after rebase: 233 passed; dependency modules passed.
  - `mvn -B test -Dmaven.test.skip=false -DskipTests=false -f chat2db-community-server/pom.xml`: passed in `Community CI / Backend tests and package`.
  - Fork code and CodeQL checks are rerunning for the rebased head.
  - Latest-main revalidation: adversarial SQL Server `GO 2` case first failed (1 unsafe execution), was fixed, then focused 7/7 and full domain-core 233/233 passed; related combined domain-core suite 250/250 and 45/45 pairwise merge simulations passed.
- Manual verification: Independent adversarial review found no unresolved correctness or security issue.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or storage format changes.
- Database or driver compatibility: The new split check runs only when normal SQL parsing throws or returns no classified statements. SQL Server `GO` handling is limited to real lexer tokens outside literals and comments.
- Network, privacy, or security: Fails closed for ambiguous CTEs and multi-statements so AI cannot auto-execute unclassified DML.
- Community / Local / Pro boundary: The community policy still requires manual confirmation for non-query SQL; extension points are unchanged.
- Backward compatibility: Parser-failure CTE queries may now require manual confirmation. This is an intentional safety tradeoff; parser-confirmed query behavior is unchanged.

## Reviewer map

- Start here: `AiToolServiceImpl.resolveSqlTypes`, then the fallback splitting helpers and `AiToolServiceImplTest`.
- Failure condition: A parser exception or empty parser result must not let a CTE-prefixed DML statement or a trailing statement reach `dlTemplateService.execute`; ordinary single SELECT fallback and parser-confirmed CTE SELECT must still execute.
- Rollback or disable path: Revert commit `17e108c01`; there is no runtime flag because this closes an auto-execution safety gap.

## Contributor declaration

- [ ] I linked the Issue that defines this change. (N/A - no public issue exists.)
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for implementation, tests, and adversarial review; the resulting diff and test evidence were manually inspected.
