### PR TITLE
fix(ai): roll back config memory on persistence failure

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImpl.java
@@ -161,42 +161,51 @@ public class AiModelConfigServiceImpl implements IAiModelConfigService {
 
     public synchronized AiModelConfigResponse saveCurrentUserConfig(AiModelConfigSaveRequest request) {
         Long userId = identityService.currentUserId();
-        List<AiModelConfig> configs = userConfigMap.computeIfAbsent(userId, key -> new ArrayList<>());
+        boolean hadUserConfigs = userConfigMap.containsKey(userId);
+        List<AiModelConfig> previousConfigs = copyConfigs(userConfigMap.get(userId));
+        AiModelConfig config;
+        try {
+            List<AiModelConfig> configs = userConfigMap.computeIfAbsent(userId, key -> new ArrayList<>());
 
-        AiModelConfig config = findById(configs, request.getId());
-        boolean isNew = Objects.isNull(config);
-        if (isNew) {
-            config = new AiModelConfig();
-            config.setId(StringUtils.defaultIfBlank(request.getId(), UUID.randomUUID().toString()));
-            config.setUserId(userId);
-            config.setGmtCreate(LocalDateTime.now());
-            configs.add(config);
+            config = findById(configs, request.getId());
+            boolean isNew = Objects.isNull(config);
+            if (isNew) {
+                config = new AiModelConfig();
+                config.setId(StringUtils.defaultIfBlank(request.getId(), UUID.randomUUID().toString()));
+                config.setUserId(userId);
+                config.setGmtCreate(LocalDateTime.now());
+                configs.add(config);
+            }
+
+            String originalApiKey = config.getApiKey();
+            updateModelConfig(request, config);
+            config.setEnabled(defaultBoolean(config.getEnabled(), Boolean.TRUE));
+            config.setDefaultConfig(defaultBoolean(config.getDefaultConfig(), Boolean.FALSE));
+            config.setGmtModified(LocalDateTime.now());
+
+            if (StringUtils.isBlank(request.getApiKey()) && StringUtils.isNotBlank(originalApiKey)) {
+                config.setApiKey(originalApiKey);
+            } else if (StringUtils.isNotBlank(request.getApiKey())) {
+                config.setApiKey(request.getApiKey().trim());
+            }
+
+            if (Boolean.TRUE.equals(config.getDefaultConfig())) {
+                String currentId = config.getId();
+                configs.forEach(item -> {
+                    if (!Objects.equals(currentId, item.getId())) {
+                        item.setDefaultConfig(Boolean.FALSE);
+                    }
+                });
+            } else if (CollectionUtils.isNotEmpty(configs)
+                    && configs.stream().noneMatch(c -> Boolean.TRUE.equals(c.getDefaultConfig()))) {
+                configs.get(0).setDefaultConfig(Boolean.TRUE);
+            }
+
+            persistToDisk();
+        } catch (RuntimeException e) {
+            restoreUserConfigs(userId, hadUserConfigs, previousConfigs);
+            throw e;
         }
-
-        String originalApiKey = config.getApiKey();
-        updateModelConfig(request, config);
-        config.setEnabled(defaultBoolean(config.getEnabled(), Boolean.TRUE));
-        config.setDefaultConfig(defaultBoolean(config.getDefaultConfig(), Boolean.FALSE));
-        config.setGmtModified(LocalDateTime.now());
-
-        if (StringUtils.isBlank(request.getApiKey()) && StringUtils.isNotBlank(originalApiKey)) {
-            config.setApiKey(originalApiKey);
-        } else if (StringUtils.isNotBlank(request.getApiKey())) {
-            config.setApiKey(request.getApiKey().trim());
-        }
-
-        if (Boolean.TRUE.equals(config.getDefaultConfig())) {
-            String currentId = config.getId();
-            configs.forEach(item -> {
-                if (!Objects.equals(currentId, item.getId())) {
-                    item.setDefaultConfig(Boolean.FALSE);
-                }
-            });
-        } else if (CollectionUtils.isNotEmpty(configs) && configs.stream().noneMatch(c -> Boolean.TRUE.equals(c.getDefaultConfig()))) {
-            configs.get(0).setDefaultConfig(Boolean.TRUE);
-        }
-
-        persistToDisk();
         return aiModelConfigConverter.toMaskedResponse(config);
     }
 
@@ -206,12 +215,40 @@ public class AiModelConfigServiceImpl implements IAiModelConfigService {
         if (CollectionUtils.isEmpty(configs)) {
             return;
         }
-        boolean removedDefault = configs.stream().anyMatch(c -> Objects.equals(c.getId(), id) && Boolean.TRUE.equals(c.getDefaultConfig()));
-        configs.removeIf(c -> Objects.equals(c.getId(), id));
-        if (removedDefault && CollectionUtils.isNotEmpty(configs)) {
-            configs.get(0).setDefaultConfig(Boolean.TRUE);
+        List<AiModelConfig> previousConfigs = copyConfigs(configs);
+        try {
+            boolean removedDefault = configs.stream()
+                    .anyMatch(c -> Objects.equals(c.getId(), id) && Boolean.TRUE.equals(c.getDefaultConfig()));
+            configs.removeIf(c -> Objects.equals(c.getId(), id));
+            if (removedDefault && CollectionUtils.isNotEmpty(configs)) {
+                configs.get(0).setDefaultConfig(Boolean.TRUE);
+            }
+            persistToDisk();
+        } catch (RuntimeException e) {
+            userConfigMap.put(userId, previousConfigs);
+            throw e;
         }
-        persistToDisk();
+    }
+
+    private List<AiModelConfig> copyConfigs(List<AiModelConfig> configs) {
+        if (configs == null) {
+            return null;
+        }
+        return configs.stream().map(this::copyConfig).collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private AiModelConfig copyConfig(AiModelConfig config) {
+        AiModelConfig copy = new AiModelConfig();
+        BeanUtils.copyProperties(config, copy);
+        return copy;
+    }
+
+    private void restoreUserConfigs(Long userId, boolean hadUserConfigs, List<AiModelConfig> previousConfigs) {
+        if (hadUserConfigs) {
+            userConfigMap.put(userId, previousConfigs);
+        } else {
+            userConfigMap.remove(userId);
+        }
     }
 
     public ModelConfigTestResponse testModelConfig(AiModelConfigSaveRequest request) {

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImplStorageTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiModelConfigServiceImplStorageTest.java
@@ -226,6 +226,46 @@ class AiModelConfigServiceImplStorageTest {
         assertEquals(0, randomTempFileCount());
     }
 
+    @Test
+    void failedCreateDoesNotPublishConfigInMemory() {
+        FailingAiModelConfigService failing = new FailingAiModelConfigService();
+
+        assertThrows(IllegalStateException.class,
+                () -> failing.saveCurrentUserConfig(saveRequest("replacement", "sk-replacement-123456")));
+
+        assertTrue(failing.listCurrentUserConfigs().isEmpty());
+    }
+
+    @Test
+    void failedUpdateRestoresConfigInMemory() {
+        AiModelConfigResponse saved = service(KEY).saveCurrentUserConfig(saveRequest("primary", API_KEY));
+        FailingAiModelConfigService failing = new FailingAiModelConfigService();
+        failing.init();
+        AiModelConfigSaveRequest update = saveRequest("replacement", "sk-replacement-123456");
+        update.setId(saved.getId());
+
+        assertThrows(IllegalStateException.class, () -> failing.saveCurrentUserConfig(update));
+
+        List<AiModelConfigResponse> configs = failing.listCurrentUserConfigs();
+        assertEquals(1, configs.size());
+        assertEquals("primary", configs.get(0).getName());
+        assertEquals(API_KEY, resolveApiKey(failing, saved.getId()));
+    }
+
+    @Test
+    void failedDeleteRestoresConfigInMemory() {
+        AiModelConfigResponse saved = service(KEY).saveCurrentUserConfig(saveRequest("primary", API_KEY));
+        FailingAiModelConfigService failing = new FailingAiModelConfigService();
+        failing.init();
+
+        assertThrows(IllegalStateException.class, () -> failing.deleteCurrentUserConfig(saved.getId()));
+
+        List<AiModelConfigResponse> configs = failing.listCurrentUserConfigs();
+        assertEquals(1, configs.size());
+        assertEquals(saved.getId(), configs.get(0).getId());
+        assertEquals(API_KEY, resolveApiKey(failing, saved.getId()));
+    }
+
     private AiModelConfigServiceImpl service(String key) {
         return new AiModelConfigServiceImpl(objectMapper, new AiModelConfigConverter(), () -> USER_ID,
                 storagePath, new AesGcmUtil(key));


### PR DESCRIPTION
## Related issue

N/A - this defect was found during review of AI model configuration persistence; no public issue currently tracks it.

## Summary

- Snapshot the current user's model configurations before create, update, or delete mutations.
- Restore the prior in-memory state when atomic disk persistence fails.
- Preserve successful persistence behavior and avoid changing other users' configurations.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `AiModelConfigServiceImplStorageTest`: 17 passed.
  - AI model configuration test suite: 30 passed.
  - Domain-core module tests after rebase: 229 passed; dependency modules passed.
  - `mvn -B test -Dmaven.test.skip=false -DskipTests=false -f chat2db-community-server/pom.xml`: passed in `Community CI / Backend tests and package`.
  - Fork code and CodeQL checks are rerunning for the rebased head.
  - Latest-main revalidation: focused 17/17 and full domain-core module 229/229 passed; related combined domain-core suite 250/250 and 45/45 pairwise merge simulations passed.
- Manual verification: Independent adversarial review found no unresolved correctness, isolation, or secret-handling issue.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No public API or on-disk schema/format changes; rollback snapshots exist only in process memory.
- Database or driver compatibility: N/A - no database or driver behavior changes.
- Network, privacy, or security: API keys remain in the same in-memory model objects and are neither logged nor added to responses; rollback copies do not leave process memory.
- Community / Local / Pro boundary: No boundary or edition-specific behavior changes.
- Backward compatibility: Successful saves/deletes are unchanged. Failed persistence now restores memory to match the unchanged disk file instead of exposing an uncommitted mutation.

## Reviewer map

- Start here: `AiModelConfigServiceImpl.saveCurrentUserConfig`, `deleteCurrentUserConfig`, and the three new failure-path storage tests.
- Failure condition: When `persistToDisk` throws, a failed create must not appear in `listCurrentUserConfigs`, and failed update/delete operations must restore the previous name, API key, identity, and default selection.
- Rollback or disable path: Revert commit `ea930401e`; the previous behavior is otherwise unchanged and there is no runtime flag.

## Contributor declaration

- [ ] I linked the Issue that defines this change. (N/A - no public issue exists.)
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for implementation, tests, and adversarial review; the resulting diff and test evidence were manually inspected.
