### PR TITLE
fix(storage): make console pagination overflow-safe

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/model/operation/Operation.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/model/operation/Operation.java
@@ -6,7 +6,6 @@ import lombok.Data;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 
@@ -58,10 +57,10 @@ public class Operation {
             return Lists.newArrayList();
         }
         List<Operation> result = new ArrayList<>();
-        Collections.reverse(operations);
-        int start = (pageNo - 1) * pageSize;
-        int n = 0;
-        for (Operation o : operations) {
+        long start = ((long) pageNo - 1L) * pageSize;
+        long n = 0L;
+        for (int index = operations.size() - 1; index >= 0; index--) {
+            Operation o = operations.get(index);
             if (select(o)) {
                 if (n >= start) {
                     result.add(o);

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/LocalWorkspaceStoragePaginationTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/LocalWorkspaceStoragePaginationTest.java
@@ -78,6 +78,29 @@ class LocalWorkspaceStoragePaginationTest {
     }
 
     @Test
+    void consoleSelectorReturnsEmptyPageBeyondIntegerOffsetRange() {
+        ConsoleStorage.INSTANCE.save(new Operation());
+
+        List<Operation> page = ConsoleStorage.INSTANCE.getDataList(
+                new Operation(), Integer.MAX_VALUE, 2);
+
+        assertTrue(page.isEmpty());
+    }
+
+    @Test
+    void operationSelectorDoesNotReverseCallerOwnedList() {
+        Operation first = operation(1L);
+        Operation second = operation(2L);
+        Operation third = operation(3L);
+        List<Operation> operations = new ArrayList<>(List.of(first, second, third));
+
+        List<Operation> page = new Operation().select(operations, 1, 2);
+
+        assertEquals(List.of(third, second), page);
+        assertEquals(List.of(first, second, third), operations);
+    }
+
+    @Test
     void operationLogListReturnsOnlyTheRequestedSlice() {
         for (int i = 0; i < 5; i++) {
             OperationLogStorage.INSTANCE.save(new OperationLog());
@@ -190,5 +213,11 @@ class LocalWorkspaceStoragePaginationTest {
         } finally {
             System.clearProperty(AesGcmUtil.KEY_PROPERTY);
         }
+    }
+
+    private static Operation operation(long id) {
+        Operation operation = new Operation();
+        operation.setId(id);
+        return operation;
     }
 }


### PR DESCRIPTION
## Related issue

N/A — found by deterministic local-storage pagination audit.

## Summary

Make console record selection overflow-safe by calculating the matching-row offset with long arithmetic. Iterate the source list from newest to oldest by index so the returned ordering stays unchanged while the caller-owned list is no longer reversed in place. Far-out positive pages now return an empty list instead of wrapping to an earlier page.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-storage -am -Dmaven.test.skip=false -DskipTests=false -Dtest=LocalWorkspaceStoragePaginationTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test — reproduced two baseline failures (far page returned a record and the input list was reversed), then passed 8/8 after the fix.
  - mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-storage -am -Dmaven.test.skip=false -DskipTests=false -Dsurefire.includes=**/*Test.java -Dmaven.test.failure.ignore=false package — passed after rebase: Tools 68/68, Domain API 27/27, Storage 59/59; all six reactor modules succeeded and the storage JAR was produced.
  - Latest-main revalidation: focused 8/8 and full storage module 59/59 passed; related combined storage suite 85/85 and 45/45 pairwise merge simulations passed.
- Manual verification: N/A — deterministic shared model and storage pagination logic.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: Operation.select no longer mutates its input list; returned newest-first ordering and filters are preserved. No stored-data format changes.
- Database or driver compatibility: N/A — no database or driver behavior changed.
- Network, privacy, or security: N/A — in-memory local console selection only.
- Community / Local / Pro boundary: Shared Operation API plus the existing local ConsoleStorage path; runtime registration is unchanged.
- Backward compatibility: Normal pages return the same records in the same order; only overflowed far pages and the unintended input mutation change.

## Reviewer map

- Start here: Operation.select, consoleSelectorReturnsEmptyPageBeyondIntegerOffsetRange, and operationSelectorDoesNotReverseCallerOwnedList.
- Failure condition: A far-out positive page returns records, the input list order changes, or normal newest-first pagination changes.
- Rollback or disable path: Revert 0fb0d1520148a04d22bc0198740aa5d81a640b97; there is no runtime flag or storage migration.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for repository analysis, implementation, deterministic tests, and adversarial review.