### PR TITLE
fix(xugudb): return distinct view records

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/main/java/ai/chat2db/plugin/xugudb/XUGUDBMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/main/java/ai/chat2db/plugin/xugudb/XUGUDBMetaData.java
@@ -224,10 +224,10 @@ public class XUGUDBMetaData extends DefaultMetaService implements IDbMetaData {
         String sql = String.format(VIEW_SQL_LIST, getSQLIdentifierProcessor().escapeString(databaseName), getSQLIdentifierProcessor().escapeString(schemaName));
         List<Table> tables = new ArrayList<>();
         return DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> {
-            Table table = new Table();
-            table.setDatabaseName(databaseName);
-            table.setSchemaName(schemaName);
             while (resultSet.next()) {
+                Table table = new Table();
+                table.setDatabaseName(databaseName);
+                table.setSchemaName(schemaName);
                 table.setName(resultSet.getString("VIEW_NAME"));
                 table.setDdl(resultSet.getString("DEFINE"));
                 tables.add(table);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/test/java/ai/chat2db/plugin/xugudb/XUGUDBViewMetadataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/test/java/ai/chat2db/plugin/xugudb/XUGUDBViewMetadataTest.java
@@ -1,0 +1,80 @@
+package ai.chat2db.plugin.xugudb;
+
+import ai.chat2db.community.domain.api.model.metadata.Table;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class XUGUDBViewMetadataTest {
+
+    @Test
+    void viewsMapsEachRowToItsOwnTableInstance() {
+        List<Table> views = new XUGUDBMetaData().views(
+                connection(viewResultSet(new String[][]{{"V1", "SELECT 1"}, {"V2", "SELECT 2"}})),
+                "DB", "SCH");
+
+        assertEquals(2, views.size());
+        assertNotSame(views.get(0), views.get(1));
+        assertEquals("V1", views.get(0).getName());
+        assertEquals("SELECT 1", views.get(0).getDdl());
+        assertEquals("V2", views.get(1).getName());
+        assertEquals("SELECT 2", views.get(1).getDdl());
+    }
+
+    @Test
+    void viewsReturnsEmptyListWhenTheResultSetIsEmpty() {
+        List<Table> views = new XUGUDBMetaData().views(
+                connection(viewResultSet(new String[0][0])), "DB", "SCH");
+
+        assertTrue(views.isEmpty());
+    }
+
+    private static Connection connection(ResultSet resultSet) {
+        PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                XUGUDBViewMetadataTest.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "execute" -> true;
+                    case "getResultSet" -> resultSet;
+                    default -> defaultValue(method.getReturnType());
+                });
+        return (Connection) Proxy.newProxyInstance(
+                XUGUDBViewMetadataTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> "prepareStatement".equals(method.getName())
+                        ? statement : defaultValue(method.getReturnType()));
+    }
+
+    private static ResultSet viewResultSet(String[][] rows) {
+        int[] row = {-1};
+        return (ResultSet) Proxy.newProxyInstance(
+                XUGUDBViewMetadataTest.class.getClassLoader(),
+                new Class<?>[]{ResultSet.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "next" -> ++row[0] < rows.length;
+                    case "getString" -> "VIEW_NAME".equals(args[0]) ? rows[row[0]][0] : rows[row[0]][1];
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

XUGUDB view listing allocated one Table object outside the ResultSet loop, so every returned list entry aliased the same object and ended with the final row's name and definition. This change creates one Table per row while preserving database, schema, row order, and empty-result behavior.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Focused XUGUDBViewMetadataTest run: 2 tests passed, 0 failures/errors.
  - XUGUDB module tests after rebase: 39 passed; dependency modules passed. Combined with #2819: 4 focused tests passed.
  - Fork code and CodeQL checks are rerunning for the rebased head.
  - git diff --check main..HEAD: passed.
  - Latest-main revalidation: focused 2/2 and full XuguDB module 39/39 passed; combined XuguDB suite 41/41 and 45/45 pairwise merge simulations passed.
- Manual verification: N/A - JDBC proxies cover multiple rows, object identity, row values, and an empty ResultSet.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or storage-format changes.
- Database or driver compatibility: XUGUDB view metadata only; SQL and ResultSet column names are unchanged.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community XUGUDB plugin only.
- Backward compatibility: View ordering and fields are preserved; object identity is corrected.

## Reviewer map

- Start here: XUGUDBMetaData.views and XUGUDBViewMetadataTest.
- Failure condition: Two metadata rows return the same Table instance, expose the final row twice, or an empty ResultSet returns a non-empty list.
- Rollback or disable path: Revert commit a579e3613; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.
