### PR TITLE
fix(xugudb): preserve nullable column ordinals

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/main/java/ai/chat2db/plugin/xugudb/XUGUDBMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/main/java/ai/chat2db/plugin/xugudb/XUGUDBMetaData.java
@@ -329,7 +329,8 @@ public class XUGUDBMetaData extends DefaultMetaService implements IDbMetaData {
                 column.setDefaultValue(resultSet.getString("DEF_VAL"));
                 column.setComment(resultSet.getString("COMMENTS"));
                 column.setNullable(resultSet.getBoolean("NOT_NULL") ? 0 : 1);
-                column.setOrdinalPosition(resultSet.getInt("SCALE"));
+                int ordinalPosition = resultSet.getInt("COL_NO");
+                column.setOrdinalPosition(resultSet.wasNull() ? null : ordinalPosition);
                 column.setColumnSize(resultSet.getInt("SCALE") == -1 ? null : resultSet.getInt("SCALE"));
                 tableColumns.add(column);
             }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/test/java/ai/chat2db/plugin/xugudb/XUGUDBMetaDataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/test/java/ai/chat2db/plugin/xugudb/XUGUDBMetaDataTest.java
@@ -1,0 +1,110 @@
+package ai.chat2db.plugin.xugudb;
+
+import ai.chat2db.community.domain.api.model.metadata.TableColumn;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class XUGUDBMetaDataTest {
+
+    @Test
+    void columnsUsesColumnNumberForOrdinalAndKeepsScaleAsColumnSize() {
+        List<TableColumn> columns = new XUGUDBMetaData().columns(
+                connection(columnResultSet(7, 2)), "DB", "SCH", "T1");
+
+        assertEquals(1, columns.size());
+        assertEquals(7, columns.get(0).getOrdinalPosition());
+        assertEquals(2, columns.get(0).getColumnSize());
+    }
+
+    @Test
+    void columnsPreservesNullOrdinalAndMinusOneScaleAsNull() {
+        List<TableColumn> columns = new XUGUDBMetaData().columns(
+                connection(columnResultSet(null, -1)), "DB", "SCH", "T1");
+
+        assertEquals(1, columns.size());
+        assertNull(columns.get(0).getOrdinalPosition());
+        assertNull(columns.get(0).getColumnSize());
+    }
+
+    private static Connection connection(ResultSet resultSet) {
+        PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                XUGUDBMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "execute" -> true;
+                    case "getResultSet" -> resultSet;
+                    default -> defaultValue(method.getReturnType());
+                });
+        return (Connection) Proxy.newProxyInstance(
+                XUGUDBMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> "prepareStatement".equals(method.getName())
+                        ? statement : defaultValue(method.getReturnType()));
+    }
+
+    private static ResultSet columnResultSet(Integer columnNumber, Integer scale) {
+        boolean[] unread = {true};
+        boolean[] wasNull = {false};
+        return (ResultSet) Proxy.newProxyInstance(
+                XUGUDBMetaDataTest.class.getClassLoader(),
+                new Class<?>[]{ResultSet.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "next" -> {
+                        boolean hasRow = unread[0];
+                        unread[0] = false;
+                        yield hasRow;
+                    }
+                    case "getString" -> {
+                        String value = switch ((String) args[0]) {
+                            case "COL_NAME" -> "C1";
+                            case "TYPE_NAME" -> "VARCHAR";
+                            case "DEF_VAL" -> null;
+                            case "COMMENTS" -> "comment";
+                            default -> throw new AssertionError("Unexpected string column: " + args[0]);
+                        };
+                        wasNull[0] = value == null;
+                        yield value;
+                    }
+                    case "getBoolean" -> {
+                        String column = (String) args[0];
+                        if (!"VARYING".equals(column) && !"NOT_NULL".equals(column)) {
+                            throw new AssertionError("Unexpected boolean column: " + column);
+                        }
+                        wasNull[0] = false;
+                        yield false;
+                    }
+                    case "getInt" -> {
+                        Integer value = switch ((String) args[0]) {
+                            case "COL_NO" -> columnNumber;
+                            case "SCALE" -> scale;
+                            default -> throw new AssertionError("Unexpected integer column: " + args[0]);
+                        };
+                        wasNull[0] = value == null;
+                        yield value == null ? 0 : value;
+                    }
+                    case "wasNull" -> wasNull[0];
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

XUGUDB column metadata used SCALE as the ordinal position even though the catalog query orders columns by COL_NO. This change reads the ordinal from COL_NO, immediately preserves JDBC NULL through wasNull(), and leaves the existing SCALE-based columnSize behavior unchanged.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Focused XUGUDBMetaDataTest run: 2 tests passed, 0 failures/errors.
  - XUGUDB module tests after rebase: 39 passed; dependency modules passed.
  - Fork code and CodeQL checks are rerunning for the rebased head.
  - git diff --check main..HEAD: passed.
  - Latest-main revalidation: focused 2/2 and full XuguDB module 39/39 passed; combined XuguDB suite 41/41 and 45/45 pairwise merge simulations passed.
- Manual verification: N/A - a strict JDBC proxy distinguishes COL_NO from SCALE, tracks last-read wasNull state, and covers COL_NO NULL plus SCALE -1.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or storage-format changes.
- Database or driver compatibility: XUGUDB column metadata only; catalog SQL is unchanged.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community XUGUDB plugin only.
- Backward compatibility: Non-null ordinals now reflect COL_NO; nullable ordinals remain null, and existing SCALE columnSize semantics are preserved.

## Reviewer map

- Start here: XUGUDBMetaData.columns and XUGUDBMetaDataTest.
- Failure condition: Ordinal position is read from SCALE, JDBC NULL becomes zero, or SCALE -1 no longer maps columnSize to null.
- Rollback or disable path: Revert commit 07a8c75a8; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.