### PR TITLE
fix(storage): honor local datasource filters

### DIFF
--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/LocalWorkspaceStorage.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/LocalWorkspaceStorage.java
@@ -1,6 +1,7 @@
 package ai.chat2db.community.storage;
 
 import ai.chat2db.community.domain.api.model.PageResponse;
+import ai.chat2db.community.domain.api.enums.DataSourceKindEnum;
 import ai.chat2db.community.domain.api.enums.StorageTypeEnum;
 import ai.chat2db.community.domain.api.model.datasource.DataSource;
 import ai.chat2db.community.domain.api.model.datasource.DataSourceIdentityColorUtils;
@@ -28,6 +29,7 @@ import ai.chat2db.community.tools.exception.DataNotFoundException;
 import ai.chat2db.community.tools.wrapper.result.DataResult;
 import cn.hutool.core.date.DatePattern;
 import cn.hutool.core.date.DateUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
@@ -98,7 +100,17 @@ public class LocalWorkspaceStorage implements IWorkspaceStorage {
 
     @Override
     public PageResponse<WorkspaceDataSource> listDataSources(DbDataSourcePageQueryRequest dataSourcePageQueryRequest) {
-        List<DataSource> dataSources = DataSourceStorage.INSTANCE.getDataList();
+        String searchKey = dataSourcePageQueryRequest.getSearchKey();
+        String kind = dataSourcePageQueryRequest.getKind();
+        List<DataSource> dataSources = DataSourceStorage.INSTANCE.getDataList().stream()
+                .filter(dataSource -> StringUtils.isBlank(searchKey)
+                        || StringUtils.containsIgnoreCase(dataSource.getAlias(), searchKey))
+                .filter(dataSource -> StringUtils.isBlank(kind)
+                        || StringUtils.equalsIgnoreCase(
+                                dataSource.getKind() == null
+                                        ? DataSourceKindEnum.PRIVATE.getCode() : dataSource.getKind(),
+                                kind))
+                .toList();
         List<WorkspaceDataSource> result = storageConverter.dataSource2workspace(dataSources);
         result.forEach(dataSource -> dataSource.setStorageType(StorageTypeEnum.LOCAL.name()));
         return page(result, dataSourcePageQueryRequest.getPageNo(), dataSourcePageQueryRequest.getPageSize());

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/LocalWorkspaceStorageDataSourceFilterTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/LocalWorkspaceStorageDataSourceFilterTest.java
@@ -1,0 +1,110 @@
+package ai.chat2db.community.storage;
+
+import ai.chat2db.community.domain.api.model.PageResponse;
+import ai.chat2db.community.domain.api.model.datasource.DataSource;
+import ai.chat2db.community.domain.api.model.request.datasource.DbDataSourcePageQueryRequest;
+import ai.chat2db.community.domain.api.model.storage.WorkspaceDataSource;
+import ai.chat2db.community.storage.converter.StorageConverterImpl;
+import ai.chat2db.community.storage.small.DataSourceStorage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalWorkspaceStorageDataSourceFilterTest {
+
+    private LocalWorkspaceStorage workspaceStorage;
+
+    @BeforeAll
+    static void useTempHome() {
+        TestHome.init();
+    }
+
+    @BeforeEach
+    void setUp() {
+        workspaceStorage = new LocalWorkspaceStorage(new StorageConverterImpl());
+        List<Long> ids = DataSourceStorage.INSTANCE.getDataList().stream()
+                .map(DataSource::getId)
+                .toList();
+        new ArrayList<>(ids).forEach(DataSourceStorage.INSTANCE::delete);
+    }
+
+    @Test
+    void listDataSourcesAppliesCaseInsensitiveSearchBeforePagingAndTotal() {
+        saveDataSource(null, "PRIVATE");
+        saveDataSource("Unrelated", "SHARED");
+        saveDataSource("Alpha Primary", "PRIVATE");
+        saveDataSource("alpha Replica", "SHARED");
+        DbDataSourcePageQueryRequest request = new DbDataSourcePageQueryRequest();
+        request.setSearchKey("ALPHA");
+        request.setPageNo(1);
+        request.setPageSize(1);
+
+        PageResponse<WorkspaceDataSource> page1 = workspaceStorage.listDataSources(request);
+        assertEquals(List.of("Alpha Primary"), page1.getData().stream().map(WorkspaceDataSource::getAlias).toList());
+        assertEquals(2L, page1.getTotal());
+        assertTrue(page1.getHasNextPage());
+
+        request.setPageNo(2);
+        PageResponse<WorkspaceDataSource> page2 = workspaceStorage.listDataSources(request);
+        assertEquals(List.of("alpha Replica"), page2.getData().stream().map(WorkspaceDataSource::getAlias).toList());
+        assertEquals(2L, page2.getTotal());
+        assertFalse(page2.getHasNextPage());
+    }
+
+    @Test
+    void listDataSourcesIgnoresBlankSearchAndKindFilters() {
+        saveDataSource(null, "PRIVATE");
+        saveDataSource("Beta", "SHARED");
+        DbDataSourcePageQueryRequest request = new DbDataSourcePageQueryRequest();
+        request.setSearchKey(" \t ");
+        request.setKind("   ");
+        request.setPageNo(1);
+        request.setPageSize(10);
+
+        PageResponse<WorkspaceDataSource> page = workspaceStorage.listDataSources(request);
+
+        assertEquals(2, page.getData().size());
+        assertNull(page.getData().get(0).getAlias());
+        assertEquals("Beta", page.getData().get(1).getAlias());
+        assertEquals(2L, page.getTotal());
+    }
+
+    @Test
+    void listDataSourcesMatchesKindIgnoringCaseAndTreatsLegacyNullAsPrivate() {
+        saveDataSource("Shared First", "SHARED");
+        saveDataSource("Legacy Private", null);
+        saveDataSource("Private First", "PRIVATE");
+        DbDataSourcePageQueryRequest request = new DbDataSourcePageQueryRequest();
+        request.setKind("private");
+        request.setPageNo(1);
+        request.setPageSize(1);
+
+        PageResponse<WorkspaceDataSource> page1 = workspaceStorage.listDataSources(request);
+        assertEquals(List.of("Legacy Private"),
+                page1.getData().stream().map(WorkspaceDataSource::getAlias).toList());
+        assertEquals(2L, page1.getTotal());
+        assertTrue(page1.getHasNextPage());
+
+        request.setPageNo(2);
+        PageResponse<WorkspaceDataSource> page2 = workspaceStorage.listDataSources(request);
+        assertEquals(List.of("Private First"),
+                page2.getData().stream().map(WorkspaceDataSource::getAlias).toList());
+        assertEquals(2L, page2.getTotal());
+        assertFalse(page2.getHasNextPage());
+    }
+
+    private static void saveDataSource(String alias, String kind) {
+        DataSource dataSource = new DataSource();
+        dataSource.setAlias(alias);
+        dataSource.setKind(kind);
+        DataSourceStorage.INSTANCE.save(dataSource);
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - this defect was found during review of local datasource pagination; no public issue currently tracks it.

## Summary

- Apply alias search and datasource-kind filters before pagination and total calculation.
- Match the actual `PRIVATE` and `SHARED` kind codes case-insensitively.
- Treat legacy null kinds as private and handle null aliases without failing.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Reproduced on current main: the original 3 filter tests ran with 2 failures (name and kind filters ignored).
- After integration with main, storage reactor package passed: storage 65, tools 77, domain-api 27; 169 tests, zero failures/errors/skips.
- Command: `mvn -B -ntp -f chat2db-community-server/pom.xml -pl :chat2db-community-storage -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false package`. Test JVM home/temp directories were isolated.
- Executable backend package passed. Fresh Playwright CLI verification created four SQLite connections through the UI and checked real browser requests for case-insensitive search, both result pages, out-of-range pages, totals, empty results, blank filters and reload.
- The two PR files in the integrated head are byte-identical to the Web-tested version. New-head checks are available below.
- Scope: the Web list request exposes searchKey but does not expose kind; kind filtering is verified at the storage layer. This does not change sidebar tree search.

## Risk and compatibility

- Public API or stored data: No request/response or on-disk schema changes. Existing query fields now affect local storage results as their contract requires.
- Database or driver compatibility: N/A - filtering is limited to the local datasource store.
- Network, privacy, or security: N/A - no network, credential, or password handling changes.
- Community / Local / Pro boundary: The change is confined to `LocalWorkspaceStorage`; other storage implementations and editions are unchanged.
- Backward compatibility: Unfiltered listing order and pagination are unchanged. Legacy records with a null kind are intentionally included by the private filter.

## Reviewer map

- Reviewer: `@openai0229` (default CODEOWNER for community storage).
- Start here: `LocalWorkspaceStorage.listDataSources`, then the three filter-focused cases in `LocalWorkspaceStorageDataSourceFilterTest`.
- Failure condition: Search and kind filters must be applied before slicing and total calculation; null aliases must not throw, and legacy null kinds must match `PRIVATE`.
- Rollback or disable path: Revert commit `7191e49bd0a96a88d1e786558bc6a54714e77147`; there is no runtime flag because this makes existing request fields effective for local storage.

## Contributor declaration

- [ ] I linked the Issue that defines this change. (N/A - no public issue exists.)
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for implementation, tests, and adversarial review; the resulting diff and test evidence were manually inspected.
