### PR TITLE
fix(client): surface desktop AI stream request failures

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -63,7 +63,7 @@
     "test:search-result-tab-selection": "tsx src/blocks/SearchResult/tabSelection.test.ts",
     "test:saved-console-tree-refresh": "tsx src/store/tree/savedConsoleTreeRefresh.test.ts",
     "test:saved-console-lifecycle": "tsx src/store/workspace/utils/savedConsoleLifecycle.test.ts && tsx src/store/workspace/utils/workspaceTabPersistence.test.ts",
-    "test:sse-request": "tsx src/components/SSERequest/requestOwnership.test.ts && tsx src/components/SSERequest/requestTransport.test.ts",
+    "test:sse-request": "tsx src/components/SSERequest/requestOwnership.test.ts && tsx src/components/SSERequest/requestTransport.test.ts && tsx src/service/sse/requestFailure.test.ts",
     "test:settings-layout": "tsx src/blocks/Setting/navigation.test.ts && tsx src/blocks/Setting/search.test.ts && tsx src/blocks/Setting/BaseSetting/model.test.ts && tsx src/client-extension/settingMenus.test.ts && tsx src/blocks/Setting/settingsLayout.test.ts",
     "test:shortcut": "tsx src/constants/shortcut.test.ts && tsx src/utils/appTitleBarAction.test.ts && tsx src/layouts/GlobalLayout/AppTitleBar/platform.test.ts && tsx src/utils/jcefZoom.test.ts && tsx src/utils/shortcutDispatch.test.ts",
     "test:sql-execution-log": "tsx src/service/sqlExecutionLog.test.ts",

--- a/chat2db-community-client/src/service/sse/index.tsx
+++ b/chat2db-community-client/src/service/sse/index.tsx
@@ -1,5 +1,7 @@
 import { useGlobalStore } from '@/store/global';
+import { JcefEventBus } from '@/jcef/eventBus';
 import { v4 as uuidv4 } from 'uuid';
+import { dispatchDesktopStreamRequest } from './requestFailure';
 
 export interface IJcefSseRequest {
   requestId: string;
@@ -35,10 +37,11 @@ const sendClientSSERequest = (baseURL, message) => {
     }),
   );
 
-  window.javaQuery({
-    request: JSON.stringify(res),
-    onSuccess: function () {},
-    onFailure: function () {},
+  dispatchDesktopStreamRequest({
+    requestId,
+    serializedRequest: JSON.stringify(res),
+    javaQuery: typeof window.javaQuery === 'function' ? (request) => window.javaQuery(request) : undefined,
+    publish: (eventName, output) => JcefEventBus.publish(eventName, output),
   });
 
   return {

--- a/chat2db-community-client/src/service/sse/requestFailure.test.ts
+++ b/chat2db-community-client/src/service/sse/requestFailure.test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { JcefEventBus } from '@/jcef/eventBus';
+import { createClientRequestHandle } from '@/components/SSERequest/clientRequestHandle';
+import type { SSERequestCallbacks } from '@/components/SSERequest';
+import {
+  buildStreamErrorOutput,
+  dispatchDesktopStreamRequest,
+  describeRequestFailure,
+  extractEnvelopeErrorMessage,
+  streamEventName,
+} from './requestFailure';
+
+const testExtractEnvelopeErrorMessage = () => {
+  const errorEnvelope = JSON.stringify({
+    actionType: 'error',
+    uuid: 'req-1',
+    message: { success: false, errorCode: 'model.invalid', errorMessage: 'AI model is not available' },
+  });
+  assert.equal(extractEnvelopeErrorMessage(errorEnvelope), 'AI model is not available');
+
+  assert.equal(
+    extractEnvelopeErrorMessage({ actionType: 'error', message: { success: false } }),
+    'AI stream request failed',
+  );
+
+  const failedActionResultOnly = { actionType: 'execute', message: { success: false, errorMessage: 'boom' } };
+  assert.equal(extractEnvelopeErrorMessage(failedActionResultOnly), 'boom');
+
+  assert.equal(extractEnvelopeErrorMessage(JSON.stringify({ actionType: 'execute', uuid: 'req-1' })), undefined);
+  assert.equal(extractEnvelopeErrorMessage({ actionType: 'execute', message: { success: true } }), undefined);
+  assert.equal(extractEnvelopeErrorMessage('not json'), undefined);
+  assert.equal(extractEnvelopeErrorMessage(undefined), undefined);
+  assert.equal(extractEnvelopeErrorMessage(42), undefined);
+};
+
+const testDescribeRequestFailure = () => {
+  assert.equal(describeRequestFailure(500, 'bridge unavailable'), 'bridge unavailable');
+  assert.equal(describeRequestFailure(500, '   '), 'AI stream request failed (500)');
+  assert.equal(describeRequestFailure(undefined, undefined), 'AI stream request failed');
+};
+
+const testPublishedFailureSettlesStreamHandle = async () => {
+  const eventName = streamEventName('failed-before-stream');
+  const errors: Error[] = [];
+  const successes: unknown[][] = [];
+  const callbacks: SSERequestCallbacks<any> = {
+    onSuccess: (chunks) => successes.push(chunks),
+    onError: (error) => errors.push(error),
+    onUpdate: () => {},
+  };
+  const handle = createClientRequestHandle({
+    callbacks,
+    eventBus: JcefEventBus,
+    eventName,
+    handleErrorPayload: () => false,
+  });
+
+  JcefEventBus.publish(eventName, buildStreamErrorOutput('AI model is not available'));
+
+  await assert.rejects(handle.done, /AI model is not available/);
+  assert.equal(errors.length, 1);
+  assert.equal(successes.length, 0);
+
+  // The listener must be removed once settled: a late event changes nothing.
+  JcefEventBus.publish(eventName, buildStreamErrorOutput('late'));
+  assert.equal(errors.length, 1);
+};
+
+const createFailureHandle = (requestId: string) => {
+  const errors: Error[] = [];
+  const updates: unknown[] = [];
+  const handle = createClientRequestHandle({
+    callbacks: {
+      onSuccess: () => assert.fail('failed stream must not succeed'),
+      onError: (error) => errors.push(error),
+      onUpdate: (output) => updates.push(output),
+    },
+    eventBus: JcefEventBus,
+    eventName: streamEventName(requestId),
+    handleErrorPayload: () => false,
+  });
+  return { handle, errors, updates };
+};
+
+const testSynchronousErrorEnvelopeWaitsForListener = async () => {
+  const requestId = 'sync-error-envelope';
+  dispatchDesktopStreamRequest({
+    requestId,
+    serializedRequest: '{}',
+    javaQuery: ({ onSuccess }) => {
+      onSuccess(
+        JSON.stringify({
+          actionType: 'error',
+          message: { success: false, errorMessage: 'model unavailable' },
+        }),
+      );
+    },
+    publish: JcefEventBus.publish,
+  });
+  const { handle, errors, updates } = createFailureHandle(requestId);
+
+  await assert.rejects(handle.done, /model unavailable/);
+  assert.equal(errors.length, 1);
+  assert.equal(updates.length, 1);
+};
+
+const testSynchronousNativeFailureWaitsForListener = async () => {
+  const requestId = 'sync-native-failure';
+  dispatchDesktopStreamRequest({
+    requestId,
+    serializedRequest: '{}',
+    javaQuery: ({ onFailure }) => onFailure(503, 'bridge unavailable'),
+    publish: JcefEventBus.publish,
+  });
+  const { handle, errors } = createFailureHandle(requestId);
+
+  await assert.rejects(handle.done, /bridge unavailable/);
+  assert.equal(errors.length, 1);
+  JcefEventBus.publish(streamEventName(requestId), buildStreamErrorOutput('late'));
+  assert.equal(errors.length, 1);
+};
+
+const testMissingAndThrowingBridgePublishFailures = async () => {
+  const published: Array<{ eventName: string; output: ReturnType<typeof buildStreamErrorOutput> }> = [];
+  const publish = (eventName: string, output: ReturnType<typeof buildStreamErrorOutput>) => {
+    published.push({ eventName, output });
+  };
+
+  dispatchDesktopStreamRequest({ requestId: 'missing', serializedRequest: '{}', publish });
+  dispatchDesktopStreamRequest({
+    requestId: 'throwing',
+    serializedRequest: '{}',
+    javaQuery: () => {
+      throw new Error('bridge threw');
+    },
+    publish,
+  });
+  await Promise.resolve();
+
+  assert.deepEqual(
+    published.map(({ eventName }) => eventName),
+    [streamEventName('missing'), streamEventName('throwing')],
+  );
+  assert.match(published[0].output.data, /Java Query is not available/);
+  assert.match(published[1].output.data, /bridge threw/);
+};
+
+const testNormalAcknowledgementDoesNotPublish = async () => {
+  const published: unknown[] = [];
+  dispatchDesktopStreamRequest({
+    requestId: 'normal-ack',
+    serializedRequest: '{}',
+    javaQuery: ({ onSuccess }) => onSuccess(JSON.stringify({ actionType: 'execute', message: { success: true } })),
+    publish: (...args) => published.push(args),
+  });
+  await Promise.resolve();
+  assert.deepEqual(published, []);
+};
+
+const main = async () => {
+  testExtractEnvelopeErrorMessage();
+  testDescribeRequestFailure();
+  await testPublishedFailureSettlesStreamHandle();
+  await testSynchronousErrorEnvelopeWaitsForListener();
+  await testSynchronousNativeFailureWaitsForListener();
+  await testMissingAndThrowingBridgePublishFailures();
+  await testNormalAcknowledgementDoesNotPublish();
+  console.log('sse request failure tests passed');
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/chat2db-community-client/src/service/sse/requestFailure.ts
+++ b/chat2db-community-client/src/service/sse/requestFailure.ts
@@ -1,0 +1,115 @@
+import { JavaPushActionType } from '@/jcef/eventBus';
+
+const DEFAULT_FAILURE_MESSAGE = 'AI stream request failed';
+
+export const streamEventName = (requestId: string) => `${JavaPushActionType.AI_SSE_MESSAGE}_${requestId}`;
+
+/**
+ * Shapes a request-level failure like a stream error event so the stream listener
+ * settles through its existing error path (onError + rejected done + cleanup)
+ * instead of waiting forever for stream events that will never arrive.
+ */
+export const buildStreamErrorOutput = (message: string) => ({
+  event: 'error',
+  data: JSON.stringify({ content: message }),
+});
+
+export const describeRequestFailure = (errorCode: unknown, errorMessage: unknown): string => {
+  if (typeof errorMessage === 'string' && errorMessage.trim()) {
+    return errorMessage;
+  }
+  if (errorCode === undefined || errorCode === null || `${errorCode}`.trim() === '') {
+    return DEFAULT_FAILURE_MESSAGE;
+  }
+  return `${DEFAULT_FAILURE_MESSAGE} (${errorCode})`;
+};
+
+interface JavaQueryRequest {
+  request: string;
+  onSuccess: (data: unknown) => void;
+  onFailure: (errorCode: unknown, errorMessage: unknown) => void;
+}
+
+interface DispatchDesktopStreamRequestOptions {
+  requestId: string;
+  serializedRequest: string;
+  javaQuery?: (request: JavaQueryRequest) => unknown;
+  publish: (eventName: string, output: ReturnType<typeof buildStreamErrorOutput>) => void;
+  schedule?: (callback: () => void) => void;
+}
+
+const thrownFailureMessage = (error: unknown) => {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return describeRequestFailure(undefined, error);
+};
+
+export const dispatchDesktopStreamRequest = ({
+  requestId,
+  serializedRequest,
+  javaQuery,
+  publish,
+  schedule = queueMicrotask,
+}: DispatchDesktopStreamRequestOptions) => {
+  const publishFailure = (message: string) => {
+    schedule(() => publish(streamEventName(requestId), buildStreamErrorOutput(message)));
+  };
+
+  if (!javaQuery) {
+    publishFailure('Java Query is not available');
+    return;
+  }
+
+  try {
+    javaQuery({
+      request: serializedRequest,
+      onSuccess: (data) => {
+        const errorMessage = extractEnvelopeErrorMessage(data);
+        if (errorMessage !== undefined) {
+          publishFailure(errorMessage);
+        }
+      },
+      onFailure: (errorCode, errorMessage) => {
+        publishFailure(describeRequestFailure(errorCode, errorMessage));
+      },
+    });
+  } catch (error) {
+    publishFailure(thrownFailureMessage(error));
+  }
+};
+
+const parseJsonObject = (value: unknown): Record<string, any> | undefined => {
+  if (typeof value === 'object' && value !== null) {
+    return value as Record<string, any>;
+  }
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === 'object' && parsed !== null ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Detects the ConsoleResult error envelope that the JCEF bridge returns through the
+ * success callback when the controller fails before the stream is subscribed
+ * (ConsoleHelper.error: actionType "error" + ActionResult {success: false}).
+ * Returns undefined for regular acknowledgements.
+ */
+export const extractEnvelopeErrorMessage = (rawResponse: unknown): string | undefined => {
+  const envelope = parseJsonObject(rawResponse);
+  if (!envelope) {
+    return undefined;
+  }
+  const actionResult = parseJsonObject(envelope.message);
+  const failed = envelope.actionType === 'error' || actionResult?.success === false;
+  if (!failed) {
+    return undefined;
+  }
+  const errorMessage = actionResult?.errorMessage;
+  return typeof errorMessage === 'string' && errorMessage.trim() ? errorMessage : DEFAULT_FAILURE_MESSAGE;
+};


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Desktop AI SSE startup failures were rejected by the controller bridge without being delivered to the request-specific stream listener, leaving the consumer waiting indefinitely. Synchronous bridge callbacks could also fire before listener registration, while ordinary acknowledgement payloads could be mistaken for failures. This change normalizes controller/native failures into stream error events, defers synchronous dispatch until listener registration, settles missing or throwing bridges, and preserves normal acknowledgements.

The final manifest amendment keeps the expanded `test:sse-request` command but removes its redundant insertion into the shared prebuild chain. Community CI already invokes that named test directly, and the amendment avoids a merge conflict with the database-selector PR.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:sse-request`: passed ownership, transport, and production adapter contracts.
  - Targeted ESLint for the desktop SSE adapter, failure helper, and tests: passed.
  - Full Community Umi/Webpack build, including the complete prebuild contract set: succeeded.
  - Production bundle verifier passed both as postbuild and standalone.
  - `git diff --check origin/main...HEAD`: passed.
  - Merge-tree with selector head `2828cf80e`: zero conflict markers; both selector and SSE test scripts are retained.
  - Temporary fork verification PR #85 at head `7aa7ea315a32fefe2b8a6039abf5cb108ffe67a9`: Frontend, Backend, JavaScript CodeQL, and Java CodeQL all passed.
- Manual verification: N/A - deterministic event-bus tests cover controller envelopes, native rejection, synchronous callbacks, missing/throwing bridges, acknowledgements, and listener ordering.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No public API or persisted-state changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: No new data flow; existing failure messages are routed to the owning stream request.
- Community / Local / Pro boundary: Shared Community desktop SSE adapter.
- Backward compatibility: Successful stream setup and normal acknowledgements keep their existing behavior; previously silent terminal failures now reject through the stream error path.

## Reviewer map

- Start here: `service/sse/requestFailure.ts`, then `service/sse/index.tsx` and the adapter tests.
- Failure condition: a controller/native setup failure leaves the stream pending, a synchronous callback is lost before listener registration, a normal acknowledgement is emitted as an error, or the manifest conflicts with selector head `2828cf80e`.
- Rollback or disable path: Revert commit `7aa7ea315a32fefe2b8a6039abf5cb108ffe67a9`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, conflict analysis, and adversarial review.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head 7aa7ea315.
- SSE ownership, transport, and desktop request-failure tests passed; targeted ESLint passed.
- Included in the green combined Community production build and bundle verification.