### PR TITLE
fix(snowflake): preserve view definitions

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/main/java/ai/chat2db/plugin/snowflake/SnowflakeMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/main/java/ai/chat2db/plugin/snowflake/SnowflakeMetaData.java
@@ -54,7 +54,8 @@ public class SnowflakeMetaData extends DefaultMetaService implements IDbMetaData
             table.setSchemaName(schemaName);
             table.setName(viewName);
             if (resultSet.next()) {
-                table.setDdl(resultSet.getString("DEFINITION").substring(resultSet.getString("DEFINITION").indexOf("as") + 3));
+                // INFORMATION_SCHEMA.VIEWS already returns the view query definition.
+                table.setDdl(resultSet.getString("DEFINITION"));
             }
             return table;
         });

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/test/java/ai/chat2db/plugin/snowflake/SnowflakeMetaDataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-snowflake/src/test/java/ai/chat2db/plugin/snowflake/SnowflakeMetaDataTest.java
@@ -1,0 +1,134 @@
+package ai.chat2db.plugin.snowflake;
+
+import ai.chat2db.community.domain.api.model.metadata.Table;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SnowflakeMetaDataTest {
+
+    @Test
+    void viewPreservesDefinitionContainingUppercaseAs() {
+        String definition = "SELECT PRICE AS UNIT_PRICE FROM SALES";
+
+        assertEquals(definition, viewWithDefinition(definition).getDdl());
+    }
+
+    @Test
+    void viewPreservesDefinitionContainingLowercaseAlias() {
+        String definition = "select price as unit_price from sales";
+
+        assertEquals(definition, viewWithDefinition(definition).getDdl());
+    }
+
+    @Test
+    void viewPreservesDefinitionWithoutAs() {
+        String definition = "SELECT PRICE FROM SALES";
+
+        assertEquals(definition, viewWithDefinition(definition).getDdl());
+    }
+
+    @Test
+    void viewPreservesNullDefinition() {
+        assertNull(viewWithDefinition(null).getDdl());
+    }
+
+    @Test
+    void viewKeepsIdentityWhenResultSetIsEmpty() {
+        Table view = new SnowflakeMetaData().view(connection(false, null), "WAREHOUSE", "REPORTING", "SALES_VIEW");
+
+        assertEquals("WAREHOUSE", view.getDatabaseName());
+        assertEquals("REPORTING", view.getSchemaName());
+        assertEquals("SALES_VIEW", view.getName());
+        assertNull(view.getDdl());
+    }
+
+    private static Table viewWithDefinition(String definition) {
+        return new SnowflakeMetaData().view(connection(true, definition),
+                "WAREHOUSE", "REPORTING", "SALES_VIEW");
+    }
+
+    private static Connection connection(boolean hasRow, String definition) {
+        ResultSet resultSet = resultSet(hasRow, definition);
+        PreparedStatement statement = proxy(PreparedStatement.class, (proxy, method, args) -> switch (method.getName()) {
+            case "execute" -> true;
+            case "getResultSet" -> resultSet;
+            default -> defaultValue(method.getReturnType());
+        });
+        return proxy(Connection.class, (proxy, method, args) -> switch (method.getName()) {
+            case "prepareStatement" -> statement;
+            default -> defaultValue(method.getReturnType());
+        });
+    }
+
+    private static ResultSet resultSet(boolean hasRow, String definition) {
+        boolean[] consumed = {false};
+        return proxy(ResultSet.class, (proxy, method, args) -> switch (method.getName()) {
+            case "next" -> {
+                if (!hasRow || consumed[0]) {
+                    yield false;
+                }
+                consumed[0] = true;
+                yield true;
+            }
+            case "getString" -> "DEFINITION".equals(args[0]) ? definition : null;
+            default -> defaultValue(method.getReturnType());
+        });
+    }
+
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        Object proxy = Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type},
+                (target, method, args) -> method.getDeclaringClass() == Object.class
+                        ? objectMethod(target, method, args)
+                        : handler.invoke(target, method, args));
+        return type.cast(proxy);
+    }
+
+    private static Object objectMethod(Object target, Method method, Object[] args) {
+        return switch (method.getName()) {
+            case "toString" -> target.getClass().getInterfaces()[0].getSimpleName() + "Proxy";
+            case "hashCode" -> System.identityHashCode(target);
+            case "equals" -> target == args[0];
+            default -> null;
+        };
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0F;
+        }
+        if (type == double.class) {
+            return 0D;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Snowflake `INFORMATION_SCHEMA.VIEWS.VIEW_DEFINITION` already contains the view query definition. The previous implementation searched that value for a lowercase `as` and returned a substring, which truncated uppercase/no-`AS` definitions, returned only the suffix after lowercase aliases, and threw for null definitions. This change preserves the JDBC definition verbatim while retaining the existing view identity and empty-result behavior.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Focused `SnowflakeMetaDataTest`: 5 tests passed, 0 failures/errors/skips.
  - Snowflake module tests after rebase: 40 passed; all 9 reactor modules succeeded.
  - `git diff --check`: passed.
  - Fork PR #80 code checks: Frontend, Backend, JavaScript/Java CodeQL, repository/docs, SBOM, and frontend license succeeded on `5ca0306a45273899c4dad41396b29f4367004176`.
  - Latest-main revalidation: focused 5/5 and full Snowflake module 40/40 passed; 45/45 pairwise merge simulations passed.
- Manual verification: N/A - JDBC proxy tests cover uppercase `AS`, lowercase aliases, no `AS`, null definitions, and empty result sets.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or storage-format changes.
- Database or driver compatibility: Snowflake view definitions now follow the JDBC `VIEW_DEFINITION` contract without parsing or rewriting the returned SQL.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community Snowflake plugin behavior.
- Backward compatibility: Existing view identity fields and no-row behavior remain unchanged; only previously truncated definitions change.

## Reviewer map

- Start here: `SnowflakeMetaData.view` and `SnowflakeMetaDataTest`.
- Failure condition: a definition differs from the exact JDBC `DEFINITION` value, null throws, or an empty result loses database/schema/view identity.
- Rollback or disable path: Revert commit `d305d2c69`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, CI monitoring, and adversarial review.