### PR TITLE
fix(client): settle failed SQL formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Run SQL execution batch contract
         run: yarn run test:sql-execution-batch
 
+      - name: Run SQL format failure contract
+        run: yarn run test:sql-format
+
       - name: Run SQL execution request tracker contract
         run: yarn run test:sql-execution-request-tracker
 

--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -68,6 +68,7 @@
     "test:shortcut": "tsx src/constants/shortcut.test.ts && tsx src/utils/appTitleBarAction.test.ts && tsx src/layouts/GlobalLayout/AppTitleBar/platform.test.ts && tsx src/utils/jcefZoom.test.ts && tsx src/utils/shortcutDispatch.test.ts",
     "test:sql-execution-log": "tsx src/service/sqlExecutionLog.test.ts",
     "test:sql-execution-batch": "tsx src/service/sqlExecutionBatch.test.ts",
+    "test:sql-format": "tsx src/utils/sql/formatSqlRequest.test.ts",
     "test:data-source-execution-snapshot": "tsx src/service/dataSourceExecutionSnapshot.test.ts",
     "test:sql-execution-request-tracker": "tsx src/service/sqlExecutionRequestTracker.test.ts",
     "test:sql-execution-stream": "tsx src/service/sqlExecutionStream.test.ts && tsx src/pages/main/workspace/components/SQLExecute/streamResultExecutionParams.test.ts",

--- a/chat2db-community-client/src/utils/sql/formatSql.ts
+++ b/chat2db-community-client/src/utils/sql/formatSql.ts
@@ -1,15 +1,7 @@
 import { DatabaseTypeCode } from '@/constants';
 import sqlServer from '@/service/sql';
+import { formatSqlWithRequester } from './formatSqlRequest';
 
-export function formatSql(sql: string, dbType?: DatabaseTypeCode) {
-  return new Promise((r: (sql: string) => void) => {
-    sqlServer
-      .sqlFormat({
-        sql,
-        dbType,
-      })
-      .then((res) => {
-        r(res);
-      });
-  });
+export function formatSql(sql: string, dbType?: DatabaseTypeCode): Promise<string> {
+  return formatSqlWithRequester((request) => sqlServer.sqlFormat(request), sql, dbType);
 }

--- a/chat2db-community-client/src/utils/sql/formatSqlRequest.test.ts
+++ b/chat2db-community-client/src/utils/sql/formatSqlRequest.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import type { DatabaseTypeCode } from '@/constants';
+import { formatSqlWithRequester, type SqlFormatRequest } from './formatSqlRequest';
+
+const MYSQL = 'MYSQL' as DatabaseTypeCode;
+const POSTGRESQL = 'POSTGRESQL' as DatabaseTypeCode;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const settlementWithinTurn = <T>(promise: Promise<T>) =>
+  Promise.race([
+    promise.then(
+      (value) => ({ status: 'resolved' as const, value }),
+      (error) => ({ status: 'rejected' as const, error }),
+    ),
+    new Promise<{ status: 'pending' }>((resolve) => {
+      setImmediate(() => resolve({ status: 'pending' }));
+    }),
+  ]);
+
+const testSuccessfulFormattingUsesRequester = async () => {
+  let capturedRequest: SqlFormatRequest | undefined;
+  const formatted = await formatSqlWithRequester(async (request) => {
+    capturedRequest = request;
+    return 'SELECT\n  1';
+  }, 'select 1', MYSQL);
+
+  assert.equal(formatted, 'SELECT\n  1');
+  assert.deepEqual(capturedRequest, { sql: 'select 1', dbType: MYSQL });
+};
+
+const testRejectedFormattingFallsBackWithoutRemainingPending = async () => {
+  const request = deferred<string>();
+  const originalSql = 'select * from unfinished_query';
+  const formatted = formatSqlWithRequester(() => request.promise, originalSql, POSTGRESQL);
+
+  request.reject(new Error('format service unavailable'));
+
+  assert.deepEqual(await settlementWithinTurn(formatted), {
+    status: 'resolved',
+    value: originalSql,
+  });
+};
+
+const testSynchronousRequesterFailureFallsBack = async () => {
+  const originalSql = 'select * from synchronous_failure';
+  const formatted = formatSqlWithRequester(() => {
+    throw new Error('request setup failed');
+  }, originalSql, MYSQL);
+
+  assert.equal(await formatted, originalSql);
+};
+
+const main = async () => {
+  await testSuccessfulFormattingUsesRequester();
+  await testRejectedFormattingFallsBackWithoutRemainingPending();
+  await testSynchronousRequesterFailureFallsBack();
+  console.log('SQL format request tests passed');
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/chat2db-community-client/src/utils/sql/formatSqlRequest.ts
+++ b/chat2db-community-client/src/utils/sql/formatSqlRequest.ts
@@ -1,0 +1,21 @@
+import type { DatabaseTypeCode } from '@/constants';
+
+export interface SqlFormatRequest {
+  sql: string;
+  dbType?: DatabaseTypeCode;
+}
+
+export type SqlFormatRequester = (request: SqlFormatRequest) => Promise<string>;
+
+export function formatSqlWithRequester(
+  requester: SqlFormatRequester,
+  sql: string,
+  dbType?: DatabaseTypeCode,
+): Promise<string> {
+  return Promise.resolve()
+    .then(() => requester({ sql, dbType }))
+    .catch((error) => {
+      console.error('Server-side SQL formatting error:', error);
+      return sql;
+    });
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

The shared SQL formatting utility wrapped the server request in a Promise that only handled fulfillment. A rejected formatting request left callers pending forever, while a synchronous request setup failure escaped before a Promise was returned. This change routes the real `sqlServer.sqlFormat` requester through a small injectable settlement helper: successful formatting is unchanged, and both asynchronous rejection and synchronous throw log the failure and resolve with the original SQL, matching the existing SQL editor fallback contract.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn run test:sql-format`: passed; covers success, deferred rejection without permanent pending, and synchronous throw fallback.
  - Targeted ESLint for the formatting utility/helper/test: passed with zero warnings.
  - Full Community prebuild, Webpack production build, and production-bundle verifier: passed.
  - `git diff --check`: passed.
  - Fork PR #83 code checks: Frontend, Backend, JavaScript/Java CodeQL, repository/docs, SBOM, and frontend license succeeded on `d18ee70eb3a98daa9a9de0130ee16dcfa6691f39`.
- Manual verification: N/A - the pure Node contract test injects controlled success, deferred rejection, and synchronous failure.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No HTTP API or persisted-data changes; `formatSql` retains `Promise<string>`.
- Database or driver compatibility: The original SQL and dbType are still sent to the same formatting endpoint.
- Network, privacy, or security: Request failures are logged locally and no longer leave an unresolved workflow; no new data is transmitted.
- Community / Local / Pro boundary: Shared Community client utility consumed by existing editions.
- Backward compatibility: Successful formatted output is unchanged; failure now resolves to the caller-provided SQL instead of hanging or throwing synchronously.

## Reviewer map

- Start here: `formatSql.ts`, then `formatSqlRequest.ts` and its deferred Node test.
- Failure condition: rejection remains pending, synchronous requester failure escapes, fallback changes the original SQL, or successful formatting is replaced.
- Rollback or disable path: Revert commit `166da49c6`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, CI monitoring, and adversarial review.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head d18ee70eb.
- SQL format rejection/synchronous-failure tests and targeted ESLint passed.
- Playwright verified a real Monaco Ctrl+L request returning 500 preserved SQL, then a second Ctrl+L retry succeeded and applied the formatted SQL.
- Included in the green combined Community production build and bundle verification.