### PR TITLE
fix(metadata): prevent table page offset overflow

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbTableServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbTableServiceImpl.java
@@ -171,12 +171,13 @@ public class DbTableServiceImpl implements IDbTableService {
             return PageResponse.of(new ArrayList<>(), 0L, param.getPageNo(), param.getPageSize());
         }
         long total = tables.size();
-        int start = (param.getPageNo() - 1) * param.getPageSize();
-        if (start >= total) {
+        long start = ((long) param.getPageNo() - 1L) * param.getPageSize();
+        if (start < 0L || start >= total) {
             return PageResponse.of(Lists.newArrayList(), total, param.getPageNo(), param.getPageSize());
         }
-        int end = Math.min(start + param.getPageSize(), tables.size());
-        List<Table> subList = tables.subList(start, end);
+        int startIndex = (int) start;
+        int end = (int) Math.min(start + param.getPageSize(), total);
+        List<Table> subList = tables.subList(startIndex, end);
         return PageResponse.of(subList, total, param.getPageNo(), param.getPageSize());
     }
 

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/DbMetadataAccessPolicyTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/DbMetadataAccessPolicyTest.java
@@ -93,6 +93,20 @@ class DbMetadataAccessPolicyTest {
     }
 
     @Test
+    void tablePaginationTreatsOverflowedOffsetAsOutOfRange() {
+        MemoryCacheManage.put(getTableKey(DATA_SOURCE_ID, DATABASE, SCHEMA),
+                new ArrayList<>(List.of(table("orders"))));
+        DbTablePageQueryRequest request = DbTablePageQueryRequest.builder()
+                .dataSourceId(DATA_SOURCE_ID).databaseName(DATABASE).schemaName(SCHEMA)
+                .pageNo(Integer.MAX_VALUE).pageSize(100_000).build();
+
+        PageResponse<Table> page = service().pageQuery(request, null);
+
+        assertEquals(1L, page.getTotal());
+        assertEquals(List.of(), page.getData());
+    }
+
+    @Test
     void columnListReturnsOnlyAuthorizedColumns() {
         DbTableQueryRequest request = DbTableQueryRequest.builder()
                 .dataSourceId(DATA_SOURCE_ID).databaseName(DATABASE).schemaName(SCHEMA)


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Cached relational table pagination calculated `(pageNo - 1) * pageSize` with `int` arithmetic. Accepted maximum-bound requests wrapped to negative indexes and reached `subList`, raising `IndexOutOfBoundsException`. This change derives the offset and end with `long`, returns an empty out-of-range page, and only converts indexes after proving they fit the table list.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Current-main reproduction: original test suite ran 3 tests; maximum pageNo / pageSize produced `IndexOutOfBoundsException: fromIndex = -200000` before the fix.
- After main integration, owning reactor tests and package passed: domain-core 304, SPI 147, tools 77, domain-api 27; 555 total, zero failures/errors/skips.
- Command: `mvn -B -ntp -f chat2db-community-server/pom.xml -pl :chat2db-community-domain-core -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false package`. Test JVM home/temp were isolated.
- Executable backend package passed. Playwright CLI created an actual SQLite connection through the UI and verified eight real API cases: normal pages, ordinary out-of-range pages, two overflow boundaries, search totals, search plus overflow, empty search results, then reload.
- The two integrated PR files are byte-identical to the Web-tested version. Current-head CI is available in PR checks.
- Extreme page numbers were sent as browser HTTP requests; this is not claimed as a normally reachable UI pagination action.

## Risk and compatibility

- Public API or stored data: No API or storage format changes.
- Database or driver compatibility: Applies only to local cached table list slicing; metadata retrieval is unchanged.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community metadata service.
- Backward compatibility: Normal pages preserve their existing ordering, totals, and contents; out-of-range pages remain empty.

## Reviewer map

- Start here: `DbTableServiceImpl.pageQuery` and the maximum-bound case in `DbMetadataAccessPolicyTest`.
- Failure condition: an accepted page request produces a negative list index, or normal page slicing changes.
- Rollback or disable path: Revert commit `785fe519d8cf776ed9c3d47f0d55e19e59b60c5e`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, deterministic tests, verification, and adversarial review.