### PR TITLE
fix(h2): bind routine details to schema

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-h2/src/main/java/ai/chat2db/plugin/h2/H2Meta.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-h2/src/main/java/ai/chat2db/plugin/h2/H2Meta.java
@@ -117,7 +117,7 @@ public class H2Meta extends DefaultMetaService implements IDbMetaData {
     public Function function(Connection connection, @NotEmpty String databaseName, String schemaName,
         String functionName) {
 
-        String sql = String.format(ROUTINES_SQL, "FUNCTION", getSQLIdentifierProcessor().escapeString(databaseName),
+        String sql = String.format(ROUTINES_SQL, "FUNCTION", getSQLIdentifierProcessor().escapeString(schemaName),
             getSQLIdentifierProcessor().escapeString(functionName));
         return DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> {
             Function function = new Function();
@@ -159,7 +159,7 @@ public class H2Meta extends DefaultMetaService implements IDbMetaData {
     public Trigger trigger(Connection connection, @NotEmpty String databaseName, String schemaName,
         String triggerName) {
 
-        String sql = String.format(TRIGGER_SQL, getSQLIdentifierProcessor().escapeString(databaseName),
+        String sql = String.format(TRIGGER_SQL, getSQLIdentifierProcessor().escapeString(schemaName),
             getSQLIdentifierProcessor().escapeString(triggerName));
         return DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> {
             Trigger trigger = new Trigger();
@@ -176,7 +176,7 @@ public class H2Meta extends DefaultMetaService implements IDbMetaData {
     @Override
     public Procedure procedure(Connection connection, @NotEmpty String databaseName, String schemaName,
         String procedureName) {
-        String sql = String.format(ROUTINES_SQL, "PROCEDURE", getSQLIdentifierProcessor().escapeString(databaseName),
+        String sql = String.format(ROUTINES_SQL, "PROCEDURE", getSQLIdentifierProcessor().escapeString(schemaName),
             getSQLIdentifierProcessor().escapeString(procedureName));
         return DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> {
             Procedure procedure = new Procedure();

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-h2/src/test/java/ai/chat2db/plugin/h2/H2MetaSchemaBindingTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-h2/src/test/java/ai/chat2db/plugin/h2/H2MetaSchemaBindingTest.java
@@ -1,0 +1,60 @@
+package ai.chat2db.plugin.h2;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class H2MetaSchemaBindingTest {
+
+    @Test
+    void routineAndTriggerDetailsFilterBySchemaInsteadOfCatalog() {
+        List<String> sql = new ArrayList<>();
+        Connection connection = connection(sql);
+        H2Meta metaData = new H2Meta();
+
+        metaData.function(connection, "CATALOG", "APP", "F1");
+        metaData.procedure(connection, "CATALOG", "APP", "P1");
+        metaData.trigger(connection, "CATALOG", "APP", "T1");
+
+        assertTrue(sql.get(0).contains("ROUTINE_SCHEMA ='APP'"), sql.get(0));
+        assertTrue(sql.get(1).contains("ROUTINE_SCHEMA ='APP'"), sql.get(1));
+        assertTrue(sql.get(2).contains("TRIGGER_SCHEMA = 'APP'"), sql.get(2));
+    }
+
+    private static Connection connection(List<String> sql) {
+        ResultSet resultSet = (ResultSet) Proxy.newProxyInstance(
+            H2MetaSchemaBindingTest.class.getClassLoader(),
+            new Class<?>[]{ResultSet.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "next" -> false;
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected ResultSet call: " + method.getName());
+            });
+        return (Connection) Proxy.newProxyInstance(
+            H2MetaSchemaBindingTest.class.getClassLoader(),
+            new Class<?>[]{Connection.class},
+            (proxy, method, args) -> {
+                if (!"prepareStatement".equals(method.getName())) {
+                    throw new AssertionError("Unexpected Connection call: " + method.getName());
+                }
+                sql.add((String) args[0]);
+                return Proxy.newProxyInstance(
+                    H2MetaSchemaBindingTest.class.getClassLoader(),
+                    new Class<?>[]{PreparedStatement.class},
+                    (statement, statementMethod, statementArgs) -> switch (statementMethod.getName()) {
+                        case "execute" -> true;
+                        case "getResultSet" -> resultSet;
+                        case "close" -> null;
+                        default -> throw new AssertionError(
+                            "Unexpected PreparedStatement call: " + statementMethod.getName());
+                    });
+            });
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

H2 function, procedure, and trigger detail queries placed the catalog name into `ROUTINE_SCHEMA` / `TRIGGER_SCHEMA` predicates. In ordinary catalog-plus-schema connections this returned no detail or the wrong schema. This change binds those predicates to the requested schema while preserving the catalog on the returned metadata objects.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Strict JDBC schema-binding regression test: 1 passed.
  - H2 module tests after rebase: 33 passed.
  - Plugin reactor package: succeeded.
  - Fork Frontend, Backend, JavaScript CodeQL, and Java CodeQL checks: rerunning for the rebased head.
  - `git diff --check origin/main...HEAD`: passed.
- Manual verification: N/A - the proxy captures the real generated SQL for all three detail methods.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or storage changes.
- Database or driver compatibility: H2 metadata detail predicates only; returned catalog/schema fields are unchanged.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community H2 plugin.
- Backward compatibility: Connections where catalog and schema happen to match retain equivalent SQL.

## Reviewer map

- Start here: `H2Meta.function`, `procedure`, `trigger`, and `H2MetaSchemaBindingTest`.
- Failure condition: schema predicates contain the catalog, or list/detail schema behavior diverges.
- Rollback or disable path: Revert commit `38355c81590f6c2cec1592854483041ed52ef966`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.