### PR TITLE
fix(client): serialize update restarts

### DIFF
--- a/chat2db-community-client/src/store/global/slices/hotUpdate/action.test.ts
+++ b/chat2db-community-client/src/store/global/slices/hotUpdate/action.test.ts
@@ -51,11 +51,13 @@ function restoreGlobal<T extends keyof typeof globalObject>(key: T, value: (type
 }
 
 async function run() {
-  const [{ createHotUpdateAction }, { default: jcefApi }, { UpdatedStatus }] = await Promise.all([
+  const [{ createHotUpdateAction }, { default: jcefApi }, { UpdatedStatus }, { clientRuntime }] = await Promise.all([
     import('./action'),
     import('@/jcef'),
     import('@/constants/settings'),
+    import('@client-runtime'),
   ]);
+  const originalAutoUpdate = clientRuntime.enableAutoUpdate;
   const originalApi = {
     appCheckUpdate: jcefApi.appCheckUpdate,
     triggerInstallation: jcefApi.triggerInstallation,
@@ -111,8 +113,39 @@ async function run() {
     await state.updateHotUpdateConfig('remindMe', false);
     assert.equal(state.hotUpdateConfig.remindMe, false);
 
+    clientRuntime.enableAutoUpdate = true;
+    state.updateDetail = { status: UpdatedStatus.Updated };
+    let resolveInstallation: ((accepted: boolean) => void) | undefined;
+    let installationCalls = 0;
+    let restartCalls = 0;
+    jcefApi.triggerInstallation = () => {
+      installationCalls += 1;
+      return new Promise<boolean>((resolve) => {
+        resolveInstallation = resolve;
+      });
+    };
+    jcefApi.restartApp = async () => {
+      restartCalls += 1;
+      return true;
+    };
+
+    const firstRestart = state.updateAndRestartApp();
+    await Promise.resolve();
+    const joinedRestart = state.updateAndRestartApp();
+    await Promise.resolve();
+
+    assert.equal(joinedRestart, firstRestart, 'concurrent callers must receive the same in-flight operation');
+    assert.equal(installationCalls, 1, 'concurrent restart requests must share one installation');
+    assert.equal(restartCalls, 0, 'the app must not restart before installation is accepted');
+
+    assert.ok(resolveInstallation);
+    resolveInstallation(true);
+    await Promise.all([firstRestart, joinedRestart]);
+    assert.equal(restartCalls, 1, 'joined callers must share one restart');
+
     console.log('Community hot update boundary tests passed');
   } finally {
+    clientRuntime.enableAutoUpdate = originalAutoUpdate;
     Object.assign(jcefApi, originalApi);
   }
 }

--- a/chat2db-community-client/src/store/global/slices/hotUpdate/action.ts
+++ b/chat2db-community-client/src/store/global/slices/hotUpdate/action.ts
@@ -9,7 +9,7 @@ import { GlobalStore } from '../../store';
 
 export interface HotUpdateAction {
   // Update and restart the app
-  updateAndRestartApp: () => void;
+  updateAndRestartApp: () => Promise<void>;
   // Check for updates
   handleCheckUpdate: () => Promise<boolean>;
   // Synchronize updater-owned preferences
@@ -21,11 +21,10 @@ export interface HotUpdateAction {
 export const createHotUpdateAction: StateCreator<GlobalStore, [['zustand/devtools', never]], [], HotUpdateAction> = (
   set,
   get,
-) => ({
-  updateAndRestartApp: async () => {
-    if (!clientRuntime.enableAutoUpdate) {
-      return;
-    }
+) => {
+  let updateAndRestartInFlight: Promise<void> | null = null;
+
+  const runUpdateAndRestart = async () => {
     if (get().updateDetail.status === UpdatedStatus.Updated) {
       get().setUpdateDetail({
         status: UpdatedStatus.Installing,
@@ -52,57 +51,78 @@ export const createHotUpdateAction: StateCreator<GlobalStore, [['zustand/devtool
         status: UpdatedStatus.UpdateFailed,
       });
     }
-  },
-  handleCheckUpdate: async () => {
-    if (!isDesktop || !clientRuntime.enableAutoUpdate) {
-      return false;
-    }
-    try {
-      const res = await jcefApi.appCheckUpdate();
-      get().setUpdateDetail({
-        status: res.status,
-        version: res.version,
-      });
-      return res.status === UpdatedStatus.Available;
-    } catch {
-      get().setUpdateDetail({
-        status: UpdatedStatus.UpdateFailed,
-      });
-      return false;
-    }
-  },
-  syncUpdatePreferences: async () => {
-    if (!isDesktop || !clientRuntime.enableAutoUpdate) {
-      return;
-    }
-    try {
-      const preferences = await jcefApi.updatePreferences();
-      set({
-        hotUpdateConfig: produce(get().hotUpdateConfig, (draft) => {
-          draft.receiveBeta = preferences.receiveBeta;
-        }),
-      });
-    } catch {
-      // Keep the last locally confirmed preference when the desktop bridge fails.
-    }
-  },
-  updateHotUpdateConfig: async (property, value) => {
-    let persistedValue = value;
-    if (property === 'receiveBeta' && isDesktop && clientRuntime.enableAutoUpdate) {
-      try {
-        const preferences = await jcefApi.updatePreferences({ receiveBeta: Boolean(value) });
-        if (!preferences.saved) {
-          return;
+  };
+
+  return {
+    updateAndRestartApp: () => {
+      if (!clientRuntime.enableAutoUpdate) {
+        return Promise.resolve();
+      }
+      if (updateAndRestartInFlight) {
+        return updateAndRestartInFlight;
+      }
+
+      const operation = Promise.resolve().then(runUpdateAndRestart);
+      updateAndRestartInFlight = operation;
+      const clearOperation = () => {
+        if (updateAndRestartInFlight === operation) {
+          updateAndRestartInFlight = null;
         }
-        persistedValue = preferences.receiveBeta;
+      };
+      void operation.then(clearOperation, clearOperation);
+      return operation;
+    },
+    handleCheckUpdate: async () => {
+      if (!isDesktop || !clientRuntime.enableAutoUpdate) {
+        return false;
+      }
+      try {
+        const res = await jcefApi.appCheckUpdate();
+        get().setUpdateDetail({
+          status: res.status,
+          version: res.version,
+        });
+        return res.status === UpdatedStatus.Available;
       } catch {
+        get().setUpdateDetail({
+          status: UpdatedStatus.UpdateFailed,
+        });
+        return false;
+      }
+    },
+    syncUpdatePreferences: async () => {
+      if (!isDesktop || !clientRuntime.enableAutoUpdate) {
         return;
       }
-    }
-    set({
-      hotUpdateConfig: produce(get().hotUpdateConfig, (draft) => {
-        draft[property] = persistedValue;
-      }),
-    });
-  },
-});
+      try {
+        const preferences = await jcefApi.updatePreferences();
+        set({
+          hotUpdateConfig: produce(get().hotUpdateConfig, (draft) => {
+            draft.receiveBeta = preferences.receiveBeta;
+          }),
+        });
+      } catch {
+        // Keep the last locally confirmed preference when the desktop bridge fails.
+      }
+    },
+    updateHotUpdateConfig: async (property, value) => {
+      let persistedValue = value;
+      if (property === 'receiveBeta' && isDesktop && clientRuntime.enableAutoUpdate) {
+        try {
+          const preferences = await jcefApi.updatePreferences({ receiveBeta: Boolean(value) });
+          if (!preferences.saved) {
+            return;
+          }
+          persistedValue = preferences.receiveBeta;
+        } catch {
+          return;
+        }
+      }
+      set({
+        hotUpdateConfig: produce(get().hotUpdateConfig, (draft) => {
+          draft[property] = persistedValue;
+        }),
+      });
+    },
+  };
+};


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Concurrent update-and-restart commands did not share lifecycle ownership. Once the first command changed the status to Installing and awaited the desktop installer, a second command skipped installation and called restart immediately. This change makes callers join one store-scoped operation and releases the guard after either success or failure.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Hot-update action contracts: passed, including deferred concurrent installation.
  - Targeted ESLint: passed.
  - Full Community prebuild, Umi/Webpack build, and production bundle verifier: passed.
  - Fork Frontend, Backend, JavaScript CodeQL, and Java CodeQL checks: passed.
  - `git diff --check origin/main...HEAD`: passed.
- Manual verification: N/A - mocked desktop bridge promises deterministically hold installation open while a second command runs.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: The action now explicitly returns its existing Promise; no stored data changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community desktop updater state.
- Backward compatibility: Single-command installation and restart behavior is preserved; concurrent callers now join it.

## Reviewer map

- Start here: `createHotUpdateAction.updateAndRestartApp` and its deferred concurrency test.
- Failure condition: restart occurs before installer acceptance, or concurrent calls invoke install/restart more than once.
- Rollback or disable path: Revert commit `8ba1a7407661fec637ded88e97019b433fd56251`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.