### PR TITLE
fix(client): settle table paging cancellation and errors

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/viewTablePagingFlow.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/viewTablePagingFlow.test.ts
@@ -208,11 +208,46 @@ test('web table browse retains execution params across consecutive page requests
   assert.equal(secondPage.executeSqlParams?.pageSize, 5000);
 });
 
-test('a cancelled table browse never publishes its buffered partial rows', () => {
-  const params = { sql: BASE_SQL, dataSourceId: 42, pageNo: 1, pageSize: 50_000 };
+test('a failed table browse page preserves the confirmed result and reports the backend error', () => {
+  const confirmedResult = result({
+    uuid: 'confirmed-result',
+    dataList: [[{ value: 'confirmed-row' }]] as any,
+    pageNo: 1,
+  });
+  const params = { sql: BASE_SQL, dataSourceId: 42, pageNo: 2, pageSize: 1000 };
   const requestSequence = 8;
+
+  const transition = reduceViewTablePagingEvent(
+    createViewTablePagingState(requestSequence, params, confirmedResult),
+    event(
+      'resultFinished',
+      result({
+        success: false,
+        message: 'Unknown column status',
+        dataList: [],
+        pageNo: 2,
+      }),
+    ),
+    requestSequence,
+  );
+
+  assert.equal(transition.completedResult, undefined, 'a failed page must not replace confirmed rows');
+  assert.equal(transition.errorMessage, 'Unknown column status');
+  assert.equal(transition.state.errorMessage, 'Unknown column status');
+  assert.deepEqual(confirmedResult.dataList, [[{ value: 'confirmed-row' }]]);
+});
+
+test('a cancelled table browse republishes the confirmed page without buffered partial rows', () => {
+  const params = { sql: BASE_SQL, dataSourceId: 42, pageNo: 2, pageSize: 50_000 };
+  const confirmedResult = result({
+    uuid: 'confirmed-result',
+    dataList: [[{ value: 'confirmed-row' }]] as any,
+    pageNo: 1,
+    pageSize: 1000,
+  });
+  const requestSequence = 9;
   let transition = reduceViewTablePagingEvent(
-    createViewTablePagingState(requestSequence, params),
+    createViewTablePagingState(requestSequence, params, confirmedResult),
     event('rows', result({ dataList: [[{ value: 'partial' }]] as any })),
     requestSequence,
   );
@@ -223,7 +258,10 @@ test('a cancelled table browse never publishes its buffered partial rows', () =>
     event('cancelled', result()),
     requestSequence,
   );
-  assert.equal(transition.completedResult, undefined, 'cancellation leaves the visible completed result untouched');
+  assert.notEqual(transition.completedResult, confirmedResult, 'rollback must publish a new object');
+  assert.equal(transition.completedResult?.pageNo, 1);
+  assert.equal(transition.completedResult?.pageSize, 1000);
+  assert.deepEqual(transition.completedResult?.dataList, [[{ value: 'confirmed-row' }]]);
 });
 
 test('table browse cancellation targets the active JCEF execution and releases the request', async () => {

--- a/chat2db-community-client/src/components/ViewTable/index.tsx
+++ b/chat2db-community-client/src/components/ViewTable/index.tsx
@@ -51,7 +51,7 @@ const ViewTable = memo<IProps>((props) => {
       if (executeSqlParams.dataSourceId == null || !executeSqlParams.sql) {
         return;
       }
-      return executePage(executeSqlParams);
+      return executePage(executeSqlParams, _resultData);
     },
     [executePage],
   );

--- a/chat2db-community-client/src/hooks/useViewTablePaging.ts
+++ b/chat2db-community-client/src/hooks/useViewTablePaging.ts
@@ -1,9 +1,10 @@
 import { useCallback, useRef, useState } from 'react';
-import type { IExecuteSqlParams } from '@/typings';
+import type { IExecuteSqlParams, IManageResultData } from '@/typings';
 import type { SqlExecutionEvent } from '@/service/sqlExecutionStream';
 import useSqlExecutor from './useSqlExecutor';
 import {
   createViewTablePagingState,
+  getViewTablePagingErrorMessage,
   normalizeViewTablePageResults,
   reduceViewTablePagingEvent,
   type ViewTablePagingState,
@@ -12,13 +13,18 @@ import {
 export default function useViewTablePaging() {
   const requestSequenceRef = useRef<number>();
   const paramsRef = useRef<IExecuteSqlParams>();
+  const confirmedResultRef = useRef<IManageResultData>();
   const pagingStateRef = useRef<ViewTablePagingState>();
   const [resultData, setResultData] = useState<ViewTablePagingState['result']>();
 
   const handleRequestStart = useCallback((requestSequence: number) => {
     requestSequenceRef.current = requestSequence;
     if (paramsRef.current) {
-      pagingStateRef.current = createViewTablePagingState(requestSequence, paramsRef.current);
+      pagingStateRef.current = createViewTablePagingState(
+        requestSequence,
+        paramsRef.current,
+        confirmedResultRef.current,
+      );
     }
   }, []);
 
@@ -40,10 +46,21 @@ export default function useViewTablePaging() {
   });
 
   const executePage = useCallback(
-    (params: IExecuteSqlParams) => {
+    (params: IExecuteSqlParams, confirmedResult: IManageResultData) => {
       paramsRef.current = params;
+      confirmedResultRef.current = confirmedResult;
       return executeSQL(params).then((data) => {
+        const streamState = pagingStateRef.current;
+        if (streamState?.params === params && streamState.errorMessage) {
+          throw new Error(streamState.errorMessage);
+        }
         const normalizedData = normalizeViewTablePageResults(data, params);
+        const responseError = normalizedData
+          .map(getViewTablePagingErrorMessage)
+          .find((message): message is string => !!message);
+        if (responseError) {
+          throw new Error(responseError);
+        }
         if (normalizedData.length) {
           setResultData(normalizedData[0]);
         }

--- a/chat2db-community-client/src/hooks/viewTablePagingModel.ts
+++ b/chat2db-community-client/src/hooks/viewTablePagingModel.ts
@@ -7,12 +7,15 @@ export type ViewTableStreamEventType = 'resultStarted' | 'rows' | 'resultFinishe
 export interface ViewTablePagingState {
   requestSequence: number;
   params: IExecuteSqlParams;
+  confirmedResult?: IManageResultData;
   result?: IManageResultData;
+  errorMessage?: string;
 }
 
 export interface ViewTablePagingTransition {
   state: ViewTablePagingState;
   completedResult?: IManageResultData;
+  errorMessage?: string;
 }
 
 function isResultEvent(eventType: SqlExecutionEvent['eventType']): eventType is ViewTableStreamEventType {
@@ -44,8 +47,12 @@ function mergeResultEvent(
   };
 }
 
-export function createViewTablePagingState(requestSequence: number, params: IExecuteSqlParams) {
-  return { requestSequence, params } satisfies ViewTablePagingState;
+export function createViewTablePagingState(
+  requestSequence: number,
+  params: IExecuteSqlParams,
+  confirmedResult?: IManageResultData,
+) {
+  return { requestSequence, params, confirmedResult } satisfies ViewTablePagingState;
 }
 
 export function normalizeViewTablePageResults(
@@ -55,18 +62,42 @@ export function normalizeViewTablePageResults(
   return processResultDataList(results, params);
 }
 
+export function getViewTablePagingErrorMessage(result: IManageResultData) {
+  if (result.success !== false) {
+    return undefined;
+  }
+  return result.message?.trim() || result.description?.trim() || 'SQL execution failed';
+}
+
 export function reduceViewTablePagingEvent(
   state: ViewTablePagingState,
   event: SqlExecutionEvent,
   requestSequence: number,
 ): ViewTablePagingTransition {
-  if (state.requestSequence !== requestSequence || !isResultEvent(event.eventType)) {
+  if (state.requestSequence !== requestSequence) {
+    return { state };
+  }
+  if (event.eventType === 'cancelled') {
+    const completedResult = state.confirmedResult ? { ...state.confirmedResult } : undefined;
+    return {
+      state: { ...state, result: undefined, errorMessage: undefined },
+      completedResult,
+    };
+  }
+  if (!isResultEvent(event.eventType)) {
     return { state };
   }
 
   const eventResult = normalizeViewTablePageResults([event.message], state.params)[0];
   if (!eventResult) {
     return { state };
+  }
+  const errorMessage = getViewTablePagingErrorMessage(eventResult);
+  if (errorMessage) {
+    return {
+      state: { ...state, result: undefined, errorMessage },
+      errorMessage,
+    };
   }
 
   const result = mergeResultEvent(state.result, eventResult, event.eventType);


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Table-browser paging treated a `success=false` result as completed data and replaced the last confirmed page. Desktop cancellation resolved as success without republishing that confirmed page, leaving an optimistic page number beside old rows. This change keeps a confirmed result in the paging state, rejects failed Web/Desktop results through the existing error path, and republishes a clean confirmed clone on cancellation.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Red result-pagination suite: 10 passed / 2 failed on current main.
  - Fixed result-pagination suite: 12 passed.
  - Related result-set, status, SQL request-tracker, stream, and execution-log contracts: passed.
  - Targeted ESLint: passed.
  - Full Community prebuild, Umi/Webpack build, and production bundle verifier: passed.
  - Fork code and CodeQL checks: passed.
- Manual verification: N/A - pure reducer and deferred stream tests cover failure and cancellation settlement.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or persisted-state changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community table-browser paging.
- Backward compatibility: Successful page responses preserve current normalization and result identity behavior.

## Reviewer map

- Start here: `viewTablePagingModel.reduceViewTablePagingEvent`, then `useViewTablePaging.executePage`.
- Failure condition: a failed result replaces confirmed rows, or cancellation leaves page controls ahead of visible data.
- Rollback or disable path: Revert commit `d5aac0924f22cc422e25272dc2530ac97b05ea36`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head d5aac0924.
- Table paging flow and related pagination suite: 12/12 passed; targeted ESLint passed.
- Included in the green combined Community production build and bundle verification.