### PR TITLE
fix(cache): recover from corrupt scalar entries

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/cache/CacheManage.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/cache/CacheManage.java
@@ -174,8 +174,13 @@ public class CacheManage {
 
         private <T> T get(Cache<String, String> cache, String key, Class<T> clazz) {
             String value = cache.get(key);
-            if (!StringUtils.isEmpty(value)) {
-                return JSON.parseObject(value, clazz);
+            try {
+                if (!StringUtils.isEmpty(value)) {
+                    return JSON.parseObject(value, clazz);
+                }
+            } catch (Exception e) {
+                log.error("get error", e);
+                remove(cache, key);
             }
             return null;
         }

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/cache/CacheManageTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/cache/CacheManageTest.java
@@ -1,6 +1,12 @@
 package ai.chat2db.community.domain.core.cache;
 
 import org.junit.jupiter.api.Test;
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.units.EntryUnit;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -8,6 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CacheManageTest {
@@ -73,5 +80,66 @@ class CacheManageTest {
         assertDoesNotThrow(() -> cacheStore.fuzzyDelete("key"));
         assertDoesNotThrow(cacheStore::close);
         assertDoesNotThrow(cacheStore::close);
+    }
+
+    @Test
+    void corruptScalarEntryIsEvictedBeforeFallbackAndRepaired() {
+        CacheManager cacheManager = newCacheManager();
+        CacheManage.CacheStore cacheStore = new CacheManage.CacheStore(() -> cacheManager);
+        Cache<String, String> cache = cacheManager.getCache("meta_cache", String.class, String.class);
+        cache.put("scalar", "{");
+        AtomicInteger fallbackCalls = new AtomicInteger();
+
+        try {
+            String first = cacheStore.get("scalar", String.class, ignored -> false, ignored -> {
+                assertNull(cache.get("scalar"));
+                fallbackCalls.incrementAndGet();
+                return "fallback";
+            });
+            String second = cacheStore.get("scalar", String.class, ignored -> false, ignored -> {
+                fallbackCalls.incrementAndGet();
+                return "unexpected";
+            });
+
+            assertEquals("fallback", first);
+            assertEquals("fallback", second);
+            assertEquals(1, fallbackCalls.get());
+        } finally {
+            cacheStore.close();
+        }
+    }
+
+    @Test
+    void corruptListEntryFallsBackAndIsRepaired() {
+        CacheManager cacheManager = newCacheManager();
+        CacheManage.CacheStore cacheStore = new CacheManage.CacheStore(() -> cacheManager);
+        Cache<String, String> cache = cacheManager.getCache("meta_cache", String.class, String.class);
+        cache.put("list", "{");
+        AtomicInteger fallbackCalls = new AtomicInteger();
+
+        try {
+            List<String> first = cacheStore.getList("list", String.class, ignored -> false, ignored -> {
+                fallbackCalls.incrementAndGet();
+                return List.of("fallback");
+            });
+            List<String> second = cacheStore.getList("list", String.class, ignored -> false, ignored -> {
+                fallbackCalls.incrementAndGet();
+                return List.of("unexpected");
+            });
+
+            assertEquals(List.of("fallback"), first);
+            assertEquals(List.of("fallback"), second);
+            assertEquals(1, fallbackCalls.get());
+        } finally {
+            cacheStore.close();
+        }
+    }
+
+    private static CacheManager newCacheManager() {
+        return CacheManagerBuilder.newCacheManagerBuilder()
+                .withCache("meta_cache", CacheConfigurationBuilder.newCacheConfigurationBuilder(
+                        String.class, String.class,
+                        ResourcePoolsBuilder.newResourcePoolsBuilder().heap(10, EntryUnit.ENTRIES)))
+                .build(true);
     }
 }


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

A malformed scalar JSON entry escaped `CacheManage` before the configured fallback loader could run, so the same cache key remained unusable for its TTL. This change catches scalar deserialization failures, removes only the corrupt key, and lets the existing fallback path rebuild and cache a valid value.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Current main reproduced `JSONException: input end` before the fallback loader: 6 tests, 1 error before the fix.
- Integrated head owning reactor tests and package passed: domain-core 306, SPI 147, tools 77, domain-api 27; 557 total, zero failures/errors/skips.
- Command: `mvn -B -ntp -f chat2db-community-server/pom.xml -pl :chat2db-community-domain-core -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false package`. Test JVM home/temp were isolated.
- An additional temporary review test passed for neighboring-key preservation, loader exception propagation and subsequent recovery; it is not part of this PR.
- Executable backend package passed. Playwright CLI created a SQLite connection, warmed the actual scalar metadata cache, and verified recovery after a test-only attach agent injected malformed JSON into that exact datasource key. First request, repeat request and reload passed; the underlying cache value was verified as valid JSON afterward.
- This verifies recovery from an injected corrupt value, not a claim that ordinary user actions naturally produce corrupt JSON.
- The two integrated PR files are byte-identical to the Web-tested version. Current-head checks are available below.

## Risk and compatibility

- Public API or stored data: No API or cache format changes; only an unreadable key is evicted.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community metadata cache.
- Backward compatibility: Valid scalar and list entries retain existing behavior.

## Reviewer map

- Start here: `CacheManage.CacheStore.get` and the corrupt scalar regression case.
- Failure condition: malformed JSON escapes before fallback or a valid neighboring key is removed.
- Rollback or disable path: Revert commit `8618ac7e9edd87667ac9c0674f6b5516922956e3`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.