### PR TITLE
fix(storage): publish small mutations after persistence

### DIFF
--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/small/SmallDataStorage.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/small/SmallDataStorage.java
@@ -30,11 +30,14 @@ public class SmallDataStorage<T> implements IWorkspaceLocalStorage<T> {
 
     protected String filePath;
 
+    private final Class<T> clazz;
+
     protected SmallDataStorage(String name, Class<T> clazz) {
         this(new File(DB_STORAGE_PATH + File.separator + name + File.separator + name + ".json"), clazz);
     }
 
     protected SmallDataStorage(File storageFile, Class<T> clazz) {
+        this.clazz = clazz;
         this.filePath = storageFile.getAbsolutePath();
         if (!FileUtil.exist(filePath)) {
             FileUtil.writeUtf8String("", filePath);
@@ -78,13 +81,10 @@ public class SmallDataStorage<T> implements IWorkspaceLocalStorage<T> {
         }
         try {
             Long id = LocalStorageConverter.ensureId(data, this::generateId);
-            if (dataMap.get(id) != null) {
-                dataMap.put(id, data);
-                saveDataList();
-            } else {
-                dataMap.put(id, data);
-                FileUtil.appendUtf8String(JSON.toJSONString(data) + "\n", filePath);
-            }
+            Map<Long, T> nextDataMap = new ConcurrentSkipListMap<>(dataMap);
+            nextDataMap.put(id, data);
+            saveDataList(Lists.newArrayList(nextDataMap.values()));
+            dataMap.put(id, data);
             return id;
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -105,9 +105,11 @@ public class SmallDataStorage<T> implements IWorkspaceLocalStorage<T> {
             if (before == null) {
                 return;
             }
-            before = getAfterSave(before, data);
-            dataMap.put(id, before);
-            saveDataList();
+            T replacement = getAfterSave(copy(before), data);
+            Map<Long, T> nextDataMap = new ConcurrentSkipListMap<>(dataMap);
+            nextDataMap.put(id, replacement);
+            saveDataList(Lists.newArrayList(nextDataMap.values()));
+            dataMap.put(id, replacement);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -116,8 +118,10 @@ public class SmallDataStorage<T> implements IWorkspaceLocalStorage<T> {
 
     @Override
     public synchronized void delete(Long id) {
+        Map<Long, T> nextDataMap = new ConcurrentSkipListMap<>(dataMap);
+        nextDataMap.remove(id);
+        saveDataList(Lists.newArrayList(nextDataMap.values()));
         dataMap.remove(id);
-        saveDataList();
     }
 
     protected synchronized void saveDataList() {
@@ -166,6 +170,10 @@ public class SmallDataStorage<T> implements IWorkspaceLocalStorage<T> {
 
     public Long generateId() {
         return IdUtil.generateId();
+    }
+
+    private T copy(T data) {
+        return JSON.parseObject(JSON.toJSONString(data), clazz);
     }
 
 }

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/small/SmallDataStorageAtomicWriteTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/small/SmallDataStorageAtomicWriteTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,6 +66,82 @@ class SmallDataStorageAtomicWriteTest {
         }
     }
 
+    @Test
+    void failedExistingSaveKeepsMemoryFileAndReloadState() throws Exception {
+        File storageFile = new File(tempDir, "records-save.json");
+        FailingRecordStorage storage = seededStorage(storageFile);
+        String original = Files.readString(storageFile.toPath(), StandardCharsets.UTF_8);
+        storage.failWrites = true;
+
+        assertThrows(RuntimeException.class, () -> storage.save(record(1L, "after")));
+
+        assertNotNull(storage.getById(1L));
+        assertEquals("before", storage.getById(1L).getValue());
+        assertEquals(original, Files.readString(storageFile.toPath(), StandardCharsets.UTF_8));
+        assertEquals("before", new RecordStorage(storageFile).getById(1L).getValue());
+    }
+
+    @Test
+    void failedUpdateKeepsMemoryFileAndReloadState() throws Exception {
+        File storageFile = new File(tempDir, "records-update.json");
+        FailingRecordStorage storage = seededStorage(storageFile);
+        String original = Files.readString(storageFile.toPath(), StandardCharsets.UTF_8);
+        storage.failWrites = true;
+
+        assertThrows(RuntimeException.class, () -> storage.update(record(1L, "after")));
+
+        assertNotNull(storage.getById(1L));
+        assertEquals("before", storage.getById(1L).getValue());
+        assertEquals(original, Files.readString(storageFile.toPath(), StandardCharsets.UTF_8));
+        assertEquals("before", new RecordStorage(storageFile).getById(1L).getValue());
+    }
+
+    @Test
+    void failedDeleteKeepsMemoryFileAndReloadState() throws Exception {
+        File storageFile = new File(tempDir, "records-delete.json");
+        FailingRecordStorage storage = seededStorage(storageFile);
+        String original = Files.readString(storageFile.toPath(), StandardCharsets.UTF_8);
+        storage.failWrites = true;
+
+        assertThrows(RuntimeException.class, () -> storage.delete(1L));
+
+        assertNotNull(storage.getById(1L));
+        assertEquals("before", storage.getById(1L).getValue());
+        assertEquals(original, Files.readString(storageFile.toPath(), StandardCharsets.UTF_8));
+        assertEquals("before", new RecordStorage(storageFile).getById(1L).getValue());
+    }
+
+    @Test
+    void failedNewSaveKeepsMemoryAndReloadStateEmpty() throws Exception {
+        File storageFile = new File(tempDir, "records-new.json");
+        RecordStorage storage = new RecordStorage(storageFile);
+        String original = Files.readString(storageFile.toPath(), StandardCharsets.UTF_8);
+        Files.delete(storageFile.toPath());
+        Files.createDirectory(storageFile.toPath());
+        Path blocker = Files.writeString(storageFile.toPath().resolve("blocker"), "block");
+
+        assertThrows(RuntimeException.class, () -> storage.save(record(1L, "new")));
+
+        Files.delete(blocker);
+        Files.delete(storageFile.toPath());
+        Files.writeString(storageFile.toPath(), original, StandardCharsets.UTF_8);
+        assertNull(storage.getById(1L));
+        assertNull(new RecordStorage(storageFile).getById(1L));
+    }
+
+    private static FailingRecordStorage seededStorage(File storageFile) {
+        FailingRecordStorage storage = new FailingRecordStorage(storageFile);
+        storage.save(record(1L, "before"));
+        return storage;
+    }
+
+    private static TestRecord record(long id, String value) {
+        TestRecord record = new TestRecord();
+        record.setId(id);
+        record.setValue(value);
+        return record;
+    }
+
     private static TreeNode treeNode(long id) {
         TreeNode node = new TreeNode();
         node.setId(id);
@@ -95,6 +172,49 @@ class SmallDataStorageAtomicWriteTest {
         @Override
         protected void replaceStorageFile(Path temp, Path target) throws IOException {
             throw new IOException("forced replace failure");
+        }
+    }
+
+    public static class TestRecord {
+        private Long id;
+        private String value;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    private static class RecordStorage extends SmallDataStorage<TestRecord> {
+        RecordStorage(File storageFile) {
+            super(storageFile, TestRecord.class);
+        }
+    }
+
+    private static final class FailingRecordStorage extends RecordStorage {
+        private boolean failWrites;
+
+        FailingRecordStorage(File storageFile) {
+            super(storageFile);
+        }
+
+        @Override
+        protected void replaceStorageFile(Path temp, Path target) throws IOException {
+            if (failWrites) {
+                throw new IOException("forced replace failure");
+            }
+            super.replaceStorageFile(temp, target);
         }
     }
 }


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

`SmallDataStorage` published save, update, and delete mutations to its in-memory map before persistence completed. A filesystem failure left memory showing the new state while disk and a reloaded instance retained the old state. This change writes a candidate map atomically before publishing it and merges updates into a detached persistence-compatible copy.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- On current main, the original atomic storage suite ran 7 tests with 4 failures: new save, existing save, update and delete published memory changes after failed writes.
- After main integration, storage reactor tests and package passed: storage 69, tools 77, domain-api 27; 173 total, zero failures/errors/skips.
- Command: `mvn -B -ntp -f chat2db-community-server/pom.xml -pl :chat2db-community-storage -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false package`. Test JVM home/temp directories were isolated.
- Executable backend package passed. Playwright CLI created two groups, then actual directory write denial caused create/update requests and UI delete to fail while memory, file bytes, neighboring records and refreshed state remained unchanged. After restoring permissions and restarting the backend, normal create/update/delete passed; canceling deletion sent zero write requests.
- Existing-record save failure is covered by the storage test, not claimed as a separate UI action.
- The two integrated PR files are byte-identical to the Web-tested version. Current-head CI is available in PR checks.

## Risk and compatibility

- Public API or stored data: Existing newline-delimited JSON format and method signatures are unchanged.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community local storage base class.
- Backward compatibility: Successful mutations retain ordering and returned IDs; failed mutations no longer publish. New saves now rewrite the small record file instead of appending, adding linear serialization and write cost.
- Scope: This protects mutations performed by the base class within one file. It does not provide transactions across datasource, namespace and tree files, or undo mutations callers already made through shared object references.

## Reviewer map

- Start here: `SmallDataStorage.save/update/delete` and `SmallDataStorageAtomicWriteTest`.
- Failure condition: a failed write changes `getById`, file contents, or reload state.
- Rollback or disable path: Revert commit `c783a75f10f8c99498800b1ed901042abed59a49`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.