### PR TITLE
fix(sundb): preserve complete function source

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/main/java/ai/chat2db/plugin/sundb/SUNDBMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/main/java/ai/chat2db/plugin/sundb/SUNDBMetaData.java
@@ -239,8 +239,12 @@ public class SUNDBMetaData extends DefaultMetaService implements IDbMetaData {
             function.setDatabaseName(databaseName);
             function.setSchemaName(schemaName);
             function.setFunctionName(functionName);
-            if (resultSet.next()) {
-                function.setFunctionBody(resultSet.getString("text") + "\n");
+            StringBuilder body = new StringBuilder();
+            while (resultSet.next()) {
+                body.append(resultSet.getString("TEXT")).append("\n");
+            }
+            if (body.length() > 0) {
+                function.setFunctionBody(body.toString());
             }
             return function;
         });

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/main/java/ai/chat2db/plugin/sundb/constant/SUNDBMetaDataConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/main/java/ai/chat2db/plugin/sundb/constant/SUNDBMetaDataConstants.java
@@ -44,7 +44,7 @@ public final class SUNDBMetaDataConstants {
     public static final String SQL_SELECT_TC_TABLE_SCHEMA_TC = "SELECT\r\nTC.TABLE_SCHEMA,\r\nTC.TABLE_NAME,\r\nTC.CONSTRAINT_NAME,\r\nTC.CONSTRAINT_TYPE,\r\nUCC.COLUMN_NAME\r\nFROM TABLE_CONSTRAINTS TC\r\nJOIN USER_CONS_COLUMNS UCC ON TC.TABLE_NAME = UCC.TABLE_NAME\r\nWHERE TC.TABLE_NAME = '";
     public static final String SQL_SELECT_UT_TABLE_SCHEMA_UT = "SELECT \r\nUT.TABLE_SCHEMA, \r\nUT.TABLE_NAME,\r\nUT.TABLESPACE_NAME,\r\nUT.PCT_FREE,\r\nUT.PCT_USED,\r\nUT.INI_TRANS,\r\nUT.MAX_TRANS,\r\nUT.INITIAL_EXTENT*TBS.EXTENT_SIZE,\r\nUT.NEXT_EXTENT*TBS.EXTENT_SIZE,\r\nUT.MIN_EXTENTS*TBS.EXTENT_SIZE,\r\nUT.MAX_EXTENTS*TBS.EXTENT_SIZE\r\nFROM ALL_TABLES UT \r\nJOIN V$TABLESPACE TBS ON TBS.TBS_NAME = UT.TABLESPACE_NAME \r\nWHERE UT.TABLE_NAME = '";
     public static final String ALL_PROCEDURES_SQL = "select OBJECT_NAME from ALL_PROCEDURES where owner = '%s' and schema_name = '%s' and OBJECT_TYPE = '%s' order by OBJECT_NAME";
-    public static final String ALL_SOURCE_SQL = "select text from all_source where TYPE = '%s' and owner = '%s' and schema_name = '%s' and name = '%s'";
+    public static final String ALL_SOURCE_SQL = "select text from all_source where TYPE = '%s' and owner = '%s' and schema_name = '%s' and name = '%s' ORDER BY LINE";
     public static final String TRIGGER_SQL = "SELECT OWNER, TRIGGER_NAME, TABLE_OWNER, TABLE_NAME, TRIGGERING_TYPE, TRIGGERING_EVENT, STATUS, TRIGGER_BODY "
             + "FROM ALL_TRIGGERS WHERE OWNER = '%s' AND TRIGGER_NAME = '%s'";
     public static final String TRIGGER_SQL_LIST = "SELECT OWNER, TRIGGER_NAME FROM ALL_TRIGGERS WHERE OWNER = '%s'";

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/test/java/ai/chat2db/plugin/sundb/SUNDBFunctionSourceTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sundb/src/test/java/ai/chat2db/plugin/sundb/SUNDBFunctionSourceTest.java
@@ -1,0 +1,84 @@
+package ai.chat2db.plugin.sundb;
+
+import ai.chat2db.community.domain.api.model.metadata.Function;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SUNDBFunctionSourceTest {
+
+    @Test
+    void functionReadsEverySourceLineInLineOrder() {
+        List<String> sql = new ArrayList<>();
+
+        Function function = new SUNDBMetaData().function(
+            connection(sql, "line 1", "line 2"), "db", "APP", "F1");
+
+        assertEquals("line 1\nline 2\n", function.getFunctionBody());
+        assertTrue(sql.get(0).toLowerCase(Locale.ROOT).endsWith(" order by line"), sql.get(0));
+    }
+
+    private static Connection connection(List<String> sql, String... sourceLines) {
+        DatabaseMetaData databaseMetaData = (DatabaseMetaData) Proxy.newProxyInstance(
+            SUNDBFunctionSourceTest.class.getClassLoader(),
+            new Class<?>[]{DatabaseMetaData.class},
+            (proxy, method, args) -> {
+                if ("getUserName".equals(method.getName())) {
+                    return "TESTER";
+                }
+                throw new AssertionError("Unexpected DatabaseMetaData call: " + method.getName());
+            });
+        ResultSet resultSet = sourceResultSet(sourceLines);
+        return (Connection) Proxy.newProxyInstance(
+            SUNDBFunctionSourceTest.class.getClassLoader(),
+            new Class<?>[]{Connection.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getMetaData" -> databaseMetaData;
+                case "prepareStatement" -> {
+                    sql.add((String) args[0]);
+                    yield statement(resultSet);
+                }
+                default -> throw new AssertionError("Unexpected Connection call: " + method.getName());
+            });
+    }
+
+    private static PreparedStatement statement(ResultSet resultSet) {
+        return (PreparedStatement) Proxy.newProxyInstance(
+            SUNDBFunctionSourceTest.class.getClassLoader(),
+            new Class<?>[]{PreparedStatement.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "execute" -> true;
+                case "getResultSet" -> resultSet;
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected PreparedStatement call: " + method.getName());
+            });
+    }
+
+    private static ResultSet sourceResultSet(String... sourceLines) {
+        int[] row = {-1};
+        return (ResultSet) Proxy.newProxyInstance(
+            SUNDBFunctionSourceTest.class.getClassLoader(),
+            new Class<?>[]{ResultSet.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "next" -> ++row[0] < sourceLines.length;
+                case "getString" -> {
+                    if (!(args[0] instanceof String label) || !"TEXT".equalsIgnoreCase(label)) {
+                        throw new AssertionError("Unexpected ResultSet label: " + args[0]);
+                    }
+                    yield sourceLines[row[0]];
+                }
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected ResultSet call: " + method.getName());
+            });
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

SunDB function detail metadata read only the first row from `ALL_SOURCE`, truncating every multiline function body. The shared source query also had no line ordering. This change reads every source row and orders function/procedure source by `LINE`, preserving the existing newline-separated body format.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Red test returned only the first of two source rows.
  - Focused function source test: 1 passed.
  - SunDB module tests after rebase: 26 passed.
  - Plugin reactor package: succeeded.
  - Fork code and CodeQL checks: rerunning for the rebased head.
  - Merge-tree with upstream #2807: passed.
- Manual verification: N/A - strict JDBC proxies supply ordered source rows and capture the generated SQL.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or stored data changes.
- Database or driver compatibility: SunDB routine source queries only; source text is no longer truncated.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community SunDB plugin.
- Backward compatibility: Single-line bodies retain the same text plus trailing newline.

## Reviewer map

- Start here: `SUNDBMetaData.function` and shared `ALL_SOURCE_SQL`.
- Failure condition: only the first source row is returned or rows are not ordered by `LINE`.
- Rollback or disable path: Revert commit `f99a0980285bb2fa15ec70d1740aea404dff3e6d`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.