### PR TITLE
fix(hive): map not-null metadata correctly

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/main/java/ai/chat2db/plugin/hive/HiveMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/main/java/ai/chat2db/plugin/hive/HiveMetaData.java
@@ -247,7 +247,7 @@ public class HiveMetaData extends DefaultMetaService implements IDbMetaData {
                     tableColumn.setPrimaryKey(true);
                 }
                 if (constraints.get("notnull") !=null && constraints.get("notnull").keySet().contains(columnMap.get("col_name"))) {
-                    tableColumn.setNullable(1);
+                    tableColumn.setNullable(0);
                 }
                 tableColumns.add(tableColumn);
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/test/java/ai/chat2db/plugin/hive/HiveNotNullMetadataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/test/java/ai/chat2db/plugin/hive/HiveNotNullMetadataTest.java
@@ -1,0 +1,91 @@
+package ai.chat2db.plugin.hive;
+
+import ai.chat2db.community.domain.api.model.metadata.TableColumn;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HiveNotNullMetadataTest {
+
+    private static final String[] COLUMN_LABELS = {"col_name", "data_type", "comment"};
+
+    @Test
+    void notNullConstraintMapsToJdbcNoNullsValue() {
+        String[][] rows = {
+            {"# col_name", "", ""},
+            {"id", "int", "identifier"},
+            {"# Not Null Constraints", "", ""},
+            {"Constraint:", "NN_ID", ""},
+            {"Column:", "id", ""}
+        };
+
+        List<TableColumn> columns = new HiveMetaData().columns(connection(rows), "db", "APP", "items");
+
+        assertEquals(1, columns.size());
+        assertEquals("id", columns.get(0).getName());
+        assertEquals(0, columns.get(0).getNullable());
+    }
+
+    private static Connection connection(String[][] rows) {
+        ResultSet resultSet = resultSet(rows);
+        return (Connection) Proxy.newProxyInstance(
+            HiveNotNullMetadataTest.class.getClassLoader(),
+            new Class<?>[]{Connection.class},
+            (proxy, method, args) -> {
+                if (!"prepareStatement".equals(method.getName())) {
+                    throw new AssertionError("Unexpected Connection call: " + method.getName());
+                }
+                return Proxy.newProxyInstance(
+                    HiveNotNullMetadataTest.class.getClassLoader(),
+                    new Class<?>[]{PreparedStatement.class},
+                    (statement, statementMethod, statementArgs) -> switch (statementMethod.getName()) {
+                        case "execute" -> true;
+                        case "getResultSet" -> resultSet;
+                        case "close" -> null;
+                        default -> throw new AssertionError(
+                            "Unexpected PreparedStatement call: " + statementMethod.getName());
+                    });
+            });
+    }
+
+    private static ResultSet resultSet(String[][] rows) {
+        ResultSetMetaData metaData = (ResultSetMetaData) Proxy.newProxyInstance(
+            HiveNotNullMetadataTest.class.getClassLoader(),
+            new Class<?>[]{ResultSetMetaData.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getColumnCount" -> COLUMN_LABELS.length;
+                case "getColumnName" -> COLUMN_LABELS[(Integer) args[0] - 1];
+                default -> throw new AssertionError("Unexpected ResultSetMetaData call: " + method.getName());
+            });
+        int[] row = {-1};
+        return (ResultSet) Proxy.newProxyInstance(
+            HiveNotNullMetadataTest.class.getClassLoader(),
+            new Class<?>[]{ResultSet.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "next" -> ++row[0] < rows.length;
+                case "getMetaData" -> metaData;
+                case "getString" -> rows[row[0]][columnIndex(args[0])];
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected ResultSet call: " + method.getName());
+            });
+    }
+
+    private static int columnIndex(Object selector) {
+        if (selector instanceof Integer index) {
+            return index - 1;
+        }
+        for (int i = 0; i < COLUMN_LABELS.length; i++) {
+            if (COLUMN_LABELS[i].equals(selector)) {
+                return i;
+            }
+        }
+        throw new AssertionError("Unexpected ResultSet label: " + selector);
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Hive `DESCRIBE FORMATTED` parsing mapped entries from `# Not Null Constraints` to nullable value `1`. JDBC and the shared metadata model use `0` for no-nulls and `1` for nullable, so NOT NULL columns were reported backwards. This change maps those constraints to `0` and leaves other column attributes unchanged.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Red test returned nullable=1 for a NOT NULL column.
  - Focused Hive metadata test: 1 passed.
  - Hive module tests after rebase: 37 passed.
  - Plugin reactor package: succeeded.
  - Fork code and CodeQL checks: rerunning for the rebased head.
- Manual verification: N/A - strict ResultSet proxies reproduce the real formatted metadata sections.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or stored data changes.
- Database or driver compatibility: Corrects Hive NOT NULL metadata to the existing JDBC convention.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community Hive plugin.
- Backward compatibility: Columns without a NOT NULL constraint retain existing nullable metadata.

## Reviewer map

- Start here: the NOT NULL branch in `HiveMetaData.columns` and `HiveNotNullMetadataTest`.
- Failure condition: constrained columns report nullable=1 or unrelated metadata parsing changes.
- Rollback or disable path: Revert commit `f0843e258cecfdfc527430de2e15034d11320425`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.