### PR TITLE
fix(ai): keep latest mention table request

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -27,7 +27,7 @@
     "test:community-boundary": "node ./scripts/verify-community-boundary.cjs",
     "test:database-capabilities": "tsx src/utils/databaseJudgments.test.ts",
     "test:table-editor": "tsx src/blocks/DatabaseTableEditor/ColumnList/normalizeColumn.test.ts",
-    "test:retired-ai": "tsx src/blocks/AI/retiredAiSurface.test.ts && tsx src/blocks/AI/components/AIChatInput/mentionSelection.test.ts && tsx src/blocks/AI/knowledgeSelection.test.ts && tsx src/blocks/AI/messageNavigation.test.ts",
+    "test:retired-ai": "tsx src/blocks/AI/retiredAiSurface.test.ts && tsx src/blocks/AI/components/AIChatInput/mentionSelection.test.ts && tsx src/blocks/AI/components/AIChatInput/mentionTableRequestCoordinator.test.ts && tsx src/blocks/AI/knowledgeSelection.test.ts && tsx src/blocks/AI/messageNavigation.test.ts",
     "test:hot-update": "tsx src/store/global/slices/hotUpdate/action.test.ts",
     "test:active-transactions": "tsx src/blocks/NewTree/components/ActiveTransactionsContent/activeTransactionUtils.test.ts && tsx src/blocks/NewTree/treeMenuGrouping.test.ts",
     "test:result-pagination": "tsx src/blocks/SearchResult/components/ResultSet/pagination.test.ts",

--- a/chat2db-community-client/src/blocks/AI/components/AIChatInput/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AIChatInput/index.tsx
@@ -51,6 +51,23 @@ import {
   type MentionTrigger,
   type SelectedMention,
 } from './mentionSelection';
+import {
+  MentionSuggestionResolution,
+  MentionTableRequestCoordinator,
+  type MentionTableRequestContext,
+  type MentionTableRequestOwner,
+} from './mentionTableRequestCoordinator';
+
+function toMentionTableRequestContext(contextInfo: IAICascaderData): MentionTableRequestContext {
+  if (!('dataSourceId' in contextInfo)) {
+    return {};
+  }
+  return {
+    dataSourceId: contextInfo.dataSourceId,
+    databaseName: contextInfo.databaseName,
+    schemaName: contextInfo.schemaName,
+  };
+}
 
 export interface SendParams {
   input: string;
@@ -168,6 +185,7 @@ const AIChatInput = forwardRef((props: ChatInputProps, ref: ForwardedRef<ChatInp
   const knowledgeRequestSequenceRef = useRef(0);
   const knowledgeSearchCursorRef = useRef<KnowledgeSearchCursor | null>(null);
   const knowledgeLoadingSequenceRef = useRef<number | null>(null);
+  const mentionTableRequestCoordinatorRef = useRef(new MentionTableRequestCoordinator<PageType>());
 
   // caches tables without search conditions
   const tableListWithoutSearchKey = useRef<ITable[]>([]);
@@ -246,76 +264,116 @@ const AIChatInput = forwardRef((props: ChatInputProps, ref: ForwardedRef<ChatInp
     knowledgeSearchCursorRef.current = null;
     knowledgeLoadingSequenceRef.current = null;
     setKnowledgeLoadingMore(false);
-    if (cascaderDataMap[mainPageActiveTab]) {
-      fetchTableList(cascaderDataMap[mainPageActiveTab], '');
+    const contextInfo = cascaderDataMap[mainPageActiveTab];
+    if (contextInfo) {
+      const requestOwner = mentionTableRequestCoordinatorRef.current.beginRequest(
+        mainPageActiveTab as PageType,
+        toMentionTableRequestContext(contextInfo),
+        '',
+      );
+      fetchTableList(contextInfo, '', requestOwner);
+    } else {
+      mentionTableRequestCoordinatorRef.current.invalidate();
     }
-  }, [cascaderDataMap[mainPageActiveTab]]);
+  }, [mainPageActiveTab, cascaderDataMap[mainPageActiveTab]]);
 
   const fetchTableList = useRef(
-    debounce(async (_contextInfo: IAICascaderData, searchKey: string) => {
-      if (!_contextInfo) return;
-      if ('dataSourceId' in _contextInfo && _contextInfo?.dataSourceId) {
-        if (!searchKey && tableListWithoutSearchKey.current.length) {
-          setTableList(tableListWithoutSearchKey.current);
-          return;
-        }
-        let res;
-        let viewRes;
-        try {
-          res = await sqlService.getTableList({
-            dataSourceId: _contextInfo.dataSourceId,
-            databaseName: _contextInfo.databaseName,
-            schemaName: _contextInfo.schemaName,
-            pageNo: 1,
-            pageSize: 1000,
-            searchKey,
-          });
-          viewRes = await sqlService.getViewList({
-            dataSourceId: _contextInfo.dataSourceId,
-            databaseName: _contextInfo.databaseName,
-            schemaName: _contextInfo.schemaName,
-            pageNo: 1,
-            pageSize: 1000,
-            searchKey,
-          });
-        } catch (error) {
-          const requestError = error as { errorCode?: string };
-          if (
-            requestError.errorCode === 'QUERY_DATASOURCE_ERROR' ||
-            requestError.errorCode === ErrorCode.NeedLoggedIn
-          ) {
-            tableListWithoutSearchKey.current = [];
-            setTableList([]);
-            clearCascaderData(mainPageActiveTab as PageType);
+    debounce(
+      async (
+        _contextInfo: IAICascaderData,
+        searchKey: string,
+        requestOwner: MentionTableRequestOwner<PageType>,
+        onResolved?: (hasCandidates: boolean) => void,
+      ) => {
+        if (!_contextInfo || !('dataSourceId' in _contextInfo) || !_contextInfo.dataSourceId) {
+          if (mentionTableRequestCoordinatorRef.current.isCurrent(requestOwner)) {
+            onResolved?.(false);
           }
           return;
         }
+        if ('dataSourceId' in _contextInfo && _contextInfo?.dataSourceId) {
+          if (!mentionTableRequestCoordinatorRef.current.isCurrent(requestOwner)) {
+            return;
+          }
+          if (!searchKey && tableListWithoutSearchKey.current.length) {
+            setTableList(tableListWithoutSearchKey.current);
+            onResolved?.(tableListWithoutSearchKey.current.length > 0);
+            return;
+          }
+          let res;
+          let viewRes;
+          try {
+            res = await sqlService.getTableList({
+              dataSourceId: _contextInfo.dataSourceId,
+              databaseName: _contextInfo.databaseName,
+              schemaName: _contextInfo.schemaName,
+              pageNo: 1,
+              pageSize: 1000,
+              searchKey,
+            });
+            if (!mentionTableRequestCoordinatorRef.current.isCurrent(requestOwner)) {
+              return;
+            }
+            viewRes = await sqlService.getViewList({
+              dataSourceId: _contextInfo.dataSourceId,
+              databaseName: _contextInfo.databaseName,
+              schemaName: _contextInfo.schemaName,
+              pageNo: 1,
+              pageSize: 1000,
+              searchKey,
+            });
+            if (!mentionTableRequestCoordinatorRef.current.isCurrent(requestOwner)) {
+              return;
+            }
+          } catch (error) {
+            const requestError = error as { errorCode?: string };
+            const ownedPage = mentionTableRequestCoordinatorRef.current.getOwnedErrorPage(requestOwner);
+            if (
+              ownedPage &&
+              (requestError.errorCode === 'QUERY_DATASOURCE_ERROR' ||
+                requestError.errorCode === ErrorCode.NeedLoggedIn)
+            ) {
+              tableListWithoutSearchKey.current = [];
+              setTableList([]);
+              clearCascaderData(ownedPage);
+            }
+            if (ownedPage) {
+              onResolved?.(false);
+            }
+            return;
+          }
 
-        const atTableList =
-          res.data?.map((s) => ({
-            ...s,
-            tableType: 'TABLE',
-          })) || [];
+          const atTableList =
+            res.data?.map((s) => ({
+              ...s,
+              tableType: 'TABLE',
+            })) || [];
 
-        const atViewList =
-          viewRes.data?.map((s) => ({
-            ...s,
-            tableType: 'VIEW',
-          })) || [];
+          const atViewList =
+            viewRes.data?.map((s) => ({
+              ...s,
+              tableType: 'VIEW',
+            })) || [];
 
-        const list = [...atTableList, ...atViewList];
+          const list = [...atTableList, ...atViewList];
 
-        if (!searchKey) {
-          tableListWithoutSearchKey.current = list;
+          if (!searchKey) {
+            tableListWithoutSearchKey.current = list;
+          }
+
+          setTableList(list);
+          onResolved?.(list.length > 0);
         }
-
-        setTableList(list);
-      }
-    }, 300),
+      },
+      300,
+    ),
   ).current;
 
   useEffect(() => {
-    return () => fetchTableList.cancel();
+    return () => {
+      mentionTableRequestCoordinatorRef.current.invalidate();
+      fetchTableList.cancel();
+    };
   }, []);
 
   const requestKnowledgePage = (
@@ -686,6 +744,7 @@ const AIChatInput = forwardRef((props: ChatInputProps, ref: ForwardedRef<ChatInp
   ) => {
     const nextTrigger = detectMentionTrigger(value, cursor);
     if (!nextTrigger) {
+      mentionTableRequestCoordinatorRef.current.invalidate();
       knowledgeRequestSequenceRef.current += 1;
       setMentionTrigger(null);
       setKnowledgeList([]);
@@ -706,9 +765,29 @@ const AIChatInput = forwardRef((props: ChatInputProps, ref: ForwardedRef<ChatInp
     setKnowledgeLoadingMore(false);
     setMentionTrigger(nextTrigger);
     const contextInfo = cascaderDataMap[mainPageActiveTab];
+    const expectsTableResult = nextTrigger.mode === 'explicit' && Boolean(contextInfo);
+    const suggestionResolution = new MentionSuggestionResolution(expectsTableResult);
+    const applySuggestionDecision = (decision: ReturnType<MentionSuggestionResolution['resolveTable']>) => {
+      if (requestSequence !== knowledgeRequestSequenceRef.current) return;
+      if (decision === 'open') {
+        onTrigger(nextTrigger);
+      } else if (decision === 'close') {
+        setMentionTrigger(null);
+        onTrigger(false);
+      }
+    };
 
-    if (nextTrigger.mode === 'explicit') {
-      fetchTableList(contextInfo, nextTrigger.query);
+    if (nextTrigger.mode === 'explicit' && contextInfo) {
+      const requestOwner = mentionTableRequestCoordinatorRef.current.beginRequest(
+        mainPageActiveTab as PageType,
+        toMentionTableRequestContext(contextInfo),
+        nextTrigger.query,
+      );
+      fetchTableList(contextInfo, nextTrigger.query, requestOwner, (hasCandidates) => {
+        applySuggestionDecision(suggestionResolution.resolveTable(hasCandidates));
+      });
+    } else {
+      mentionTableRequestCoordinatorRef.current.invalidate();
     }
 
     fetchKnowledgeList(
@@ -718,13 +797,7 @@ const AIChatInput = forwardRef((props: ChatInputProps, ref: ForwardedRef<ChatInp
         : { inputText: nextTrigger.inputText.slice(-200) },
       requestSequence,
       (hasCandidates) => {
-        if (requestSequence !== knowledgeRequestSequenceRef.current) return;
-        if (hasCandidates) {
-          onTrigger(nextTrigger);
-        } else {
-          setMentionTrigger(null);
-          onTrigger(false);
-        }
+        applySuggestionDecision(suggestionResolution.resolveKnowledge(hasCandidates));
       },
     );
   };

--- a/chat2db-community-client/src/blocks/AI/components/AIChatInput/mentionSelection.test.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIChatInput/mentionSelection.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import './mentionTableRequestCoordinator.test';
 import {
   detectMentionTrigger,
   filterUnselectedMentionCandidates,

--- a/chat2db-community-client/src/blocks/AI/components/AIChatInput/mentionTableRequestCoordinator.test.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIChatInput/mentionTableRequestCoordinator.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import {
+  MentionSuggestionResolution,
+  MentionTableRequestCoordinator,
+  type MentionTableRequestOwner,
+} from './mentionTableRequestCoordinator';
+
+type TestPage = 'workspace' | 'stream';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+async function commitWhenCurrent(
+  coordinator: MentionTableRequestCoordinator<TestPage>,
+  owner: MentionTableRequestOwner<TestPage>,
+  response: Promise<string>,
+  commits: string[],
+) {
+  const value = await response;
+  if (coordinator.isCurrent(owner)) {
+    commits.push(value);
+  }
+}
+
+async function clearOwnedPageOnError(
+  coordinator: MentionTableRequestCoordinator<TestPage>,
+  owner: MentionTableRequestOwner<TestPage>,
+  response: Promise<never>,
+  clearedPages: TestPage[],
+) {
+  try {
+    await response;
+  } catch {
+    const page = coordinator.getOwnedErrorPage(owner);
+    if (page) {
+      clearedPages.push(page);
+    }
+  }
+}
+
+async function run() {
+  const tableOnlyResolution = new MentionSuggestionResolution(true);
+  assert.equal(tableOnlyResolution.resolveKnowledge(false), 'wait');
+  assert.equal(
+    tableOnlyResolution.resolveTable(true),
+    'open',
+    'table candidates must open the mention menu when knowledge has no candidates',
+  );
+
+  const knowledgeOnlyResolution = new MentionSuggestionResolution(false);
+  assert.equal(knowledgeOnlyResolution.resolveKnowledge(true), 'open');
+
+  const emptyResolution = new MentionSuggestionResolution(true);
+  assert.equal(emptyResolution.resolveTable(false), 'wait');
+  assert.equal(emptyResolution.resolveKnowledge(false), 'close');
+
+  const reverseEmptyResolution = new MentionSuggestionResolution(true);
+  assert.equal(reverseEmptyResolution.resolveKnowledge(false), 'wait');
+  assert.equal(reverseEmptyResolution.resolveTable(false), 'close');
+
+  const delayedKnowledgeResolution = new MentionSuggestionResolution(true);
+  assert.equal(delayedKnowledgeResolution.resolveTable(false), 'wait');
+  assert.equal(delayedKnowledgeResolution.resolveKnowledge(true), 'open');
+
+  const alreadyOpenResolution = new MentionSuggestionResolution(true);
+  assert.equal(alreadyOpenResolution.resolveTable(true), 'open');
+  assert.equal(alreadyOpenResolution.resolveKnowledge(true), 'ignore');
+
+  const contextCoordinator = new MentionTableRequestCoordinator<TestPage>();
+  const contextA = deferred<string>();
+  const contextB = deferred<string>();
+  const contextCommits: string[] = [];
+  const contextAOwner = contextCoordinator.beginRequest(
+    'workspace',
+    { dataSourceId: 1, databaseName: 'db-a', schemaName: 'schema-a' },
+    '',
+  );
+  const contextARequest = commitWhenCurrent(
+    contextCoordinator,
+    contextAOwner,
+    contextA.promise,
+    contextCommits,
+  );
+  const contextBOwner = contextCoordinator.beginRequest(
+    'workspace',
+    { dataSourceId: 2, databaseName: 'db-b', schemaName: 'schema-b' },
+    '',
+  );
+  const contextBRequest = commitWhenCurrent(
+    contextCoordinator,
+    contextBOwner,
+    contextB.promise,
+    contextCommits,
+  );
+  contextB.resolve('context-b');
+  await contextBRequest;
+  contextA.resolve('context-a');
+  await contextARequest;
+
+  const searchCoordinator = new MentionTableRequestCoordinator<TestPage>();
+  const oldSearch = deferred<string>();
+  const newSearch = deferred<string>();
+  const searchCommits: string[] = [];
+  const oldSearchOwner = searchCoordinator.beginRequest('stream', { dataSourceId: 7 }, 'old');
+  const oldSearchRequest = commitWhenCurrent(
+    searchCoordinator,
+    oldSearchOwner,
+    oldSearch.promise,
+    searchCommits,
+  );
+  const newSearchOwner = searchCoordinator.beginRequest('stream', { dataSourceId: 7 }, 'new');
+  const newSearchRequest = commitWhenCurrent(
+    searchCoordinator,
+    newSearchOwner,
+    newSearch.promise,
+    searchCommits,
+  );
+  newSearch.resolve('search-new');
+  await newSearchRequest;
+  oldSearch.resolve('search-old');
+  await oldSearchRequest;
+
+  const errorCoordinator = new MentionTableRequestCoordinator<TestPage>();
+  const staleFailure = deferred<never>();
+  const currentFailure = deferred<never>();
+  const clearedPages: TestPage[] = [];
+  const staleErrorOwner = errorCoordinator.beginRequest('workspace', { dataSourceId: 11 }, 'first');
+  const staleErrorRequest = clearOwnedPageOnError(
+    errorCoordinator,
+    staleErrorOwner,
+    staleFailure.promise,
+    clearedPages,
+  );
+  const currentErrorOwner = errorCoordinator.beginRequest('stream', { dataSourceId: 12 }, 'second');
+  const currentErrorRequest = clearOwnedPageOnError(
+    errorCoordinator,
+    currentErrorOwner,
+    currentFailure.promise,
+    clearedPages,
+  );
+  staleFailure.reject(new Error('stale failure'));
+  await staleErrorRequest;
+  currentFailure.reject(new Error('current failure'));
+  await currentErrorRequest;
+
+  const invalidatedOwner = errorCoordinator.beginRequest('stream', { dataSourceId: 13 }, 'pending');
+  errorCoordinator.invalidate();
+
+  assert.deepEqual(
+    {
+      contextCommits,
+      searchCommits,
+      clearedPages,
+      invalidatedOwnerIsCurrent: errorCoordinator.isCurrent(invalidatedOwner),
+    },
+    {
+      contextCommits: ['context-b'],
+      searchCommits: ['search-new'],
+      clearedPages: ['stream'],
+      invalidatedOwnerIsCurrent: false,
+    },
+  );
+
+  console.log('AI mention table request coordinator tests passed.');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/chat2db-community-client/src/blocks/AI/components/AIChatInput/mentionTableRequestCoordinator.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIChatInput/mentionTableRequestCoordinator.ts
@@ -1,0 +1,97 @@
+export interface MentionTableRequestContext {
+  dataSourceId?: string | number | null;
+  databaseName?: string | null;
+  schemaName?: string | null;
+}
+
+export interface MentionTableRequestOwner<TPage extends string> {
+  generation: number;
+  page: TPage;
+  contextKey: string;
+  searchKey: string;
+}
+
+export type MentionSuggestionDecision = 'wait' | 'open' | 'close' | 'ignore';
+
+export class MentionSuggestionResolution {
+  private tableResolved: boolean;
+
+  private tableHasCandidates = false;
+
+  private knowledgeResolved = false;
+
+  private knowledgeHasCandidates = false;
+
+  private decisionIssued = false;
+
+  constructor(expectTableResult: boolean) {
+    this.tableResolved = !expectTableResult;
+  }
+
+  resolveTable(hasCandidates: boolean): MentionSuggestionDecision {
+    this.tableResolved = true;
+    this.tableHasCandidates = hasCandidates;
+    return this.resolve();
+  }
+
+  resolveKnowledge(hasCandidates: boolean): MentionSuggestionDecision {
+    this.knowledgeResolved = true;
+    this.knowledgeHasCandidates = hasCandidates;
+    return this.resolve();
+  }
+
+  private resolve(): MentionSuggestionDecision {
+    if (this.decisionIssued) {
+      return 'ignore';
+    }
+    if (this.tableHasCandidates || this.knowledgeHasCandidates) {
+      this.decisionIssued = true;
+      return 'open';
+    }
+    if (this.tableResolved && this.knowledgeResolved) {
+      this.decisionIssued = true;
+      return 'close';
+    }
+    return 'wait';
+  }
+}
+
+export class MentionTableRequestCoordinator<TPage extends string> {
+  private generation = 0;
+
+  private currentOwner: MentionTableRequestOwner<TPage> | null = null;
+
+  beginRequest(
+    page: TPage,
+    context: MentionTableRequestContext,
+    searchKey: string,
+  ): MentionTableRequestOwner<TPage> {
+    this.generation += 1;
+    const owner = {
+      generation: this.generation,
+      page,
+      contextKey: JSON.stringify([context.dataSourceId, context.databaseName, context.schemaName]),
+      searchKey,
+    };
+    this.currentOwner = owner;
+    return owner;
+  }
+
+  invalidate(): void {
+    this.generation += 1;
+    this.currentOwner = null;
+  }
+
+  isCurrent(owner: MentionTableRequestOwner<TPage>): boolean {
+    return (
+      this.currentOwner?.generation === owner.generation &&
+      this.currentOwner.page === owner.page &&
+      this.currentOwner.contextKey === owner.contextKey &&
+      this.currentOwner.searchKey === owner.searchKey
+    );
+  }
+
+  getOwnedErrorPage(owner: MentionTableRequestOwner<TPage>): TPage | null {
+    return this.isCurrent(owner) ? owner.page : null;
+  }
+}

--- a/chat2db-community-client/src/blocks/AI/retiredAiSurface.test.ts
+++ b/chat2db-community-client/src/blocks/AI/retiredAiSurface.test.ts
@@ -87,7 +87,13 @@ const knowledgeRequestSource = inputSource.slice(
   inputSource.indexOf('const fetchKnowledgeList'),
   inputSource.indexOf('const handleSend'),
 );
+const mentionTableRequestSource = inputSource.slice(
+  inputSource.indexOf('const fetchTableList'),
+  inputSource.indexOf('const requestKnowledgePage'),
+);
 assert.doesNotMatch(knowledgeRequestSource, /debounce/);
+assert.match(mentionTableRequestSource, /getOwnedErrorPage\(requestOwner\)/);
+assert.doesNotMatch(mentionTableRequestSource, /mainPageActiveTab/);
 assert.match(inputSource, /pageSize: KNOWLEDGE_PAGE_SIZE/);
 assert.match(inputSource, /loadMoreKnowledge/);
 assert.match(mentionSource, /onScrollCapture/);


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

AI table/view mention requests had no context or search ownership. A slower response from an old datasource, page, or search could overwrite the latest list/cache, and an old error used the first-render page closure when clearing context. This change assigns every request a page/context/search generation, checks ownership after each table and view await, and invalidates in-flight work on context, trigger, or lifecycle changes. It also waits for table and knowledge candidate lookups independently, so table-only Community mentions open instead of being closed by an empty knowledge result.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Deferred ownership tests passed for context/search reverse completion, stale errors, and invalidation.
  - Retired-AI and mention-selection contracts: passed and explicitly execute the coordinator test.
  - Targeted ESLint: passed.
  - Full Community prebuild, Umi/Webpack build, and production bundle verifier: passed.
  - Fork code and CodeQL checks: passed.
  - Merge-tree with the AI session repair: passed.
  - Playwright: table-only `@` suggestions opened, `BIG` selection replaced the trigger, and a 2.4s-delayed stale `TREE` response did not replace the newer `BIG` results.
- Manual verification: Passed against an isolated H2 datasource in the Community web UI.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or persisted-state changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: Prevents cross-datasource metadata from appearing in the current mention context.
- Community / Local / Pro boundary: Shared Community AI input.
- Backward compatibility: Latest successful requests retain existing table/view ordering and cache behavior.

## Reviewer map

- Start here: `mentionTableRequestCoordinator.ts`, then `AIChatInput.fetchTableList` and trigger/context effects.
- Failure condition: stale success writes list/cache, stale error clears context, or a request survives invalidation.
- Rollback or disable path: Revert commit `db96285ca9d7bbfd67fafd863469f3f388a09075`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.
