### PR TITLE
fix(clickhouse): filter function detail by name

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/ClickHouseMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/ClickHouseMetaData.java
@@ -126,7 +126,8 @@ public class ClickHouseMetaData extends DefaultMetaService implements IDbMetaDat
     @Override
     public Function function(Connection connection, @NotEmpty String databaseName, String schemaName,
                              String functionName) {
-        return DefaultSQLExecutor.getInstance().execute(connection, FUNCTION_SQL, resultSet -> {
+        return DefaultSQLExecutor.getInstance().preExecute(connection, FUNCTION_DETAIL_SQL,
+                new String[]{functionName}, resultSet -> {
             Function function = new Function();
             function.setDatabaseName(databaseName);
             function.setSchemaName(schemaName);

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/constant/ClickHouseMetaDataConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/constant/ClickHouseMetaDataConstants.java
@@ -38,6 +38,7 @@ public final class ClickHouseMetaDataConstants {
     public static final String SQL_SELECT_NAME_SYSTEM_TABLES_DATABASE = "SELECT name FROM system.tables WHERE database = ?";
     public static final String SQL_SHOW_DATABASES = "SHOW databases";
     public static final String FUNCTION_SQL = "SELECT name,create_query as ddl from system.functions where origin='SQLUserDefined'";
+    public static final String FUNCTION_DETAIL_SQL = FUNCTION_SQL + SQL_NAME;
     public static final String ROUTINES_SQL = "SELECT SPECIFIC_NAME, ROUTINE_COMMENT, ROUTINE_DEFINITION FROM information_schema.routines WHERE "
                     + "routine_type = '%s' AND ROUTINE_SCHEMA ='%s'  AND "
                     + "routine_name = '%s';";

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/test/java/ai/chat2db/plugin/clickhouse/ClickHouseFunctionMetadataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/test/java/ai/chat2db/plugin/clickhouse/ClickHouseFunctionMetadataTest.java
@@ -1,0 +1,81 @@
+package ai.chat2db.plugin.clickhouse;
+
+import ai.chat2db.community.domain.api.model.metadata.Function;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClickHouseFunctionMetadataTest {
+
+    @Test
+    void functionDetailFiltersByRequestedName() {
+        List<String> sql = new ArrayList<>();
+        List<String> parameters = new ArrayList<>();
+
+        Function function = new ClickHouseMetaData().function(
+            connection(sql, parameters), "db", "schema", "wanted");
+
+        assertEquals("wanted ddl", function.getFunctionBody());
+        assertEquals(List.of("wanted"), parameters);
+        assertTrue(sql.get(0).endsWith(" AND name = ?"), sql.get(0));
+    }
+
+    private static Connection connection(List<String> sql, List<String> parameters) {
+        return (Connection) Proxy.newProxyInstance(
+            ClickHouseFunctionMetadataTest.class.getClassLoader(),
+            new Class<?>[]{Connection.class},
+            (proxy, method, args) -> {
+                if (!"prepareStatement".equals(method.getName())) {
+                    throw new AssertionError("Unexpected Connection call: " + method.getName());
+                }
+                sql.add((String) args[0]);
+                return statement(parameters);
+            });
+    }
+
+    private static PreparedStatement statement(List<String> parameters) {
+        return (PreparedStatement) Proxy.newProxyInstance(
+            ClickHouseFunctionMetadataTest.class.getClassLoader(),
+            new Class<?>[]{PreparedStatement.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "setString" -> {
+                    assertEquals(1, args[0]);
+                    parameters.add((String) args[1]);
+                    yield null;
+                }
+                case "execute" -> true;
+                case "getResultSet" -> functionResultSet(parameters.isEmpty() ? null : parameters.get(0));
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected PreparedStatement call: " + method.getName());
+            });
+    }
+
+    private static ResultSet functionResultSet(String requestedName) {
+        String[] definitions = "wanted".equals(requestedName)
+            ? new String[]{"wanted ddl"}
+            : new String[]{"other ddl", "wanted ddl"};
+        int[] row = {-1};
+        return (ResultSet) Proxy.newProxyInstance(
+            ClickHouseFunctionMetadataTest.class.getClassLoader(),
+            new Class<?>[]{ResultSet.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "next" -> ++row[0] < definitions.length;
+                case "getString" -> {
+                    if (!"ddl".equals(args[0])) {
+                        throw new AssertionError("Unexpected ResultSet label: " + args[0]);
+                    }
+                    yield definitions[row[0]];
+                }
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected ResultSet call: " + method.getName());
+            });
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

ClickHouse single-function detail ignored the requested function name, queried every SQL user-defined function, and assigned the first returned DDL to the requested metadata object. This change adds a parameterized name predicate for detail lookups while preserving the existing unfiltered list query.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Red test requested `wanted` and received an unrelated first-row DDL.
  - Focused function metadata test: 1 passed.
  - ClickHouse module tests after rebase: 44 passed.
  - Plugin reactor package: succeeded.
  - Fork code and CodeQL checks: rerunning for the rebased head.
- Manual verification: N/A - strict JDBC proxies capture SQL/parameters and vary rows by the bound function name.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or stored data changes.
- Database or driver compatibility: ClickHouse SQL UDF detail queries only; list queries remain unchanged.
- Network, privacy, or security: Uses a prepared-statement parameter instead of string interpolation.
- Community / Local / Pro boundary: Shared Community ClickHouse plugin.
- Backward compatibility: Requested functions now receive their own DDL rather than arbitrary first-row data.

## Reviewer map

- Start here: `ClickHouseMetaData.function` and `FUNCTION_DETAIL_SQL`.
- Failure condition: detail SQL lacks `name = ?`, binds the wrong name, or changes the list query.
- Rollback or disable path: Revert commit `08a575ec7680a0990be4253f7eef5410a00e2e36`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.