### PR TITLE
fix(storage): roll back failed large mutations

### DIFF
--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/large/LargeDataStorage.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/large/LargeDataStorage.java
@@ -42,6 +42,8 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
 
     private final int limit;
 
+    private final Class<T> clazz;
+
     protected LargeDataStorage(String name, Class<T> clazz, int limit) {
         this(name, clazz, limit, DB_STORAGE_PATH);
     }
@@ -59,6 +61,7 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
         this.storageDir = storageBasePath + File.separator + storageDirectoryName;
         this.filePath = storageDir + File.separator + indexName + ".json";
         this.limit = limit;
+        this.clazz = clazz;
         if (!FileUtil.exist(filePath)) {
             FileUtil.writeUtf8String("", filePath);
         } else {
@@ -103,21 +106,48 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
             return null;
         }
         try {
-            if (limit > 0 && dataMap.size() >= limit) {
-                Map.Entry<Long, T> entry = dataMap.pollFirstEntry();
-                if (entry != null) {
-                    saveDataList();
-                    deleteDetailData(entry.getKey());
-                }
-            }
             Long id = LocalStorageConverter.ensureId(data, this::generateId);
-
+            T previous = dataMap.get(id);
             saveDetailData(id, data);
-            if (!dataMap.containsKey(id)) {
-                FileUtil.appendUtf8String(id + "\n", filePath);
+            if (previous != null) {
+                dataMap.put(id, data);
+                return id;
+            }
+
+            ConcurrentSkipListMap<Long, T> nextDataMap = new ConcurrentSkipListMap<>(dataMap);
+            Map.Entry<Long, T> evicted = null;
+            if (limit > 0 && nextDataMap.size() >= limit) {
+                evicted = nextDataMap.pollFirstEntry();
+            }
+            nextDataMap.put(id, data);
+
+            boolean indexPersisted = false;
+            try {
+                saveDataListOrThrow(nextDataMap);
+                indexPersisted = true;
+                if (evicted != null) {
+                    deleteDetailData(evicted.getKey());
+                }
+            } catch (RuntimeException e) {
+                if (indexPersisted) {
+                    try {
+                        saveDataListOrThrow(dataMap);
+                    } catch (RuntimeException rollbackFailure) {
+                        e.addSuppressed(rollbackFailure);
+                    }
+                }
+                try {
+                    deleteDetailData(id);
+                } catch (RuntimeException cleanupFailure) {
+                    e.addSuppressed(cleanupFailure);
+                }
+                throw e;
+            }
+
+            if (evicted != null) {
+                dataMap.remove(evicted.getKey());
             }
             dataMap.put(id, data);
-
             return id;
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -153,9 +183,9 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
             if (before == null) {
                 return;
             }
-            before = getAfterSave(before, data);
-            dataMap.put(id, before);
-            saveDetailData(id, before);
+            T replacement = getAfterSave(copy(before), data);
+            saveDetailData(id, replacement);
+            dataMap.put(id, replacement);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -166,9 +196,7 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
         if (id == null) {
             return;
         }
-        dataMap.remove(id);
-        saveDataList();
-        deleteDetailData(id);
+        removeDataStrict(id);
     }
 
     protected void deleteDetailData(Long id) {
@@ -176,9 +204,9 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
             return;
         }
         try {
-            FileUtil.del(detailFilePath(id));
-        } catch (Exception e) {
-            log.error("deleteDetailData error", e);
+            Files.deleteIfExists(Path.of(detailFilePath(id)));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to delete detail file: " + detailFilePath(id), e);
         }
     }
 
@@ -191,7 +219,11 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
     }
 
     protected void saveDataListOrThrow() {
-        List<Long> dataList = dataMap.keySet().stream().toList();
+        saveDataListOrThrow(dataMap);
+    }
+
+    protected void saveDataListOrThrow(Map<Long, T> values) {
+        List<Long> dataList = values.keySet().stream().toList();
         String data = CollectionUtils.isNotEmpty(dataList)
                 ? dataList.stream().map(String::valueOf).collect(Collectors.joining("\n")) + "\n"
                 : "";
@@ -228,7 +260,11 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
             saveDataListOrThrow();
         } catch (RuntimeException e) {
             dataMap.remove(id);
-            deleteDetailData(id);
+            try {
+                deleteDetailData(id);
+            } catch (RuntimeException cleanupFailure) {
+                e.addSuppressed(cleanupFailure);
+            }
             throw e;
         }
     }
@@ -243,7 +279,7 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
         }
         try {
             saveDataListOrThrow();
-            Files.deleteIfExists(Path.of(detailFilePath(id)));
+            deleteDetailData(id);
             return removed;
         } catch (Exception e) {
             dataMap.put(id, removed);
@@ -285,5 +321,9 @@ public class LargeDataStorage<T> implements IWorkspaceLocalStorage<T> {
         } finally {
             Files.deleteIfExists(temporary);
         }
+    }
+
+    private T copy(T data) {
+        return JSON.parseObject(JSON.toJSONString(data), clazz);
     }
 }

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/large/LargeDataStorageTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/large/LargeDataStorageTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -15,6 +16,7 @@ import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -86,6 +88,44 @@ class LargeDataStorageTest {
                 throw new RuntimeException(e);
             }
             return super.getAfterSave(before, update);
+        }
+    }
+
+    static class FailingDeleteStorage extends TestStorage {
+        private boolean failIndexWrites;
+        private boolean failCandidateIndexWrites;
+        private boolean candidateDetailExistedAtFailure;
+        private Long failedDetailDeleteId;
+
+        FailingDeleteStorage(String name, int limit, File baseDir) {
+            super(name, limit, baseDir);
+        }
+
+        @Override
+        protected void saveDataListOrThrow() {
+            if (failIndexWrites) {
+                throw new IllegalStateException("simulated index write failure");
+            }
+            super.saveDataListOrThrow();
+        }
+
+        @Override
+        protected void saveDataListOrThrow(Map<Long, Item> values) {
+            if (failCandidateIndexWrites) {
+                candidateDetailExistedAtFailure = values.keySet().stream()
+                        .filter(id -> !dataMap.containsKey(id))
+                        .anyMatch(id -> new File(detailFilePath(id)).isFile());
+                throw new IllegalStateException("simulated candidate index write failure");
+            }
+            super.saveDataListOrThrow(values);
+        }
+
+        @Override
+        protected void deleteDetailData(Long id) {
+            if (id.equals(failedDetailDeleteId)) {
+                throw new IllegalStateException("simulated detail delete failure");
+            }
+            super.deleteDetailData(id);
         }
     }
 
@@ -163,6 +203,127 @@ class LargeDataStorageTest {
         assertNull(storage.getById(1L));
         assertTrue(storage.getDataList().isEmpty());
         assertEquals("", FileUtil.readUtf8String(indexFile()));
+    }
+
+    @Test
+    void failedDetailWriteAtLimitKeepsExistingRecords() {
+        FailingDetailStorage storage = new FailingDetailStorage(name, 2, baseDir);
+        storage.save(item("first", 1L));
+        storage.save(item("second", 2L));
+        storage.failWrites = true;
+
+        assertThrows(RuntimeException.class, () -> storage.save(item("third", 3L)));
+
+        assertEquals(List.of(1L, 2L), storage.getDataList().stream().map(Item::getId).toList());
+        assertTrue(detailFile(1L).isFile());
+        assertTrue(detailFile(2L).isFile());
+        assertFalse(detailFile(3L).exists());
+        assertEquals(List.of("1", "2"), FileUtil.readLines(indexFile(), "UTF-8"));
+        assertEquals(List.of(1L, 2L), new TestStorage(name, 2, baseDir).getDataList().stream()
+                .map(Item::getId).toList());
+    }
+
+    @Test
+    void savingExistingRecordAtLimitDoesNotEvictAnotherRecord() {
+        TestStorage storage = new TestStorage(name, 2, baseDir);
+        storage.save(item("first", 1L));
+        storage.save(item("second", 2L));
+
+        storage.save(item("updated", 2L));
+
+        assertEquals(List.of(1L, 2L), storage.getDataList().stream().map(Item::getId).toList());
+        assertTrue(detailFile(1L).isFile());
+        assertEquals("updated", storage.getById(2L).getValue());
+        TestStorage reloaded = new TestStorage(name, 2, baseDir);
+        assertEquals(List.of(1L, 2L), reloaded.getDataList().stream().map(Item::getId).toList());
+        assertEquals("updated", reloaded.getById(2L).getValue());
+    }
+
+    @Test
+    void failedCandidateIndexWriteCleansNewDetailAndKeepsExistingState() {
+        FailingDeleteStorage storage = new FailingDeleteStorage(name, 10, baseDir);
+        storage.save(item("before", 1L));
+        String originalIndex = FileUtil.readUtf8String(indexFile());
+        String originalDetail = FileUtil.readUtf8String(detailFile(1L));
+        storage.failCandidateIndexWrites = true;
+
+        assertThrows(RuntimeException.class, () -> storage.save(item("new", 2L)));
+
+        assertTrue(storage.candidateDetailExistedAtFailure);
+        assertEquals(List.of(1L), storage.getDataList().stream().map(Item::getId).toList());
+        assertEquals(originalIndex, FileUtil.readUtf8String(indexFile()));
+        assertEquals(originalDetail, FileUtil.readUtf8String(detailFile(1L)));
+        assertFalse(detailFile(2L).exists());
+        TestStorage reloaded = new TestStorage(name, 10, baseDir);
+        assertEquals(List.of(1L), reloaded.getDataList().stream().map(Item::getId).toList());
+        assertEquals("before", reloaded.getById(1L).getValue());
+    }
+
+    @Test
+    void failedEvictionDetailDeleteRestoresExistingRecords() {
+        FailingDeleteStorage storage = new FailingDeleteStorage(name, 2, baseDir);
+        storage.save(item("first", 1L));
+        storage.save(item("second", 2L));
+        storage.failedDetailDeleteId = 1L;
+
+        assertThrows(RuntimeException.class, () -> storage.save(item("third", 3L)));
+
+        assertEquals(List.of(1L, 2L), storage.getDataList().stream().map(Item::getId).toList());
+        assertTrue(detailFile(1L).isFile());
+        assertTrue(detailFile(2L).isFile());
+        assertFalse(detailFile(3L).exists());
+        assertEquals(List.of("1", "2"), FileUtil.readLines(indexFile(), "UTF-8"));
+        assertEquals(List.of(1L, 2L), new TestStorage(name, 2, baseDir).getDataList().stream()
+                .map(Item::getId).toList());
+    }
+
+    @Test
+    void failedUpdateKeepsMemoryDetailAndReloadState() {
+        FailingDetailStorage storage = new FailingDetailStorage(name, 10, baseDir);
+        storage.save(item("before", 1L));
+        String originalDetail = FileUtil.readUtf8String(detailFile(1L));
+        storage.failWrites = true;
+
+        assertThrows(RuntimeException.class, () -> storage.update(item("after", 1L)));
+
+        assertNotNull(storage.getById(1L));
+        assertEquals("before", storage.getById(1L).getValue());
+        assertEquals(originalDetail, FileUtil.readUtf8String(detailFile(1L)));
+        assertEquals("before", new TestStorage(name, 10, baseDir).getById(1L).getValue());
+    }
+
+    @Test
+    void failedDeleteIndexWriteRestoresMemoryDiskAndReloadState() {
+        FailingDeleteStorage storage = new FailingDeleteStorage(name, 10, baseDir);
+        storage.save(item("before", 1L));
+        String originalIndex = FileUtil.readUtf8String(indexFile());
+        String originalDetail = FileUtil.readUtf8String(detailFile(1L));
+        storage.failIndexWrites = true;
+
+        assertThrows(RuntimeException.class, () -> storage.delete(1L));
+
+        assertNotNull(storage.getById(1L));
+        assertEquals("before", storage.getById(1L).getValue());
+        assertEquals(originalIndex, FileUtil.readUtf8String(indexFile()));
+        assertEquals(originalDetail, FileUtil.readUtf8String(detailFile(1L)));
+        assertEquals("before", new TestStorage(name, 10, baseDir).getById(1L).getValue());
+    }
+
+    @Test
+    void failedDeleteDetailRestoresMemoryIndexAndReloadState() {
+        FailingDeleteStorage storage = new FailingDeleteStorage(name, 10, baseDir);
+        storage.save(item("before", 1L));
+        String originalIndex = FileUtil.readUtf8String(indexFile());
+        String originalDetail = FileUtil.readUtf8String(detailFile(1L));
+        storage.failedDetailDeleteId = 1L;
+
+        assertThrows(RuntimeException.class, () -> storage.delete(1L));
+
+        assertNotNull(storage.getById(1L));
+        assertEquals("before", storage.getById(1L).getValue());
+        assertEquals(originalIndex, FileUtil.readUtf8String(indexFile()));
+        assertEquals(originalDetail, FileUtil.readUtf8String(detailFile(1L)));
+        assertEquals("before", new TestStorage(name, 10, baseDir).getById(1L).getValue());
     }
 
     @Test


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Limited `LargeDataStorage` evicted and deleted an old record before proving the replacement detail could be persisted. Updates published mutable state before detail writes, while delete/index/detail failures were logged or left reload state inconsistent. This change stages detail/index mutations, publishes memory only after persistence, and rolls back single-step persistence failures. Delete rollback restores the index independently before attempting detail-file restoration, so a detail restore failure cannot hide the record from reload.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Current-main reproduction: the original large-storage tests reproduce lost evictions, failed-update memory divergence, and swallowed delete failures.
- Focused tests after the fix: `LargeDataStorageTest` 15 passed, including failed detail/index writes, capacity eviction, update/delete rollback, and the detail-restore-failure regression.
- Storage reactor package after the fix: storage 76, tools 77, domain-api 27; 180 tests total, zero failures/errors/skips.
- Command: `mvn -B -ntp -f chat2db-community-server/pom.xml -pl :chat2db-community-storage -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false package`. Test JVM home/temp directories were isolated.
- Executable backend package passed.
- Real macOS locked-detail regression passed: an undeletable detail file caused delete to fail while the index, memory and reload state all retained the record. This verifies the corrected rollback ordering.
- Existing Playwright API/restart reproduction was rerun against the prior head and is retained in the review report; the fix-only change is covered by the real locked-file regression and focused tests. No UI behavior or public API changed.
- New-head CI is triggered by this update; its current result is available in PR checks.

## Risk and compatibility

- Public API or stored data: Existing index/detail formats and method signatures are unchanged.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community large local storage base class.
- Backward compatibility: Successful insert/update/delete ordering is preserved; failures now throw instead of reporting false success.

## Reviewer map

- Start here: `LargeDataStorage.save`, `update`, `removeDataStrict`, then fault-injection tests.
- Failure condition: one persistence failure loses an old record, publishes an unpersisted value, or reloads a different state.
- Rollback or disable path: Revert commits `4d89722ca462b1146f47fc005f283aa8e2198943` and `dce24b4e15c2c842268b0d12a4ec6b9c97987bcf`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.