### PR TITLE
fix(sqlite): preserve view metadata identity

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlite/src/main/java/ai/chat2db/plugin/sqlite/SqliteMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlite/src/main/java/ai/chat2db/plugin/sqlite/SqliteMetaData.java
@@ -39,10 +39,12 @@ public class SqliteMetaData extends DefaultMetaService implements IDbMetaData {
     @Override
     public Table view(Connection connection, String databaseName, String schemaName, String viewName) {
         Table view = new Table();
+        view.setDatabaseName(databaseName);
+        view.setSchemaName(schemaName);
+        view.setName(viewName);
         String sql = String.format(VIEW_DDL_SQL, getSQLIdentifierProcessor().escapeString(viewName));
         DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> {
             if (resultSet.next()) {
-                view.setDatabaseName(databaseName);
                 view.setDdl(resultSet.getString("sql"));
             }
         });

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlite/src/test/java/ai/chat2db/plugin/sqlite/SqliteViewMetadataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlite/src/test/java/ai/chat2db/plugin/sqlite/SqliteViewMetadataTest.java
@@ -1,0 +1,71 @@
+package ai.chat2db.plugin.sqlite;
+
+import ai.chat2db.community.domain.api.model.metadata.Table;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SqliteViewMetadataTest {
+
+    @Test
+    void viewPreservesRequestedIdentityAlongsideDefinition() {
+        Table view = new SqliteMetaData().view(
+            connection("CREATE VIEW v_items AS SELECT * FROM items"), "main", "APP", "v_items");
+
+        assertEquals("main", view.getDatabaseName());
+        assertEquals("APP", view.getSchemaName());
+        assertEquals("v_items", view.getName());
+        assertEquals("CREATE VIEW v_items AS SELECT * FROM items", view.getDdl());
+    }
+
+    private static Connection connection(String definition) {
+        ResultSet resultSet = (ResultSet) Proxy.newProxyInstance(
+            SqliteViewMetadataTest.class.getClassLoader(),
+            new Class<?>[]{ResultSet.class},
+            new java.lang.reflect.InvocationHandler() {
+                private boolean beforeFirst = true;
+
+                @Override
+                public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) {
+                    return switch (method.getName()) {
+                        case "next" -> {
+                            boolean hasRow = beforeFirst;
+                            beforeFirst = false;
+                            yield hasRow;
+                        }
+                        case "getString" -> {
+                            if (!"sql".equals(args[0])) {
+                                throw new AssertionError("Unexpected ResultSet label: " + args[0]);
+                            }
+                            yield definition;
+                        }
+                        case "close" -> null;
+                        default -> throw new AssertionError("Unexpected ResultSet call: " + method.getName());
+                    };
+                }
+            });
+        PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+            SqliteViewMetadataTest.class.getClassLoader(),
+            new Class<?>[]{PreparedStatement.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "execute" -> true;
+                case "getResultSet" -> resultSet;
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected PreparedStatement call: " + method.getName());
+            });
+        return (Connection) Proxy.newProxyInstance(
+            SqliteViewMetadataTest.class.getClassLoader(),
+            new Class<?>[]{Connection.class},
+            (proxy, method, args) -> {
+                if ("prepareStatement".equals(method.getName())) {
+                    return statement;
+                }
+                throw new AssertionError("Unexpected Connection call: " + method.getName());
+            });
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

SQLite view detail metadata populated the DDL but omitted the requested view name and schema. Downstream consumers received an anonymous view even when the definition query succeeded. This change preserves database, schema, and name before querying the definition and leaves the DDL unchanged.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Red test returned null name/schema for a definition row.
  - Focused SQLite view metadata test: 1 passed.
  - SQLite module tests after rebase: 27 passed.
  - Plugin reactor package: succeeded.
  - Fork code and CodeQL checks: rerunning for the rebased head.
- Manual verification: N/A - a strict JDBC proxy verifies requested identity plus unchanged definition.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or stored data changes.
- Database or driver compatibility: SQLite view detail metadata only.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community SQLite plugin.
- Backward compatibility: Existing database/DDL fields remain unchanged; missing identity fields are now populated.

## Reviewer map

- Start here: `SqliteMetaData.view` and `SqliteViewMetadataTest`.
- Failure condition: requested identity is missing or the returned DDL changes.
- Rollback or disable path: Revert commit `722a3f1aff3840964528e88ef9cb93bec133abdc`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.