### PR TITLE
fix(mysql): preserve null auto increment metadata

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/MysqlMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/MysqlMetaData.java
@@ -82,7 +82,10 @@ public class MysqlMetaData extends DefaultMetaService implements IDbMetaData {
                 String collationName = resultSet.getString(FIELD_TABLE_COLLATION);
                 table.setCollate(collationName);
                 table.setComment(resultSet.getString(FIELD_TABLE_COMMENT));
-                table.setIncrementValue(resultSet.getLong(FIELD_AUTO_INCREMENT));
+                long incrementValue = resultSet.getLong(FIELD_AUTO_INCREMENT);
+                if (!resultSet.wasNull()) {
+                    table.setIncrementValue(incrementValue);
+                }
                 if (StringUtils.isNotBlank(collationName)) {
                     table.setCharset(collationMap.get(collationName));
                 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/MysqlTableMetadataNullTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/MysqlTableMetadataNullTest.java
@@ -1,0 +1,114 @@
+package ai.chat2db.plugin.mysql;
+
+import ai.chat2db.community.domain.api.model.metadata.Table;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+
+import static ai.chat2db.plugin.mysql.constant.MysqlMetaDataConstants.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class MysqlTableMetadataNullTest {
+
+    @Test
+    void nullAutoIncrementRemainsNull() {
+        List<Table> tables = new MysqlMetaData().tables(connection(null), "db", null, null);
+
+        assertEquals(1, tables.size());
+        assertNull(tables.get(0).getIncrementValue());
+    }
+
+    @Test
+    void nonNullAutoIncrementIsPreserved() {
+        List<Table> tables = new MysqlMetaData().tables(connection(42L), "db", null, null);
+
+        assertEquals(42L, tables.get(0).getIncrementValue());
+    }
+
+    private static Connection connection(Long autoIncrement) {
+        int[] query = {0};
+        return (Connection) Proxy.newProxyInstance(
+            MysqlTableMetadataNullTest.class.getClassLoader(),
+            new Class<?>[]{Connection.class},
+            (proxy, method, args) -> {
+                if (!"prepareStatement".equals(method.getName())) {
+                    throw new AssertionError("Unexpected Connection call: " + method.getName());
+                }
+                ResultSet resultSet = query[0]++ == 0 ? emptyResultSet() : tableResultSet(autoIncrement);
+                return statement(resultSet);
+            });
+    }
+
+    private static PreparedStatement statement(ResultSet resultSet) {
+        return (PreparedStatement) Proxy.newProxyInstance(
+            MysqlTableMetadataNullTest.class.getClassLoader(),
+            new Class<?>[]{PreparedStatement.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "execute" -> true;
+                case "getResultSet" -> resultSet;
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected PreparedStatement call: " + method.getName());
+            });
+    }
+
+    private static ResultSet emptyResultSet() {
+        return (ResultSet) Proxy.newProxyInstance(
+            MysqlTableMetadataNullTest.class.getClassLoader(),
+            new Class<?>[]{ResultSet.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "next" -> false;
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected collation ResultSet call: " + method.getName());
+            });
+    }
+
+    private static ResultSet tableResultSet(Long autoIncrement) {
+        int[] row = {-1};
+        boolean[] lastWasNull = {false};
+        return (ResultSet) Proxy.newProxyInstance(
+            MysqlTableMetadataNullTest.class.getClassLoader(),
+            new Class<?>[]{ResultSet.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "next" -> ++row[0] == 0;
+                case "getString" -> {
+                    String value = stringValue((String) args[0]);
+                    lastWasNull[0] = value == null;
+                    yield value;
+                }
+                case "getLong" -> {
+                    Long value = longValue((String) args[0], autoIncrement);
+                    lastWasNull[0] = value == null;
+                    yield value == null ? 0L : value;
+                }
+                case "wasNull" -> lastWasNull[0];
+                case "close" -> null;
+                default -> throw new AssertionError("Unexpected table ResultSet call: " + method.getName());
+            });
+    }
+
+    private static String stringValue(String label) {
+        return switch (label) {
+            case FIELD_TABLE_NAME -> "items";
+            case FIELD_ENGINE_UPPER -> "InnoDB";
+            case FIELD_CREATE_TIME -> "2026-08-31 00:00:00";
+            case FIELD_UPDATE_TIME -> null;
+            case FIELD_TABLE_COLLATION -> null;
+            case FIELD_TABLE_COMMENT -> "items table";
+            default -> throw new AssertionError("Unexpected string label: " + label);
+        };
+    }
+
+    private static Long longValue(String label, Long autoIncrement) {
+        return switch (label) {
+            case FIELD_TABLE_ROWS -> 12L;
+            case FIELD_DATA_LENGTH -> 128L;
+            case FIELD_AUTO_INCREMENT -> autoIncrement;
+            default -> throw new AssertionError("Unexpected long label: " + label);
+        };
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

MySQL `INFORMATION_SCHEMA.TABLES.AUTO_INCREMENT` is nullable, but the metadata mapper used `ResultSet.getLong` without `wasNull`. SQL NULL therefore became `0`, and downstream DDL generation could treat a table without an auto-increment counter as `AUTO_INCREMENT=0`. This change preserves null while retaining real increment values.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Red null case returned 0 instead of null; non-null 42 control passed.
  - Focused null/non-null metadata tests: 2 passed.
  - MySQL module tests after rebase: 702 passed.
  - Plugin reactor package: succeeded.
  - Fork code and CodeQL checks: rerunning for the rebased head.
- Manual verification: N/A - a strict ResultSet proxy models JDBC `getLong` / immediate `wasNull` semantics.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or stored data changes.
- Database or driver compatibility: Corrects nullable MySQL table metadata; non-null values are unchanged.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community MySQL plugin.
- Backward compatibility: Tables with an actual auto-increment counter retain the same value.

## Reviewer map

- Start here: `MysqlMetaData.tables` AUTO_INCREMENT mapping and `MysqlTableMetadataNullTest`.
- Failure condition: SQL NULL maps to zero or a real increment value is lost.
- Rollback or disable path: Revert commit `915dc9210d18291b56c907f1e7e7dd36d35ab3db`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, automated tests, verification, and adversarial review.