### PR TITLE
fix(storage): publish ER position after persistence

### DIFF
--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/small/ERPositionStorage.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/small/ERPositionStorage.java
@@ -4,6 +4,7 @@ import ai.chat2db.community.domain.api.model.er.ERPosition;
 import cn.hutool.core.util.ObjectUtil;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ERPositionStorage extends SmallDataStorage<ERPosition> {
@@ -36,17 +37,49 @@ public class ERPositionStorage extends SmallDataStorage<ERPosition> {
         return null;
     }
 
-    public void savePosition(ERPosition param) {
-        List<ERPosition> list = super.getDataList();
-        for (ERPosition p : list) {
-            if (p.getDataSourceId().equals(param.getDataSourceId()) &&
-                    ObjectUtil.equals(p.getDatabaseName(), param.getDatabaseName())
-                    && ObjectUtil.equals(p.getSchemaName(), param.getSchemaName())) {
-                p.setPosition(param.getPosition());
-                update(p);
-                return;
-            }
+    public synchronized void savePosition(ERPosition param) {
+        if (param == null) {
+            return;
         }
-        super.save(param);
+        List<ERPosition> candidateList = new ArrayList<>(dataMap.size() + 1);
+        ERPosition replacement = null;
+        for (ERPosition current : dataMap.values()) {
+            ERPosition candidate = copy(current);
+            if (replacement == null && samePositionKey(current, param)) {
+                candidate.setPosition(param.getPosition());
+                replacement = candidate;
+            }
+            candidateList.add(candidate);
+        }
+        boolean inserted = replacement == null;
+        if (inserted) {
+            replacement = copy(param);
+            if (replacement.getId() == null) {
+                replacement.setId(generateId());
+            }
+            candidateList.add(replacement);
+        }
+
+        saveDataList(candidateList);
+        dataMap.put(replacement.getId(), replacement);
+        if (inserted) {
+            param.setId(replacement.getId());
+        }
+    }
+
+    private boolean samePositionKey(ERPosition current, ERPosition update) {
+        return current.getDataSourceId().equals(update.getDataSourceId())
+                && ObjectUtil.equals(current.getDatabaseName(), update.getDatabaseName())
+                && ObjectUtil.equals(current.getSchemaName(), update.getSchemaName());
+    }
+
+    private ERPosition copy(ERPosition source) {
+        ERPosition copy = new ERPosition();
+        copy.setId(source.getId());
+        copy.setDataSourceId(source.getDataSourceId());
+        copy.setDatabaseName(source.getDatabaseName());
+        copy.setSchemaName(source.getSchemaName());
+        copy.setPosition(source.getPosition());
+        return copy;
     }
 }

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/small/ERPositionStorageTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/small/ERPositionStorageTest.java
@@ -5,9 +5,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Regression test for {@link ERPositionStorage#savePosition}.
@@ -72,5 +79,44 @@ class ERPositionStorageTest {
     void getPositionReturnsNullForMissingKey() throws Exception {
         ERPositionStorage storage = createStorage();
         assertNull(storage.getPosition(99L, "missing", "missing"));
+    }
+
+    @Test
+    void failedPositionReplacementKeepsMemoryFileAndReloadState() throws Exception {
+        File storageFile = storageFile();
+        FailingERPositionStorage storage = new FailingERPositionStorage(storageFile);
+        storage.savePosition(pos(1L, "db1", "schema1", "old"));
+        ERPosition before = storage.getDataList().get(0);
+        String persisted = Files.readString(storageFile.toPath(), StandardCharsets.UTF_8);
+        storage.failWrites = true;
+
+        assertThrows(RuntimeException.class,
+                () -> storage.savePosition(pos(1L, "db1", "schema1", "new")));
+
+        ERPositionStorage reloaded = new ERPositionStorage(storageFile);
+        assertAll(
+                () -> assertSame(before, storage.getDataList().get(0)),
+                () -> assertEquals("old", storage.getPosition(1L, "db1", "schema1")),
+                () -> assertEquals(persisted,
+                        Files.readString(storageFile.toPath(), StandardCharsets.UTF_8)),
+                () -> assertEquals("old", reloaded.getPosition(1L, "db1", "schema1"))
+        );
+    }
+
+    private static final class FailingERPositionStorage extends ERPositionStorage {
+
+        private boolean failWrites;
+
+        private FailingERPositionStorage(File storageFile) {
+            super(storageFile);
+        }
+
+        @Override
+        protected void replaceStorageFile(Path temp, Path target) throws IOException {
+            if (failWrites) {
+                throw new IOException("forced replace failure");
+            }
+            super.replaceStorageFile(temp, target);
+        }
     }
 }


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

`ERPositionStorage.savePosition` modified the live cached object before the base storage write completed. A write failure therefore left memory showing the new position while disk and a reloaded instance retained the old value. This change builds a detached candidate list, persists it first, and publishes only the successful replacement/generated ID.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Reproduced on main: 5 ER tests ran, with one failure showing the new in-memory position after a failed write while disk/reload retained the old value.
- Latest-main integration tests and owning reactor package passed: storage 71, tools 77, domain-api 27; 175 total, zero failures/errors/skips.
- Command: `mvn -B -ntp -f chat2db-community-server/pom.xml -pl :chat2db-community-storage -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false package`. Test JVM home/temp directories were isolated.
- Executable backend package and Playwright CLI verification passed using two isolated SQLite datasources: real mouse drags, consecutive layout updates, refresh, backend restart, reset layout and retry after permission recovery. Browser node coordinates were compared with actual save requests and persisted positions.
- Real storage-directory write denial covered first insertion and replacement: memory and file bytes were unchanged, other datasource layouts were preserved, and refresh restored the persisted layout.
- Zoom, fit-view and Escape did not write positions. The flow auto-saves and has no save-cancellation dialog.
- Both PR files are byte-identical to the Web-tested version; newer main changes are outside the ER persistence path. New-head CI is available in PR checks.
- Existing frontend limitation observed: save failures are not shown to the user, and the optimistic position remains until refresh. The unchanged frontend does not handle the rejected promise; this is recorded separately from the storage fix.

## Risk and compatibility

- Public API or stored data: Existing JSON format and method signatures are unchanged.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community ER layout storage.
- Backward compatibility: Successful inserts/updates preserve existing lookup keys and IDs.

## Reviewer map

- Start here: `ERPositionStorage.savePosition` and its failure regression test.
- Failure condition: a failed write changes memory, caller ID, file bytes, or reload state.
- Rollback or disable path: Revert this PR; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, deterministic tests, verification, and adversarial review.
