### PR TITLE
fix(ai): roll back failed history deletion

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiChatHistoryServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiChatHistoryServiceImpl.java
@@ -192,17 +192,25 @@ public class AiChatHistoryServiceImpl implements IAiChatHistoryService {
         List<AiChatSession> sessions = loadSessions(userId);
         // Only delete the message file when the session was actually owned by
         // this user; otherwise a caller could delete another user's file by id.
-        boolean removed = sessions.removeIf(s -> Objects.equals(s.getId(), sessionId));
-        persistSessions(userId, sessions);
+        List<AiChatSession> remainingSessions = new ArrayList<>(sessions);
+        boolean removed = remainingSessions.removeIf(s -> Objects.equals(s.getId(), sessionId));
         if (!removed) {
             return;
         }
+        persistSessions(userId, remainingSessions);
 
         Path msgFile = messagesPath(sessionId);
         try {
             Files.deleteIfExists(msgFile);
         } catch (IOException e) {
-            throw new BusinessException("ai.chat.history.deleteMessagesFailed", new Object[]{msgFile, e.getMessage()}, e);
+            BusinessException failure = new BusinessException("ai.chat.history.deleteMessagesFailed",
+                    new Object[]{msgFile, e.getMessage()}, e);
+            try {
+                persistSessions(userId, sessions);
+            } catch (RuntimeException rollbackFailure) {
+                failure.addSuppressed(rollbackFailure);
+            }
+            throw failure;
         }
     }
 

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiChatHistoryDeleteRollbackTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiChatHistoryDeleteRollbackTest.java
@@ -1,0 +1,139 @@
+package ai.chat2db.community.domain.core.impl.ai;
+
+import ai.chat2db.community.domain.api.model.ai.AiChatSession;
+import ai.chat2db.community.domain.api.model.request.ai.AiChatMessageAddRequest;
+import ai.chat2db.community.tools.exception.BusinessException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiChatHistoryDeleteRollbackTest {
+
+    private static final long OWNER_ID = 42L;
+    private static final long OTHER_USER_ID = 84L;
+
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void failedMessageDeletionRestoresSessionAndCanBeRetried() throws Exception {
+        AiChatHistoryServiceImpl service = service(new ObjectMapper().findAndRegisterModules());
+        AiChatSession session = sessionWithMessage(service);
+        Path messagePath = messagePath(session);
+        byte[] originalMessages = Files.readAllBytes(messagePath);
+        Path sentinel = replaceMessageFileWithNonEmptyDirectory(messagePath);
+
+        BusinessException failure = assertThrows(BusinessException.class,
+                () -> service.deleteSession(session.getId(), OWNER_ID));
+
+        assertEquals("ai.chat.history.deleteMessagesFailed", failure.getCode());
+        assertEquals(List.of(session.getId()), service.listSessions(OWNER_ID).stream()
+                .map(AiChatSession::getId).toList());
+        assertTrue(Files.exists(sentinel));
+
+        Files.delete(sentinel);
+        Files.delete(messagePath);
+        Files.write(messagePath, originalMessages);
+
+        assertDoesNotThrow(() -> service.deleteSession(session.getId(), OWNER_ID));
+        assertTrue(service.listSessions(OWNER_ID).isEmpty());
+        assertFalse(Files.exists(messagePath));
+    }
+
+    @Test
+    void nonOwnerDoesNotTouchUndeletableMessagePath() throws Exception {
+        AiChatHistoryServiceImpl service = service(new ObjectMapper().findAndRegisterModules());
+        AiChatSession session = sessionWithMessage(service);
+        Path sentinel = replaceMessageFileWithNonEmptyDirectory(messagePath(session));
+
+        assertDoesNotThrow(() -> service.deleteSession(session.getId(), OTHER_USER_ID));
+
+        assertEquals(List.of(session.getId()), service.listSessions(OWNER_ID).stream()
+                .map(AiChatSession::getId).toList());
+        assertTrue(Files.exists(sentinel));
+    }
+
+    @Test
+    void rollbackFailureIsSuppressedOnMessageDeletionFailure() throws Exception {
+        AtomicBoolean failRollback = new AtomicBoolean();
+        AtomicInteger writesAfterFailureArmed = new AtomicInteger();
+        ObjectMapper mapper = rollbackFailingMapper(failRollback, writesAfterFailureArmed);
+        AiChatHistoryServiceImpl service = service(mapper);
+        AiChatSession session = sessionWithMessage(service);
+        replaceMessageFileWithNonEmptyDirectory(messagePath(session));
+        failRollback.set(true);
+
+        BusinessException failure = assertThrows(BusinessException.class,
+                () -> service.deleteSession(session.getId(), OWNER_ID));
+
+        assertEquals("ai.chat.history.deleteMessagesFailed", failure.getCode());
+        assertEquals(1, failure.getSuppressed().length);
+        BusinessException rollbackFailure = assertInstanceOf(BusinessException.class,
+                failure.getSuppressed()[0]);
+        assertEquals("ai.chat.history.persistSessionsFailed", rollbackFailure.getCode());
+    }
+
+    private AiChatHistoryServiceImpl service(ObjectMapper mapper) {
+        return new AiChatHistoryServiceImpl(mapper, tempDirectory);
+    }
+
+    private AiChatSession sessionWithMessage(AiChatHistoryServiceImpl service) {
+        AiChatSession session = service.createSession(OWNER_ID, "rollback session");
+        AiChatMessageAddRequest request = new AiChatMessageAddRequest();
+        request.setSessionId(session.getId());
+        request.setUserId(OWNER_ID);
+        request.setRole("user");
+        request.setContent("keep this message");
+        service.addMessage(request);
+        return session;
+    }
+
+    private Path messagePath(AiChatSession session) {
+        return tempDirectory.resolve(session.getId() + ".json");
+    }
+
+    private Path replaceMessageFileWithNonEmptyDirectory(Path messagePath) throws IOException {
+        Files.delete(messagePath);
+        Files.createDirectory(messagePath);
+        return Files.writeString(messagePath.resolve("sentinel"), "keep");
+    }
+
+    private ObjectMapper rollbackFailingMapper(AtomicBoolean failRollback, AtomicInteger writesAfterFailureArmed) {
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(AiChatHistoryServiceImpl.SessionsFile.class,
+                new JsonSerializer<AiChatHistoryServiceImpl.SessionsFile>() {
+                    @Override
+                    public void serialize(AiChatHistoryServiceImpl.SessionsFile value, JsonGenerator generator,
+                                          SerializerProvider serializers) throws IOException {
+                        if (failRollback.get() && writesAfterFailureArmed.incrementAndGet() == 2) {
+                            throw new IOException("simulated sessions rollback failure");
+                        }
+                        generator.writeStartObject();
+                        generator.writeFieldName("sessions");
+                        serializers.defaultSerializeValue(value.getSessions(), generator);
+                        generator.writeEndObject();
+                    }
+                });
+        mapper.registerModule(module);
+        return mapper;
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

AI history deletion persisted removal from the owner session index before deleting the message file. If message deletion failed, the owner record was lost; a retry then saw no owned session and silently left the orphaned message path forever. This change restores the original session snapshot on deletion failure and preserves rollback failures as suppressed diagnostics.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Current-main reproduction: the 3 rollback tests ran with 2 failures, showing lost session ownership and missing rollback diagnostics. The non-owner case passed.
- After main integration, owning reactor tests and package passed: domain-core 358, SPI 191, tools 77, domain-api 27; 653 total, zero failures/errors/skips.
- Command: `mvn -B -ntp -f chat2db-community-server/pom.xml -pl :chat2db-community-domain-core -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false package`. Test JVM home/temp directories were isolated.
- Executable backend package passed. Playwright CLI tested actual history-menu deletion using isolated seeded conversations: cancel sent zero writes; normal/empty sessions deleted; same-title neighbors remained intact.
- A real macOS message-file lock caused repeated UI deletes to fail with visible feedback. All session/message file bytes were unchanged, and refresh plus backend restart retained the conversation and its messages. After unlocking, keyboard-confirmed retry succeeded; repeated delete was harmless.
- A browser HTTP delete request for a different synthetic owner did not alter files, and that owner's messages remained unreadable. No external model was called.
- The two integrated PR files are byte-identical to the Web-tested version. Current-head CI is available in PR checks.

## Risk and compatibility

- Public API or stored data: Existing history JSON formats are unchanged.
- Database or driver compatibility: N/A.
- Network, privacy, or security: Non-owner deletion remains unable to touch another user’s message path.
- Community / Local / Pro boundary: Shared Community AI history service.
- Backward compatibility: Successful and non-owner deletes retain existing behavior; failed owner deletes become retryable.
- This is compensation for a caught deletion error, not a transaction across the session and message files. Process crashes or a further rollback failure can still leave inconsistent files; rollback failures remain attached to the original exception.

## Reviewer map

- Start here: `AiChatHistoryServiceImpl.deleteSessionLocal` and `AiChatHistoryDeleteRollbackTest`.
- Failure condition: a message-delete failure removes session ownership or hides rollback diagnostics.
- Rollback or disable path: Revert this PR; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, deterministic tests, verification, and adversarial review.
