### PR TITLE
fix(ai): write chat history atomically

### DIFF
--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiChatHistoryServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/ai/AiChatHistoryServiceImpl.java
@@ -17,9 +17,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -47,7 +49,7 @@ public class AiChatHistoryServiceImpl implements IAiChatHistoryService {
 
     AiChatHistoryServiceImpl(ObjectMapper objectMapper, Path baseDir) {
         this.objectMapper = objectMapper;
-        this.baseDir = baseDir;
+        this.baseDir = Objects.requireNonNull(baseDir, "baseDir").toAbsolutePath().normalize();
     }
 
     @Override
@@ -126,6 +128,7 @@ public class AiChatHistoryServiceImpl implements IAiChatHistoryService {
                                                        String reasoningContent,
                                                        List<ChatAttachment> attachments,
                                                        List<AiSelectedKnowledge> selectedKnowledge) {
+        sessionId = canonicalSessionId(sessionId);
         if (!ownsSession(userId, sessionId)) {
             throw new BusinessException("ai.chat.history.sessionNotOwned", new Object[]{sessionId});
         }
@@ -172,6 +175,7 @@ public class AiChatHistoryServiceImpl implements IAiChatHistoryService {
         if (!ownsSession(userId, sessionId)) {
             return new ArrayList<>();
         }
+        sessionId = canonicalSessionId(sessionId);
         return loadMessages(sessionId);
     }
 
@@ -189,6 +193,10 @@ public class AiChatHistoryServiceImpl implements IAiChatHistoryService {
     }
 
     private synchronized void deleteSessionLocal(String sessionId, Long userId) {
+        if (!ownsSession(userId, sessionId)) {
+            return;
+        }
+        canonicalSessionId(sessionId);
         List<AiChatSession> sessions = loadSessions(userId);
         // Only delete the message file when the session was actually owned by
         // this user; otherwise a caller could delete another user's file by id.
@@ -207,11 +215,34 @@ public class AiChatHistoryServiceImpl implements IAiChatHistoryService {
     }
 
     private Path sessionsPath(Long userId) {
-        return baseDir.resolve("sessions-" + userId + ".json");
+        return resolveHistoryFile("sessions-" + userId + ".json");
     }
 
     private Path messagesPath(String sessionId) {
-        return baseDir.resolve(sessionId + ".json");
+        return resolveHistoryFile(canonicalSessionId(sessionId) + ".json");
+    }
+
+    private Path resolveHistoryFile(String fileName) {
+        Path target = baseDir.resolve(fileName).normalize();
+        if (!baseDir.equals(target.getParent())) {
+            throw new IllegalArgumentException("AI chat history file must stay inside its storage directory");
+        }
+        return target;
+    }
+
+    private String canonicalSessionId(String sessionId) {
+        if (StringUtils.isBlank(sessionId)) {
+            throw new BusinessException("ai.chat.history.sessionNotOwned", new Object[]{sessionId});
+        }
+        try {
+            String canonical = UUID.fromString(sessionId).toString();
+            if (!canonical.equals(sessionId)) {
+                throw new IllegalArgumentException("Session id is not canonical");
+            }
+            return canonical;
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException("ai.chat.history.sessionNotOwned", new Object[]{sessionId}, e);
+        }
     }
 
     private List<AiChatSession> loadSessions(Long userId) {
@@ -230,10 +261,9 @@ public class AiChatHistoryServiceImpl implements IAiChatHistoryService {
     private void persistSessions(Long userId, List<AiChatSession> sessions) {
         Path path = sessionsPath(userId);
         try {
-            Files.createDirectories(path.getParent());
             SessionsFile file = new SessionsFile();
             file.setSessions(sessions);
-            objectMapper.writerWithDefaultPrettyPrinter().writeValue(path.toFile(), file);
+            writeAtomically(path, file);
         } catch (IOException e) {
             throw new BusinessException("ai.chat.history.persistSessionsFailed", new Object[]{path, e.getMessage()}, e);
         }
@@ -255,10 +285,9 @@ public class AiChatHistoryServiceImpl implements IAiChatHistoryService {
     private void persistMessages(String sessionId, List<AiChatMessage> messages) {
         Path path = messagesPath(sessionId);
         try {
-            Files.createDirectories(path.getParent());
             MessagesFile file = new MessagesFile();
             file.setMessages(messages);
-            objectMapper.writerWithDefaultPrettyPrinter().writeValue(path.toFile(), file);
+            writeAtomically(path, file);
         } catch (IOException e) {
             throw new BusinessException("ai.chat.history.persistMessagesFailed", new Object[]{path, e.getMessage()}, e);
         }
@@ -271,6 +300,26 @@ public class AiChatHistoryServiceImpl implements IAiChatHistoryService {
                 .findFirst()
                 .ifPresent(s -> s.setGmtModified(LocalDateTime.now()));
         persistSessions(userId, sessions);
+    }
+
+    private void writeAtomically(Path target, Object value) throws IOException {
+        Path absoluteTarget = target.toAbsolutePath().normalize();
+        if (!baseDir.equals(absoluteTarget.getParent())) {
+            throw new IOException("AI chat history target must stay inside its storage directory");
+        }
+        Files.createDirectories(baseDir);
+        Path temporary = Files.createTempFile(baseDir, ".chat-history-", ".tmp");
+        try {
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(temporary.toFile(), value);
+            try {
+                Files.move(temporary, absoluteTarget, StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(temporary, absoluteTarget, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
     }
 
     @Data

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiChatHistoryAtomicWriteTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/ai/AiChatHistoryAtomicWriteTest.java
@@ -1,0 +1,291 @@
+package ai.chat2db.community.domain.core.impl.ai;
+
+import ai.chat2db.community.domain.api.model.ai.AiChatMessage;
+import ai.chat2db.community.domain.api.model.ai.AiChatSession;
+import ai.chat2db.community.domain.api.model.request.ai.AiChatMessageAddRequest;
+import ai.chat2db.community.tools.exception.BusinessException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiChatHistoryAtomicWriteTest {
+
+    private static final long OWNER_ID = 42L;
+
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void failedMessageSerializationKeepsPreviousHistoryReadable() throws Exception {
+        ToggleSerializer<AiChatHistoryServiceImpl.MessagesFile> serializer = new ToggleSerializer<>(
+                "messages", AiChatHistoryServiceImpl.MessagesFile::getMessages);
+        ObjectMapper objectMapper = objectMapper(AiChatHistoryServiceImpl.MessagesFile.class, serializer);
+        AiChatHistoryServiceImpl service = new AiChatHistoryServiceImpl(objectMapper, tempDirectory);
+        AiChatSession session = service.createSession(OWNER_ID, "atomic messages");
+        service.addMessage(addRequest(session.getId(), "before"));
+        Path messagesPath = tempDirectory.resolve(session.getId() + ".json");
+        byte[] original = Files.readAllBytes(messagesPath);
+        serializer.failWrites();
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.addMessage(addRequest(session.getId(), "after")));
+
+        assertEquals("ai.chat.history.persistMessagesFailed", exception.getCode());
+        assertTrue(serializer.failedAfterFlush());
+        assertAll(
+                () -> assertArrayEquals(original, Files.readAllBytes(messagesPath)),
+                () -> assertDoesNotThrow(() -> objectMapper.readTree(messagesPath.toFile())),
+                () -> assertEquals(List.of("before"), service.getMessages(session.getId(), OWNER_ID).stream()
+                        .map(AiChatMessage::getContent).toList()),
+                this::assertNoTemporaryFiles
+        );
+    }
+
+    @Test
+    void failedSessionSerializationKeepsPreviousSessionsReadable() throws Exception {
+        ToggleSerializer<AiChatHistoryServiceImpl.SessionsFile> serializer = new ToggleSerializer<>(
+                "sessions", AiChatHistoryServiceImpl.SessionsFile::getSessions);
+        ObjectMapper objectMapper = objectMapper(AiChatHistoryServiceImpl.SessionsFile.class, serializer);
+        AiChatHistoryServiceImpl service = new AiChatHistoryServiceImpl(objectMapper, tempDirectory);
+        service.createSession(OWNER_ID, "before");
+        Path sessionsPath = tempDirectory.resolve("sessions-" + OWNER_ID + ".json");
+        byte[] original = Files.readAllBytes(sessionsPath);
+        serializer.failWrites();
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.createSession(OWNER_ID, "after"));
+
+        assertEquals("ai.chat.history.persistSessionsFailed", exception.getCode());
+        assertTrue(serializer.failedAfterFlush());
+        assertAll(
+                () -> assertArrayEquals(original, Files.readAllBytes(sessionsPath)),
+                () -> assertDoesNotThrow(() -> objectMapper.readTree(sessionsPath.toFile())),
+                () -> assertEquals(List.of("before"), service.listSessions(OWNER_ID).stream()
+                        .map(AiChatSession::getTitle).toList()),
+                this::assertNoTemporaryFiles
+        );
+    }
+
+    @Test
+    void invalidSessionIdCannotCreateMessageFile() throws Exception {
+        String sessionId = "not-a-uuid";
+        Path historyDirectory = tempDirectory.resolve("invalid-history");
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        writeSessionIndex(objectMapper, historyDirectory, sessionId);
+        AiChatHistoryServiceImpl service = new AiChatHistoryServiceImpl(objectMapper, historyDirectory);
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.addMessage(addRequest(sessionId, "blocked")));
+
+        assertEquals("ai.chat.history.sessionNotOwned", exception.getCode());
+        assertTrue(Files.notExists(historyDirectory.resolve(sessionId + ".json")));
+    }
+
+    @Test
+    void traversalSessionIdCannotEscapeHistoryDirectory() throws Exception {
+        String escapedName = "escaped-" + UUID.randomUUID();
+        String sessionId = "../" + escapedName;
+        Path historyDirectory = tempDirectory.resolve("traversal-history");
+        Path escapedMessage = tempDirectory.resolve(escapedName + ".json");
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        writeSessionIndex(objectMapper, historyDirectory, sessionId);
+        AiChatHistoryServiceImpl service = new AiChatHistoryServiceImpl(objectMapper, historyDirectory);
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.addMessage(addRequest(sessionId, "blocked")));
+
+        assertEquals("ai.chat.history.sessionNotOwned", exception.getCode());
+        assertTrue(Files.notExists(escapedMessage));
+    }
+
+    @Test
+    void unownedInvalidSessionIdKeepsReadAndDeleteAsNoOps() {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        AiChatHistoryServiceImpl service = new AiChatHistoryServiceImpl(objectMapper, tempDirectory);
+
+        assertAll(
+                () -> assertTrue(service.getMessages("not-a-uuid", OWNER_ID).isEmpty()),
+                () -> assertDoesNotThrow(() -> service.deleteSession("../not-owned", OWNER_ID))
+        );
+    }
+
+    @Test
+    void ownedInvalidSessionIdIsRejectedBeforeSessionIndexChanges() throws Exception {
+        String sessionId = "../owned-invalid";
+        Path historyDirectory = tempDirectory.resolve("owned-invalid-history");
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        writeSessionIndex(objectMapper, historyDirectory, sessionId);
+        Path sessionsPath = historyDirectory.resolve("sessions-" + OWNER_ID + ".json");
+        byte[] original = Files.readAllBytes(sessionsPath);
+        AiChatHistoryServiceImpl service = new AiChatHistoryServiceImpl(objectMapper, historyDirectory);
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.deleteSession(sessionId, OWNER_ID));
+
+        assertEquals("ai.chat.history.sessionNotOwned", exception.getCode());
+        assertArrayEquals(original, Files.readAllBytes(sessionsPath));
+        assertEquals(List.of(sessionId), service.listSessions(OWNER_ID).stream().map(AiChatSession::getId).toList());
+    }
+
+    @Test
+    void deleteOwnershipCheckHoldsTheSessionMutationLock() throws Exception {
+        BlockingSessionReadObjectMapper objectMapper = new BlockingSessionReadObjectMapper();
+        AiChatHistoryServiceImpl service = new AiChatHistoryServiceImpl(objectMapper, tempDirectory);
+        AiChatSession original = service.createSession(OWNER_ID, "original");
+        objectMapper.blockNextSessionRead();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<?> deletion = executor.submit(() -> service.deleteSession(original.getId(), OWNER_ID));
+            assertTrue(objectMapper.awaitBlockedSessionRead());
+            Future<AiChatSession> creation = executor.submit(
+                    () -> service.createSession(OWNER_ID, "created while deleting"));
+
+            assertThrows(TimeoutException.class, () -> creation.get(200, TimeUnit.MILLISECONDS));
+
+            objectMapper.releaseSessionRead();
+            deletion.get(5, TimeUnit.SECONDS);
+            AiChatSession created = creation.get(5, TimeUnit.SECONDS);
+            assertEquals(List.of(created.getId()), service.listSessions(OWNER_ID).stream()
+                    .map(AiChatSession::getId).toList());
+        } finally {
+            objectMapper.releaseSessionRead();
+            executor.shutdownNow();
+        }
+    }
+
+    private AiChatMessageAddRequest addRequest(String sessionId, String content) {
+        AiChatMessageAddRequest request = new AiChatMessageAddRequest();
+        request.setSessionId(sessionId);
+        request.setUserId(OWNER_ID);
+        request.setRole("user");
+        request.setContent(content);
+        return request;
+    }
+
+    private void writeSessionIndex(ObjectMapper objectMapper, Path historyDirectory, String sessionId)
+            throws IOException {
+        Files.createDirectories(historyDirectory);
+        AiChatSession session = new AiChatSession();
+        session.setId(sessionId);
+        session.setUserId(OWNER_ID);
+        session.setTitle("malicious session fixture");
+        AiChatHistoryServiceImpl.SessionsFile sessionsFile = new AiChatHistoryServiceImpl.SessionsFile();
+        sessionsFile.setSessions(List.of(session));
+        objectMapper.writeValue(historyDirectory.resolve("sessions-" + OWNER_ID + ".json").toFile(), sessionsFile);
+    }
+
+    private void assertNoTemporaryFiles() throws IOException {
+        try (var files = Files.list(tempDirectory)) {
+            assertTrue(files.noneMatch(path -> path.getFileName().toString().endsWith(".tmp")));
+        }
+    }
+
+    private static <T> ObjectMapper objectMapper(Class<T> type, ToggleSerializer<T> serializer) {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(type, serializer);
+        objectMapper.registerModule(module);
+        return objectMapper;
+    }
+
+    private static final class ToggleSerializer<T> extends JsonSerializer<T> {
+        private final String fieldName;
+        private final Function<T, Object> valueExtractor;
+        private final AtomicBoolean failWrites = new AtomicBoolean();
+        private final AtomicBoolean failedAfterFlush = new AtomicBoolean();
+
+        private ToggleSerializer(String fieldName, Function<T, Object> valueExtractor) {
+            this.fieldName = fieldName;
+            this.valueExtractor = valueExtractor;
+        }
+
+        @Override
+        public void serialize(T value, JsonGenerator generator, SerializerProvider serializers) throws IOException {
+            generator.writeStartObject();
+            generator.writeFieldName(fieldName);
+            if (failWrites.get()) {
+                generator.writeStartArray();
+                generator.writeRaw("\"partial");
+                generator.flush();
+                failedAfterFlush.set(true);
+                throw new IOException("forced serialization failure");
+            }
+            serializers.defaultSerializeValue(valueExtractor.apply(value), generator);
+            generator.writeEndObject();
+        }
+
+        private void failWrites() {
+            failWrites.set(true);
+        }
+
+        private boolean failedAfterFlush() {
+            return failedAfterFlush.get();
+        }
+    }
+
+    private static final class BlockingSessionReadObjectMapper extends ObjectMapper {
+        private final AtomicBoolean blockNextSessionRead = new AtomicBoolean();
+        private final CountDownLatch sessionReadBlocked = new CountDownLatch(1);
+        private final CountDownLatch continueSessionRead = new CountDownLatch(1);
+
+        private BlockingSessionReadObjectMapper() {
+            findAndRegisterModules();
+        }
+
+        @Override
+        public <T> T readValue(File source, Class<T> valueType) throws IOException {
+            if (valueType == AiChatHistoryServiceImpl.SessionsFile.class
+                    && blockNextSessionRead.compareAndSet(true, false)) {
+                sessionReadBlocked.countDown();
+                try {
+                    if (!continueSessionRead.await(5, TimeUnit.SECONDS)) {
+                        throw new IOException("timed out waiting to continue the session read");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("interrupted while waiting to continue the session read", e);
+                }
+            }
+            return super.readValue(source, valueType);
+        }
+
+        private void blockNextSessionRead() {
+            blockNextSessionRead.set(true);
+        }
+
+        private boolean awaitBlockedSessionRead() throws InterruptedException {
+            return sessionReadBlocked.await(5, TimeUnit.SECONDS);
+        }
+
+        private void releaseSessionRead() {
+            continueSessionRead.countDown();
+        }
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

AI session and message histories were written directly to their final JSON files. Jackson truncates a `File` target before serialization, so a mid-write failure destroyed the last valid history and made subsequent reads fail. This change writes to a same-directory temporary file, atomically replaces the target when supported, cleans failed temporary writes, and constrains message paths to canonical UUIDs inside the normalized history directory.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Current-main reproduction: 7 atomic-history tests ran with 5 failures before the fix. Mid-serialization failures truncated the existing session/message JSON to 26 bytes and made it unreadable.
- The final integrated head passed 660 owning-reactor tests and package: domain-core 365, SPI 191, tools 77, domain-api 27; zero failures/errors/skips. This includes the previously merged deletion-rollback tests.
- Command: `mvn -B -ntp -f chat2db-community-server/pom.xml -pl :chat2db-community-domain-core -am -Dmaven.test.skip=false -DskipTests=false '-Dsurefire.includes=**/*Test.java' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false package`. Test JVM home/temp were isolated.
- Playwright CLI verified real chat creation and message appends against a loopback mock model, session rename, refresh, actual file-lock failures for session and message files, temporary-file cleanup, deletion rollback, backend restart and retry. No external model was called.
- Both merged PR files are byte-identical to the Web-tested version. The conflict resolution retains the current attachment-only method signature and the deletion rollback already on main.
- All five required checks passed on the final head, including backend package and JavaScript CodeQL. Non-required Java CodeQL initially failed while downloading Maven dependencies with HTTP 429 and was rerun; its live status is shown in checks.
- Existing limitation observed separately: the stream adapter logs history write failures and still emits an answer/done without notifying the user that the new messages were not saved. This PR protects the previous file contents and does not alter that adapter behavior.

## Risk and compatibility

- Public API or stored data: Existing JSON schemas and paths are unchanged.
- Database or driver compatibility: N/A.
- Network, privacy, or security: Canonical UUID validation and strict parent checks prevent history paths from escaping the configured directory.
- Community / Local / Pro boundary: Shared Community AI history service.
- Backward compatibility: Successful writes preserve pretty JSON; unsupported atomic moves fall back to replacement.

## Reviewer map

- Start here: `AiChatHistoryServiceImpl.writeAtomically` and `AiChatHistoryAtomicWriteTest`.
- Failure condition: a failed serializer changes the final file or leaves a temporary file.
- Rollback or disable path: Revert this PR; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, deterministic tests, verification, and adversarial review.
