### PR TITLE
fix(notification): ignore stale refreshes

### DIFF
--- a/chat2db-community-client/src/components/NotificationNav/index.tsx
+++ b/chat2db-community-client/src/components/NotificationNav/index.tsx
@@ -9,6 +9,7 @@ import { openWebPage } from '@/utils/url';
 import { Empty, EmptyImage, IconButton, IconfontSvg, Modal } from '@chat2db/ui';
 import { RefreshCcw } from 'lucide-react';
 import { useStyles } from './styles';
+import { NotificationRefreshCoordinator } from './notificationRefreshCoordinator';
 
 interface NotificationButtonProps {
   /** Drawer mode is controlled by the parent and does not render an icon button. */
@@ -28,6 +29,7 @@ const NotificationButton = ({ drawerMode, open: externalOpen, onClose }: Notific
   const [popNoSData, setNoSPopData] = useState<NotificationVO | null>(null);
   const [modalSizeWidth, setModalSizeWidth] = useState<number>();
   const mountedRef = useRef(true);
+  const refreshCoordinatorRef = useRef(new NotificationRefreshCoordinator());
 
   useEffect(() => {
     mountedRef.current = true;
@@ -36,6 +38,7 @@ const NotificationButton = ({ drawerMode, open: externalOpen, onClose }: Notific
     queryPopNotification();
     return () => {
       mountedRef.current = false;
+      refreshCoordinatorRef.current.invalidateAll();
     };
   }, []);
 
@@ -58,15 +61,17 @@ const NotificationButton = ({ drawerMode, open: externalOpen, onClose }: Notific
   }, [popSOpen]);
 
   const queryUnreadCount = () => {
+    const owner = refreshCoordinatorRef.current.begin('unread');
     notificationService.queryUnreadCount().then((res) => {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || !refreshCoordinatorRef.current.isCurrent(owner)) return;
       setHasUnread(res > 0);
     });
   };
 
   const queryNotificationList = () => {
+    const owner = refreshCoordinatorRef.current.begin('list');
     notificationService.queryNotificationList({ pageNo: 1, pageSize: 50 }).then((res) => {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || !refreshCoordinatorRef.current.isCurrent(owner)) return;
       setList(res.data);
     });
   };

--- a/chat2db-community-client/src/components/NotificationNav/notificationRefreshCoordinator.test.ts
+++ b/chat2db-community-client/src/components/NotificationNav/notificationRefreshCoordinator.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import {
+  NotificationRefreshCoordinator,
+  type NotificationRefreshChannel,
+} from './notificationRefreshCoordinator';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+async function commitWhenCurrent(
+  coordinator: NotificationRefreshCoordinator,
+  channel: NotificationRefreshChannel,
+  response: Promise<string>,
+  commits: string[],
+) {
+  const owner = coordinator.begin(channel);
+  const value = await response;
+  if (coordinator.isCurrent(owner)) {
+    commits.push(value);
+  }
+}
+
+async function run() {
+  const coordinator = new NotificationRefreshCoordinator();
+  const listCommits: string[] = [];
+  const unreadCommits: string[] = [];
+  const mountList = deferred<string>();
+  const mountUnread = deferred<string>();
+  const refreshList = deferred<string>();
+  const refreshUnread = deferred<string>();
+
+  const mountListRequest = commitWhenCurrent(coordinator, 'list', mountList.promise, listCommits);
+  const mountUnreadRequest = commitWhenCurrent(coordinator, 'unread', mountUnread.promise, unreadCommits);
+  const refreshListRequest = commitWhenCurrent(coordinator, 'list', refreshList.promise, listCommits);
+  const refreshUnreadRequest = commitWhenCurrent(coordinator, 'unread', refreshUnread.promise, unreadCommits);
+
+  refreshList.resolve('refresh-list');
+  refreshUnread.resolve('refresh-unread');
+  await Promise.all([refreshListRequest, refreshUnreadRequest]);
+  mountList.resolve('mount-list');
+  mountUnread.resolve('mount-unread');
+  await Promise.all([mountListRequest, mountUnreadRequest]);
+
+  const activeListOwner = coordinator.begin('list');
+  coordinator.begin('unread');
+  const listSurvivesUnreadRefresh = coordinator.isCurrent(activeListOwner);
+
+  const pendingAtUnmount = coordinator.begin('list');
+  coordinator.invalidateAll();
+  const unmountedOwnerIsCurrent = coordinator.isCurrent(pendingAtUnmount);
+  const remountedOwner = coordinator.begin('list');
+
+  assert.deepEqual(
+    {
+      listCommits,
+      unreadCommits,
+      listSurvivesUnreadRefresh,
+      unmountedOwnerIsCurrent,
+      remountedOwnerIsCurrent: coordinator.isCurrent(remountedOwner),
+    },
+    {
+      listCommits: ['refresh-list'],
+      unreadCommits: ['refresh-unread'],
+      listSurvivesUnreadRefresh: true,
+      unmountedOwnerIsCurrent: false,
+      remountedOwnerIsCurrent: true,
+    },
+  );
+
+  console.log('Notification refresh coordinator tests passed.');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/chat2db-community-client/src/components/NotificationNav/notificationRefreshCoordinator.ts
+++ b/chat2db-community-client/src/components/NotificationNav/notificationRefreshCoordinator.ts
@@ -1,0 +1,27 @@
+export type NotificationRefreshChannel = 'list' | 'unread';
+
+export interface NotificationRefreshOwner {
+  channel: NotificationRefreshChannel;
+  generation: number;
+}
+
+export class NotificationRefreshCoordinator {
+  private generations: Record<NotificationRefreshChannel, number> = {
+    list: 0,
+    unread: 0,
+  };
+
+  begin(channel: NotificationRefreshChannel): NotificationRefreshOwner {
+    this.generations[channel] += 1;
+    return { channel, generation: this.generations[channel] };
+  }
+
+  isCurrent(owner: NotificationRefreshOwner): boolean {
+    return this.generations[owner.channel] === owner.generation;
+  }
+
+  invalidateAll(): void {
+    this.generations.list += 1;
+    this.generations.unread += 1;
+  }
+}

--- a/chat2db-community-client/src/utils/mainPageNavigation.test.ts
+++ b/chat2db-community-client/src/utils/mainPageNavigation.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import '../components/NotificationNav/notificationRefreshCoordinator.test';
 import {
   createMainRootRoute,
   DEFAULT_MAIN_PAGE_ACTIVE_TAB,


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Notification list and unread-count requests only checked whether the component was mounted. A slower mount or mark-read refresh could therefore overwrite a newer manual refresh. This change gives list and unread requests independent generations and invalidates both channels on unmount.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Red tests committed refresh data and then regressed to mount data for both channels.
  - Notification coordinator and main-navigation contracts: passed.
  - Targeted ESLint: passed.
  - Full Community build and production bundle verifier: passed.
  - Fork code and CodeQL checks: passed.
- Manual verification: N/A - independent deferred list/unread promises reproduce reverse completion without a browser.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or persisted-state changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community notification UI.
- Backward compatibility: Latest list/unread responses retain existing rendering and mark-read behavior.

## Reviewer map

- Start here: `NotificationRefreshCoordinator` and guarded query functions in `NotificationNav`.
- Failure condition: an older response commits or an unread-only refresh invalidates the list channel.
- Rollback or disable path: Revert commit `20e91222a810dee8af7be623fab707c2262acc09`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, deterministic tests, verification, and adversarial review.