### PR TITLE
fix(mcp): serialize token resets

### DIFF
--- a/chat2db-community-client/src/blocks/Setting/McpSetting/index.tsx
+++ b/chat2db-community-client/src/blocks/Setting/McpSetting/index.tsx
@@ -9,7 +9,6 @@ import { copyToClipboard } from '@/utils/copy';
 import feedback from '@/utils/feedback';
 import SettingSubsection from '../SettingSubsection';
 import { useStyles } from '../BaseSetting/style';
-import { beginLatestRequest, invalidateLatestRequest, isLatestRequest } from '@/utils/latestRequest';
 import {
   canStartMcpOperation,
   createMcpOperationId,
@@ -19,14 +18,16 @@ import {
   type McpOperation,
 } from './mcpLifecycle';
 import { useMcpStyles } from './style';
+import { McpTokenRequestCoordinator } from './mcpTokenRequestCoordinator';
 
 export default function McpSetting() {
   const { styles } = useStyles();
   const { styles: mcpStyles } = useMcpStyles();
   const [token, setToken] = useState('');
+  const [resetTokenLoading, setResetTokenLoading] = useState(false);
   const [lifecycle, dispatch] = useReducer(reduceMcpLifecycleState, initialMcpLifecycleState);
   const activeOperationIdRef = useRef<string | null>(null);
-  const requestGenerationRef = useRef(0);
+  const tokenRequestCoordinatorRef = useRef(new McpTokenRequestCoordinator());
   const setBaseSetting = useGlobalStore((state) => state.setBaseSetting);
 
   const startOperation = useCallback((operation: McpOperation) => {
@@ -62,10 +63,10 @@ export default function McpSetting() {
   }, []);
 
   useEffect(() => {
-    const requestGeneration = beginLatestRequest(requestGenerationRef);
+    const tokenOwner = tokenRequestCoordinatorRef.current.beginMount();
     const operationId = startOperation('loading');
     if (!operationId) {
-      return () => invalidateLatestRequest(requestGenerationRef);
+      return () => tokenRequestCoordinatorRef.current.invalidate();
     }
     jcefApi.getMcpStatus({ operationId })
       .then(applyStatus)
@@ -74,17 +75,17 @@ export default function McpSetting() {
       });
     jcefApi.getMcpToken()
       .then((t) => {
-        if (isLatestRequest(requestGenerationRef, requestGeneration)) {
+        if (tokenRequestCoordinatorRef.current.isCurrent(tokenOwner)) {
           setToken(t);
         }
       })
       .catch(() => {
-        if (isLatestRequest(requestGenerationRef, requestGeneration)) {
+        if (tokenRequestCoordinatorRef.current.isCurrent(tokenOwner)) {
           feedback.error(i18n('setting.mcp.tokenLoadFailed'));
         }
       });
     return () => {
-      invalidateLatestRequest(requestGenerationRef);
+      tokenRequestCoordinatorRef.current.invalidate();
       if (activeOperationIdRef.current === operationId) {
         activeOperationIdRef.current = null;
       }
@@ -130,11 +131,28 @@ export default function McpSetting() {
     feedback.success(i18n('common.button.copySuccessfully'));
   }
 
-  function resetToken() {
-    jcefApi.resetMcpToken().then((nextToken) => {
+  async function resetToken() {
+    const owner = tokenRequestCoordinatorRef.current.beginReset();
+    if (!owner) {
+      return;
+    }
+    setResetTokenLoading(true);
+    try {
+      const nextToken = await jcefApi.resetMcpToken();
+      if (!tokenRequestCoordinatorRef.current.isCurrent(owner)) {
+        return;
+      }
       setToken(nextToken);
       feedback.success(i18n('setting.text.mcpTokenResetSuccess'));
-    });
+    } catch {
+      if (tokenRequestCoordinatorRef.current.isCurrent(owner)) {
+        feedback.error(i18n('setting.mcp.operationFailed'));
+      }
+    } finally {
+      if (tokenRequestCoordinatorRef.current.finishReset(owner)) {
+        setResetTokenLoading(false);
+      }
+    }
   }
 
   const status = lifecycle.status;
@@ -182,7 +200,11 @@ export default function McpSetting() {
             okText={i18n('common.button.confirm')}
             cancelText={i18n('common.button.cancel')}
           >
-            <Button danger disabled={lifecycle.pendingOperation === 'restarting'}>
+            <Button
+              danger
+              disabled={resetTokenLoading || lifecycle.pendingOperation === 'restarting'}
+              loading={resetTokenLoading}
+            >
               {i18n('setting.button.resetMcpToken')}
             </Button>
           </Popconfirm>

--- a/chat2db-community-client/src/blocks/Setting/McpSetting/mcpLifecycle.test.ts
+++ b/chat2db-community-client/src/blocks/Setting/McpSetting/mcpLifecycle.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import './mcpTokenRequestCoordinator.test';
 import {
   canStartMcpOperation,
   initialMcpLifecycleState,

--- a/chat2db-community-client/src/blocks/Setting/McpSetting/mcpTokenRequestCoordinator.test.ts
+++ b/chat2db-community-client/src/blocks/Setting/McpSetting/mcpTokenRequestCoordinator.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { McpTokenRequestCoordinator } from './mcpTokenRequestCoordinator';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+async function run() {
+  const ownership = new McpTokenRequestCoordinator();
+  const mountToken = deferred<string>();
+  const resetToken = deferred<string>();
+  const committedTokens: string[] = [];
+  const feedbackEvents: string[] = [];
+  const mountOwner = ownership.beginMount();
+  const mountRequest = mountToken.promise.then((token) => {
+    if (ownership.isCurrent(mountOwner)) {
+      committedTokens.push(token);
+    }
+  });
+  const resetOwner = ownership.beginReset()!;
+  const resetRequest = resetToken.promise.then((token) => {
+    if (ownership.isCurrent(resetOwner)) {
+      committedTokens.push(token);
+      feedbackEvents.push('reset-success');
+    }
+    ownership.finishReset(resetOwner);
+  });
+  resetToken.resolve('reset-token');
+  await resetRequest;
+  mountToken.resolve('mount-token');
+  await mountRequest;
+
+  const singleFlight = new McpTokenRequestCoordinator();
+  let resetStarts = 0;
+  const firstReset = singleFlight.beginReset();
+  if (firstReset) resetStarts += 1;
+  if (singleFlight.beginReset()) resetStarts += 1;
+  assert.equal(singleFlight.finishReset(firstReset!), true);
+  if (singleFlight.beginReset()) resetStarts += 1;
+
+  const unmount = new McpTokenRequestCoordinator();
+  const unmountedMount = deferred<string>();
+  const unmountedReset = deferred<string>();
+  const postUnmountTokens: string[] = [];
+  const postUnmountFeedback: string[] = [];
+  const unmountedMountOwner = unmount.beginMount();
+  const unmountedMountRequest = unmountedMount.promise.catch(() => {
+    if (unmount.isCurrent(unmountedMountOwner)) {
+      postUnmountFeedback.push('mount-error');
+    }
+  });
+  const unmountedResetOwner = unmount.beginReset()!;
+  const unmountedResetRequest = unmountedReset.promise.then((token) => {
+    if (unmount.isCurrent(unmountedResetOwner)) {
+      postUnmountTokens.push(token);
+      postUnmountFeedback.push('reset-success');
+    }
+    unmount.finishReset(unmountedResetOwner);
+  });
+  unmount.invalidate();
+  unmountedMount.reject(new Error('load failed'));
+  unmountedReset.resolve('late-reset-token');
+  await Promise.all([unmountedMountRequest, unmountedResetRequest]);
+
+  assert.deepEqual(
+    { committedTokens, feedbackEvents, resetStarts, postUnmountTokens, postUnmountFeedback },
+    {
+      committedTokens: ['reset-token'],
+      feedbackEvents: ['reset-success'],
+      resetStarts: 2,
+      postUnmountTokens: [],
+      postUnmountFeedback: [],
+    },
+  );
+
+  console.log('MCP token request coordinator tests passed.');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/chat2db-community-client/src/blocks/Setting/McpSetting/mcpTokenRequestCoordinator.ts
+++ b/chat2db-community-client/src/blocks/Setting/McpSetting/mcpTokenRequestCoordinator.ts
@@ -1,0 +1,42 @@
+export interface McpTokenRequestOwner {
+  generation: number;
+  kind: 'mount' | 'reset';
+}
+
+export class McpTokenRequestCoordinator {
+  private generation = 0;
+
+  private resetOwner: McpTokenRequestOwner | null = null;
+
+  beginMount(): McpTokenRequestOwner {
+    this.generation += 1;
+    return { generation: this.generation, kind: 'mount' };
+  }
+
+  beginReset(): McpTokenRequestOwner | null {
+    if (this.resetOwner) {
+      return null;
+    }
+    this.generation += 1;
+    const owner: McpTokenRequestOwner = { generation: this.generation, kind: 'reset' };
+    this.resetOwner = owner;
+    return owner;
+  }
+
+  isCurrent(owner: McpTokenRequestOwner): boolean {
+    return this.generation === owner.generation;
+  }
+
+  finishReset(owner: McpTokenRequestOwner): boolean {
+    if (!this.isCurrent(owner) || this.resetOwner?.generation !== owner.generation) {
+      return false;
+    }
+    this.resetOwner = null;
+    return true;
+  }
+
+  invalidate(): void {
+    this.generation += 1;
+    this.resetOwner = null;
+  }
+}

--- a/chat2db-community-client/src/pages/main/navigationItems.test.ts
+++ b/chat2db-community-client/src/pages/main/navigationItems.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import '../../blocks/Setting/McpSetting/mcpLifecycle.test';
 import { readFileSync } from 'node:fs';
 import { Layers, LayoutDashboard, MessageSquarePlus } from 'lucide-react';
 


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Initial MCP token loading and reset responses did not share ownership, and reset was not single-flight. An older mount/reset response could overwrite the newest server token, duplicate resets could generate multiple tokens, and unmounted callbacks still updated state/feedback. This change serializes reset, invalidates mount ownership, exposes reset busy state, and suppresses late callbacks.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Red tests reproduced mount-over-reset overwrite, duplicate resets, and post-unmount callbacks.
  - MCP lifecycle/token tests and main-navigation prebuild entry: passed.
  - Targeted ESLint and full Community build/bundle verifier: passed.
  - Fork code and CodeQL checks: passed.
  - Merge-tree with Notification and SQL parser repairs: passed.
- Manual verification: N/A - deferred bridge promises reproduce token response ordering without real reset operations.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: No API or token format changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: Prevents display/copy of an already superseded MCP token.
- Community / Local / Pro boundary: Shared Community MCP settings.
- Backward compatibility: One reset retains existing bridge behavior; concurrent confirmations now join/ignore while busy.

## Reviewer map

- Start here: `McpTokenRequestCoordinator`, mount token effect, and `resetToken`.
- Failure condition: two resets start concurrently, old mount data wins, or unmounted callbacks commit.
- Rollback or disable path: Revert commit `768fb79d33f80835752639fd363c8dea709a8646`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, deterministic tests, verification, and adversarial review.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head 768fb79d3.
- MCP request-owner, lifecycle, and main-navigation tests passed; targeted ESLint passed.
- Included in the green combined Community production build and bundle verification.