### PR TITLE
fix(storage): publish namespace positions atomically

### DIFF
--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/small/NamespaceStorage.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/small/NamespaceStorage.java
@@ -3,10 +3,14 @@ package ai.chat2db.community.storage.small;
 import ai.chat2db.community.domain.api.enums.NodeTypeEnum;
 import ai.chat2db.community.domain.api.model.workspace.Namespace;
 import ai.chat2db.community.domain.api.model.workspace.Node;
+import com.alibaba.fastjson2.JSON;
 import org.apache.commons.collections4.CollectionUtils;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 public class NamespaceStorage extends SmallDataStorage<Namespace> {
 
@@ -16,21 +20,14 @@ public class NamespaceStorage extends SmallDataStorage<Namespace> {
         super("namespace", Namespace.class);
     }
 
-
-    public void deleteDataSourcePosition(Long dataSourceId) {
-        for (Namespace namespace : getDataList()) {
-            List<Long> dataSourceIds = namespace.getDatasourceIds();
-            if (!CollectionUtils.isEmpty(dataSourceIds)) {
-                if (dataSourceIds.contains(dataSourceId)) {
-                    dataSourceIds.remove(dataSourceId);
-                }
-            }
-        }
-        saveDataList();
+    NamespaceStorage(File storageFile) {
+        super(storageFile, Namespace.class);
     }
 
-    public void updateDataSourcePosition(Long namespaceId, Long dataSourceId) {
-        for (Namespace namespace : getDataList()) {
+
+    public synchronized void deleteDataSourcePosition(Long dataSourceId) {
+        Map<Long, Namespace> candidateDataMap = copyDataMap();
+        for (Namespace namespace : candidateDataMap.values()) {
             List<Long> dataSourceIds = namespace.getDatasourceIds();
             if (!CollectionUtils.isEmpty(dataSourceIds)) {
                 if (dataSourceIds.contains(dataSourceId)) {
@@ -38,7 +35,20 @@ public class NamespaceStorage extends SmallDataStorage<Namespace> {
                 }
             }
         }
-        Namespace namespace = getById(namespaceId);
+        persistPositions(candidateDataMap);
+    }
+
+    public synchronized void updateDataSourcePosition(Long namespaceId, Long dataSourceId) {
+        Map<Long, Namespace> candidateDataMap = copyDataMap();
+        for (Namespace namespace : candidateDataMap.values()) {
+            List<Long> dataSourceIds = namespace.getDatasourceIds();
+            if (!CollectionUtils.isEmpty(dataSourceIds)) {
+                if (dataSourceIds.contains(dataSourceId)) {
+                    dataSourceIds.remove(dataSourceId);
+                }
+            }
+        }
+        Namespace namespace = namespaceId == null ? null : candidateDataMap.get(namespaceId);
         if (namespace != null) {
             List<Long> dataSourceIds = namespace.getDatasourceIds();
             if (CollectionUtils.isEmpty(dataSourceIds)) {
@@ -51,7 +61,19 @@ public class NamespaceStorage extends SmallDataStorage<Namespace> {
                 }
             }
         }
-        saveDataList();
+        persistPositions(candidateDataMap);
+    }
+
+    private Map<Long, Namespace> copyDataMap() {
+        Map<Long, Namespace> candidateDataMap = new ConcurrentSkipListMap<>();
+        dataMap.forEach((id, namespace) -> candidateDataMap.put(id,
+                JSON.parseObject(JSON.toJSONString(namespace), Namespace.class)));
+        return candidateDataMap;
+    }
+
+    private void persistPositions(Map<Long, Namespace> candidateDataMap) {
+        saveDataList(new ArrayList<>(candidateDataMap.values()));
+        dataMap = candidateDataMap;
     }
 
     public Long save(Namespace namespace){

--- a/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/small/SmallDataStorage.java
+++ b/chat2db-community-server/chat2db-community-storage/src/main/java/ai/chat2db/community/storage/small/SmallDataStorage.java
@@ -26,7 +26,7 @@ public class SmallDataStorage<T> implements IWorkspaceLocalStorage<T> {
 
     protected static final String DB_STORAGE_PATH = ConfigUtils.getEnvBasePath() + File.separator + "storage";
 
-    protected Map<Long, T> dataMap = new ConcurrentSkipListMap<>();
+    protected volatile Map<Long, T> dataMap = new ConcurrentSkipListMap<>();
 
     protected String filePath;
 

--- a/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/small/NamespaceStorageAtomicWriteTest.java
+++ b/chat2db-community-server/chat2db-community-storage/src/test/java/ai/chat2db/community/storage/small/NamespaceStorageAtomicWriteTest.java
@@ -1,0 +1,117 @@
+package ai.chat2db.community.storage.small;
+
+import ai.chat2db.community.domain.api.model.workspace.Namespace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class NamespaceStorageAtomicWriteTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void failedPositionUpdateKeepsMemoryFileAndReloadedState() throws Exception {
+        File storageFile = tempDir.resolve("update-namespace.json").toFile();
+        FailingNamespaceStorage storage = new FailingNamespaceStorage(storageFile);
+        storage.save(namespace(1L, 11L));
+        storage.save(namespace(2L, 22L));
+        byte[] originalBytes = Files.readAllBytes(storageFile.toPath());
+        storage.failWrites = true;
+
+        assertThrows(RuntimeException.class, () -> storage.updateDataSourcePosition(2L, 11L));
+
+        assertEquals(List.of(11L), storage.getById(1L).getDatasourceIds());
+        assertEquals(List.of(22L), storage.getById(2L).getDatasourceIds());
+        assertArrayEquals(originalBytes, Files.readAllBytes(storageFile.toPath()));
+        NamespaceStorage reloaded = new NamespaceStorage(storageFile);
+        assertEquals(List.of(11L), reloaded.getById(1L).getDatasourceIds());
+        assertEquals(List.of(22L), reloaded.getById(2L).getDatasourceIds());
+    }
+
+    @Test
+    void failedPositionDeleteKeepsMemoryFileAndReloadedState() throws Exception {
+        File storageFile = tempDir.resolve("delete-namespace.json").toFile();
+        FailingNamespaceStorage storage = new FailingNamespaceStorage(storageFile);
+        storage.save(namespace(1L, 11L, 12L));
+        byte[] originalBytes = Files.readAllBytes(storageFile.toPath());
+        storage.failWrites = true;
+
+        assertThrows(RuntimeException.class, () -> storage.deleteDataSourcePosition(11L));
+
+        assertEquals(List.of(11L, 12L), storage.getById(1L).getDatasourceIds());
+        assertArrayEquals(originalBytes, Files.readAllBytes(storageFile.toPath()));
+        NamespaceStorage reloaded = new NamespaceStorage(storageFile);
+        assertEquals(List.of(11L, 12L), reloaded.getById(1L).getDatasourceIds());
+    }
+
+    @Test
+    void successfulPositionChangesPublishAndReload() {
+        File storageFile = tempDir.resolve("successful-namespace.json").toFile();
+        NamespaceStorage storage = new NamespaceStorage(storageFile);
+        storage.save(namespace(1L, 11L));
+        storage.save(namespace(2L, 22L));
+
+        storage.updateDataSourcePosition(2L, 11L);
+
+        assertEquals(List.of(), storage.getById(1L).getDatasourceIds());
+        assertEquals(List.of(22L, 11L), storage.getById(2L).getDatasourceIds());
+        NamespaceStorage movedReload = new NamespaceStorage(storageFile);
+        assertEquals(List.of(), movedReload.getById(1L).getDatasourceIds());
+        assertEquals(List.of(22L, 11L), movedReload.getById(2L).getDatasourceIds());
+
+        storage.deleteDataSourcePosition(11L);
+
+        assertEquals(List.of(22L), storage.getById(2L).getDatasourceIds());
+        NamespaceStorage deletedReload = new NamespaceStorage(storageFile);
+        assertEquals(List.of(22L), deletedReload.getById(2L).getDatasourceIds());
+    }
+
+    @Test
+    void nullNamespaceMovesDataSourceToRootAndReloads() throws Exception {
+        File storageFile = tempDir.resolve("root-namespace.json").toFile();
+        NamespaceStorage storage = new NamespaceStorage(storageFile);
+        storage.save(namespace(1L, 11L, 12L));
+
+        storage.updateDataSourcePosition(null, 11L);
+
+        assertEquals(List.of(12L), storage.getById(1L).getDatasourceIds());
+        NamespaceStorage reloaded = new NamespaceStorage(storageFile);
+        assertEquals(List.of(12L), reloaded.getById(1L).getDatasourceIds());
+    }
+
+    private Namespace namespace(Long id, Long... datasourceIds) {
+        Namespace namespace = new Namespace();
+        namespace.setId(id);
+        namespace.setName("namespace-" + id);
+        namespace.setDatasourceIds(new ArrayList<>(List.of(datasourceIds)));
+        return namespace;
+    }
+
+    private static class FailingNamespaceStorage extends NamespaceStorage {
+
+        private boolean failWrites;
+
+        private FailingNamespaceStorage(File storageFile) {
+            super(storageFile);
+        }
+
+        @Override
+        protected void replaceStorageFile(Path temp, Path target) throws IOException {
+            if (failWrites) {
+                throw new IOException("simulated persistence failure");
+            }
+            super.replaceStorageFile(temp, target);
+        }
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Namespace datasource-position operations mutated live `datasourceIds` lists before persistence. A write failure left memory moved/deleted while disk and reload state remained old. This change deep-copies the complete namespace map, persists the candidate first, publishes one volatile map reference, and preserves null namespace as move-to-root.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - Red tests reproduced update/delete divergence and a null-target regression during review.
  - Focused namespace atomic tests: 4 passed.
  - Storage reactor: tools 68, domain API 27, storage 61 passed.
  - Storage package and fork code/CodeQL checks: passed.
  - Merge-tree with #2830, #2816, and #2835: passed.
- Manual verification: N/A - temporary-file fault injection verifies memory, bytes, reload, success, and root movement.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: Existing namespace JSON and request semantics are unchanged.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Shared Community namespace storage.
- Backward compatibility: Null target still moves a datasource to root; successful ordering remains append-to-target.

## Reviewer map

- Start here: `NamespaceStorage.copyDataMap/persistPositions` and atomic-write tests.
- Failure condition: a failed write changes live objects, or null target throws instead of moving to root.
- Rollback or disable path: Revert commit `25ada3b790c0649857cb733aa4caa792f4ccb2ef`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, deterministic tests, verification, and adversarial review.

## Latest-main revalidation (2026-09-04)

- Rebased onto upstream 144a04ee2; current head 25ada3b79.
- Full storage module: 61/61 passed.