### PR TITLE
fix(result): search custom-rendered column names

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/components/FESearch/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/FESearch/index.tsx
@@ -17,6 +17,7 @@ import { hexToRgba } from '@/utils/color';
 import { debounce } from 'lodash';
 import { IconButton } from '@chat2db/ui';
 import SearchBar, { type SearchBarRef } from '@/components/SearchBar';
+import { matchResultSearchValue } from './searchMatcher';
 
 interface IProps {
   className?: string;
@@ -56,6 +57,18 @@ const FESearch = forwardRef((props: IProps, ref: ForwardedRef<FESearchRef>) => {
       focuseHighlightCellStyle: {
         bgColor: focuseHighlightCellStyleBgColor,
       } as any,
+      queryMethod: (query, cellValue, context) =>
+        matchResultSearchValue(
+          query,
+          cellValue,
+          context
+            ? {
+                col: context.col,
+                row: context.row,
+                table: context.table as ITableInstance,
+              }
+            : undefined,
+        ),
     });
   }, [tableInstance]);
 

--- a/chat2db-community-client/src/blocks/SearchResult/components/FESearch/searchMatcher.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/FESearch/searchMatcher.ts
@@ -1,0 +1,21 @@
+import type { ITableInstance } from '@/blocks/CanvasTable/typings';
+import { getResultColumnNameAtTableColumn } from '../ResultSetTable/columnState';
+
+export interface ResultSearchQueryContext {
+  col: number;
+  row: number;
+  table: ITableInstance;
+}
+
+export function matchResultSearchValue(
+  query: string,
+  value: unknown,
+  context?: ResultSearchQueryContext,
+): boolean {
+  const headerName =
+    context?.table.isHeader(context.col, context.row) === true
+      ? getResultColumnNameAtTableColumn(context.table, context.col, context.row)
+      : undefined;
+  const searchableValue = headerName ?? value;
+  return searchableValue !== null && searchableValue !== undefined && String(searchableValue).includes(query);
+}

--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts
@@ -33,6 +33,7 @@ import {
   isResultHeaderContext,
   joinContextMenuGroups,
 } from '../ResultSetTable/event/onContextmenuCell/menuGroups';
+import { matchResultSearchValue } from '../FESearch/searchMatcher';
 
 const exportBarSource = readFileSync('src/blocks/SearchResult/components/ExportBar/index.tsx', 'utf8');
 const tabsSource = readFileSync('src/components/Tabs/index.tsx', 'utf8');
@@ -127,6 +128,18 @@ test('result search escape and close action use the same close lifecycle', () =>
   });
 
   assert.deepEqual(calls, ['close']);
+});
+
+test('result search matches custom-rendered field names and regular cell values', () => {
+  const table = {
+    columns: [{ field: '1', originalData: { name: 'record_primary_key' } }],
+    getHeaderField: (col: number) => (col === 1 ? '1' : undefined),
+    isHeader: (_col: number, row: number) => row === 0,
+  } as any;
+
+  assert.equal(matchResultSearchValue('primary', '', { col: 1, row: 0, table }), true);
+  assert.equal(matchResultSearchValue('missing', '', { col: 1, row: 0, table }), false);
+  assert.equal(matchResultSearchValue('customer', 'customer-001', { col: 1, row: 1, table }), true);
 });
 
 test('record field focus updates the cell used by the value inspector', () => {


### PR DESCRIPTION
## Related issue

Closes #2850

## Summary

Restore result-set searches for visible custom-rendered column names. The search matcher resolves header text from the stable column metadata while preserving the existing raw cell-value matching behavior.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - yarn test:result-set-ui: passed, 36 tests
  - focused ESLint for the three changed files: passed with zero warnings
  - yarn run build:web:community --app_version=0.0.0: passed, including the Community prebuild regression suite and production bundle verification
  - Community Maven package: BUILD SUCCESS with tests explicitly skipped for the runtime build
- Manual verification:
  - Executed a MySQL query returning record_primary_key and customer_business_requirement_description.
  - Searching record_primary matched the visible header and reported item 1 of 1.
  - Searching customer-001 matched the cell value and reported item 1 of 1.
- UI evidence: Playwright CLI verified both result counts and captured the highlighted header state locally.

## Risk and compatibility

- Public API or stored data: N/A; no API or persistence changes.
- Database or driver compatibility: N/A; matching uses existing result metadata for every database.
- Network, privacy, or security: N/A; search remains local to the rendered result table.
- Community / Local / Pro boundary: The change stays in the shared result-grid frontend and adds no commercial behavior.
- Backward compatibility: Existing case-sensitive cell-value matching is preserved.

## Reviewer map

- Start here: chat2db-community-client/src/blocks/SearchResult/components/FESearch/searchMatcher.ts
- Failure condition: A visible custom-rendered header is not matched, or ordinary cell-value search stops matching.
- Rollback or disable path: Revert commit 1f9ed56c1 to restore the previous search callback.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.