### PR TITLE
fix(redis): open details on row click

### DIFF
--- a/chat2db-community-client/src/blocks/RedisAllData/index.tsx
+++ b/chat2db-community-client/src/blocks/RedisAllData/index.tsx
@@ -636,6 +636,7 @@ const RedisAllData = (props) => {
           selectedRows={selectedRows}
           onSelectedRowsChange={handleSelectedRowsChange}
           onActivateRow={handleActivateRedisRow}
+          onRowClick={handleActivateRedisRow}
           onEscapeKey={handleCloseEditPane}
           primaryKey={viewMode === 'tree' ? 'key' : undefined}
           treeMode={viewMode === 'tree' ? redisTreeMode : undefined}

--- a/chat2db-community-client/src/blocks/RedisAllData/redisExplorer.test.ts
+++ b/chat2db-community-client/src/blocks/RedisAllData/redisExplorer.test.ts
@@ -13,6 +13,7 @@ assert.match(redisAllDataSource, /clickArea: 'cell'/);
 assert.match(redisAllDataSource, /iconIndent: 0/);
 assert.match(redisAllDataSource, /iconGap: 2/);
 assert.match(redisAllDataSource, /onActivateRow=\{handleActivateRedisRow\}/);
+assert.match(redisAllDataSource, /onRowClick=\{handleActivateRedisRow\}/);
 assert.match(redisAllDataSource, /onEscapeKey=\{handleCloseEditPane\}/);
 assert.match(redisAllDataSource, /\.catch\(\(\) => \{/);
 assert.match(redisAllDataSource, /detailLoadStatus === 'failed'/);

--- a/chat2db-community-client/src/components/BaseTable/index.tsx
+++ b/chat2db-community-client/src/components/BaseTable/index.tsx
@@ -106,6 +106,8 @@ interface IProps {
   showEmptyState?: boolean;
   // Activates a source row from its first cell with Enter or Space.
   onActivateRow?: (index: number, rowData: any) => void;
+  // Handles clicks anywhere inside a selectable source row.
+  onRowClick?: (index: number, rowData: any) => void;
   // Handles Escape while focus is inside the table.
   onEscapeKey?: () => void;
   // Cell-edit callback.
@@ -144,6 +146,7 @@ const BaseTable = forwardRef((props: IProps, ref: ForwardedRef<BaseTableRef>) =>
     getRowIndex,
     showEmptyState = true,
     onActivateRow,
+    onRowClick,
     onEscapeKey,
   } = props;
   const { styles, cx, theme } = useStyles();
@@ -275,6 +278,18 @@ const BaseTable = forwardRef((props: IProps, ref: ForwardedRef<BaseTableRef>) =>
         },
         ...otherColumns,
       ];
+    });
+  }
+  if (onRowClick) {
+    pipeline.appendRowPropsGetter((rowData, rowIndex) => {
+      const sourceRowIndex = getRowIndex ? getRowIndex(rowData, rowIndex) : rowIndex;
+      if (sourceRowIndex === undefined) {
+        return {};
+      }
+      return {
+        onClick: () => onRowClick(sourceRowIndex, rowData),
+        style: { cursor: 'pointer' },
+      };
     });
   }
   pipeline.use(

--- a/chat2db-community-client/src/components/BaseTable/treeInteraction.test.ts
+++ b/chat2db-community-client/src/components/BaseTable/treeInteraction.test.ts
@@ -53,6 +53,8 @@ assert.match(source, /window\.requestAnimationFrame/);
 assert.match(source, /requestTableKeyboardFocus\(currentRowKey, true\)/);
 assert.doesNotMatch(source, /keyboardActions\.indexOf/);
 assert.match(source, /onActivateRow\?\.\(index, rowData\)/);
+assert.match(source, /onRowClick\(sourceRowIndex, rowData\)/);
+assert.match(source, /pipeline\.appendRowPropsGetter/);
 assert.match(source, /event\.key === 'Escape' && onEscapeKey/);
 assert.match(
   source,


### PR DESCRIPTION
## Related issue

N/A - no matching issue was found.

## Summary

Redis key details now load when clicking anywhere on a selectable key row, not only the key-name cell. `BaseTable` exposes an optional row click callback and maps tree leaf rows back to source indices; group rows remain expansion-only.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn install --frozen-lockfile`: passed in the isolated worktree; existing peer-dependency warnings only.
  - `yarn test:base-table-interaction`: passed.
  - `yarn test:redis-explorer`: passed.
  - `yarn run lint`: passed.
  - `yarn run build:web:community --app_version=0.0.0`: passed, including Community prebuild tests, Webpack, and production bundle verification.
- Manual verification: Community Web loaded successfully at `http://127.0.0.1:8889`; backend `/api/system` returned `success:true`. The available browser session did not open a Redis key list, so the exact Redis row click was not claimed as manually verified.
- UI evidence: N/A - no Redis key-list fixture was available in the browser session.

## Risk and compatibility

- Public API or stored data: No API or storage changes.
- Database or driver compatibility: Redis UI selection behavior only; no Redis protocol changes.
- Network, privacy, or security: No change.
- Community / Local / Pro boundary: Community frontend only.
- Backward compatibility: `onRowClick` is optional; existing `BaseTable` consumers retain their behavior.

## Reviewer map

- Start here: `chat2db-community-client/src/components/BaseTable/index.tsx` row-props wiring and `chat2db-community-client/src/blocks/RedisAllData/index.tsx` callback binding.
- Failure condition: a group row maps to a source row or a selectable key row does not load its detail after a non-name-cell click.
- Rollback or disable path: Revert commit `7c1face03`; no migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, deterministic tests, verification, and PR preparation.