### PR TITLE
fix(workspace): align datasource header divider

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/style.ts
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/style.ts
@@ -27,7 +27,7 @@ export const useStyles = createStyles(({ css, token }) => {
       align-items: center;
       justify-content: space-between;
       flex-shrink: 0;
-      height: 42px;
+      height: 36px;
       box-sizing: border-box;
       padding: 0 8px 0 6px;
       border-bottom: 1px solid ${token.colorBorderLayout};


### PR DESCRIPTION
## Related issue

Closes #2852

## Summary

Align the datasource header with the workspace tab bar by using the existing 36px workspace header height on both sides. This removes the 6px divider and toolbar offset without changing the shared tab component or resize behavior.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn install --frozen-lockfile` - passed; existing peer-dependency warnings only.
  - `yarn run lint` - passed.
  - `yarn run build:web:community --app_version=0.0.0` - passed, including all configured prebuild frontend tests and production bundle verification.
  - `git diff --check` - passed.
- Manual verification: Loaded the Community Web workspace with Playwright and measured the rendered DOM. Before the change, the datasource header was 42px high and ended 6px below the 36px workspace tabs. After the change, both headers span `y=35..71`, and both 34px toolbars span `y=71..105`.
- UI evidence: Local Playwright screenshot and DOM geometry confirm the dividers align with no icon clipping or overlap.

## Risk and compatibility

- Public API or stored data: N/A - presentation-only CSS-in-TS change.
- Database or driver compatibility: N/A - no database behavior changed.
- Network, privacy, or security: N/A - no network or data-handling changes.
- Community / Local / Pro boundary: Community workspace styling only; no edition-specific behavior changed.
- Backward compatibility: The datasource header is 6px shorter; its 30px controls retain 3px vertical space on each side.

## Reviewer map

- Start here: `chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeft/style.ts`
- Failure condition: The datasource header divider or the toolbar below it no longer shares the workspace tab and operation-bar coordinates, or header controls clip vertically.
- Rollback or disable path: Revert commit `609e995f8051c242a481fbd9f75d5190ec0d0d60`.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex identified the mismatched fixed heights, applied the one-line alignment change, ran verification, and prepared the Issue and PR records.
