### PR TITLE
fix(hive): expose databases through database metadata

### DIFF
--- a/chat2db-community-client/src/constants/database.ts
+++ b/chat2db-community-client/src/constants/database.ts
@@ -124,8 +124,8 @@ export const databaseMap: {
     name: 'Hive',
     code: DatabaseTypeCode.HIVE,
     icon: 'icon-colourful-HIVE',
-    supportDatabase: false,
-    supportSchema: true,
+    supportDatabase: true,
+    supportSchema: false,
   },
   [DatabaseTypeCode.KINGBASE]: {
     name: 'Kingbase',

--- a/chat2db-community-client/src/utils/databaseJudgments.test.ts
+++ b/chat2db-community-client/src/utils/databaseJudgments.test.ts
@@ -36,6 +36,10 @@ assert.deepEqual(getDatabaseSupport(DatabaseTypeCode.MYSQL), {
   supportDatabase: true,
   supportSchema: false,
 });
+assert.deepEqual(getDatabaseSupport(DatabaseTypeCode.HIVE), {
+  supportDatabase: true,
+  supportSchema: false,
+});
 assert.deepEqual(getDatabaseSupport(DatabaseTypeCode.ORACLE), {
   supportDatabase: false,
   supportSchema: true,

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbDatabaseServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbDatabaseServiceImpl.java
@@ -178,7 +178,8 @@ public class DbDatabaseServiceImpl implements IDbDatabaseService {
         try {
             ulr = connection.getMetaData().getURL();
         } catch (SQLException e) {
-            throw new IllegalStateException("Failed to read JDBC URL while sorting schemas", e);
+            log.debug("JDBC driver does not expose its URL; skip schema ordering", e);
+            return;
         }
         int num = -1;
         for (int i = 0; i < schemas.size(); i++) {

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/DbDatabaseServiceImplTest.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/test/java/ai/chat2db/community/domain/core/impl/db/DbDatabaseServiceImplTest.java
@@ -1,0 +1,89 @@
+package ai.chat2db.community.domain.core.impl.db;
+
+import ai.chat2db.community.domain.api.model.metadata.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DbDatabaseServiceImplTest {
+
+    @Test
+    void unsupportedJdbcUrlDoesNotDiscardSchemas() throws Throwable {
+        List<Schema> schemas = new ArrayList<>();
+        schemas.add(Schema.builder().name("analytics").build());
+        schemas.add(Schema.builder().name("default").build());
+
+        invokeSortSchema(new DbDatabaseServiceImpl(), schemas, connectionWithoutUrl());
+
+        assertEquals(List.of("analytics", "default"), schemas.stream().map(Schema::getName).toList());
+    }
+
+    private static void invokeSortSchema(DbDatabaseServiceImpl service, List<Schema> schemas,
+                                         Connection connection) throws Throwable {
+        Method method = DbDatabaseServiceImpl.class.getDeclaredMethod("sortSchema", List.class, Connection.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(service, schemas, connection);
+        } catch (InvocationTargetException exception) {
+            throw exception.getCause();
+        }
+    }
+
+    private static Connection connectionWithoutUrl() {
+        DatabaseMetaData metaData = proxy(DatabaseMetaData.class, (proxy, method, args) -> {
+            if ("getURL".equals(method.getName())) {
+                throw new SQLException("Method not supported");
+            }
+            return defaultValue(method.getReturnType());
+        });
+        return proxy(Connection.class, (proxy, method, args) -> {
+            if ("getMetaData".equals(method.getName())) {
+                return metaData;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0F;
+        }
+        return 0D;
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/main/java/ai/chat2db/plugin/hive/HiveMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/main/java/ai/chat2db/plugin/hive/HiveMetaData.java
@@ -19,7 +19,6 @@ import ai.chat2db.community.domain.api.model.sql.*;
 import ai.chat2db.spi.model.value.*;
 import ai.chat2db.community.domain.api.model.view.*;
 import ai.chat2db.spi.DefaultSQLExecutor;
-import com.google.common.collect.Lists;
 import jakarta.validation.constraints.NotEmpty;
 import org.apache.commons.lang3.StringUtils;
 
@@ -38,25 +37,28 @@ public class HiveMetaData extends DefaultMetaService implements IDbMetaData {
 
     @Override
     public List<Database> databases(Connection connection) {
-        return Lists.newArrayList();
-    }
-
-    @Override
-    public List<Schema> schemas(Connection connection, String databaseName) {
-        List<Schema> schemas = new ArrayList<>();
-        return DefaultSQLExecutor.getInstance().execute(connection,SQL_SHOW_DATABASES, resultSet -> {
+        List<Database> databases = new ArrayList<>();
+        return DefaultSQLExecutor.getInstance().execute(connection, SQL_SHOW_DATABASES, resultSet -> {
             try {
                 while (resultSet.next()) {
-                    String schenaNane = resultSet.getString("database_name");
-                    Schema schema = new Schema();
-                    schema.setName(schenaNane);
-                    schemas.add(schema);
+                    String databaseName = resultSet.getString("database_name");
+                    if (StringUtils.isBlank(databaseName)) {
+                        continue;
+                    }
+                    Database database = new Database();
+                    database.setName(databaseName);
+                    databases.add(database);
                 }
             } catch (SQLException e) {
                 throw new RuntimeException(e);
             }
-            return schemas;
+            return databases;
         });
+    }
+
+    @Override
+    public List<Schema> schemas(Connection connection, String databaseName) {
+        return Collections.emptyList();
     }
 
     @Override
@@ -81,7 +83,7 @@ public class HiveMetaData extends DefaultMetaService implements IDbMetaData {
 
     @Override
     public String getMetaDataName(String... names) {
-        return Arrays.stream(names).skip(1).filter(name -> StringUtils.isNotBlank(name))
+        return Arrays.stream(names).filter(name -> StringUtils.isNotBlank(name))
                 .map(HiveIdentifierProcessor.INSTANCE::quoteIdentifierAlways)
                 .collect(Collectors.joining("."));
     }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/main/resources/ai/chat2db/plugin/hive/hive.json
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/main/resources/ai/chat2db/plugin/hive/hive.json
@@ -1,7 +1,7 @@
 {
   "dbType": "HIVE",
-  "supportDatabase": false,
-  "supportSchema": true,
+  "supportDatabase": true,
+  "supportSchema": false,
   "driverConfigList": [
     {
       "url": "jdbc:hive2://localhost:10000/",

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/test/java/ai/chat2db/plugin/hive/HiveIdentifierProcessorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/test/java/ai/chat2db/plugin/hive/HiveIdentifierProcessorTest.java
@@ -262,7 +262,7 @@ class HiveIdentifierProcessorTest {
     void metaDataFormatAndNameQuoteIdentifiers() {
         assertEquals("`a``b`", HiveMetaData.format("a`b"));
         assertEquals("`a``; DROP TABLE b; --`", HiveMetaData.format("a`; DROP TABLE b; --"));
-        assertEquals("`db`.`a``b`", new HiveMetaData().getMetaDataName("ignored", "db", "a`b"));
+        assertEquals("`db`.`a``b`", new HiveMetaData().getQualifiedTableName("db", null, "a`b"));
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/test/java/ai/chat2db/plugin/hive/HiveMetaDataTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-hive/src/test/java/ai/chat2db/plugin/hive/HiveMetaDataTest.java
@@ -1,0 +1,109 @@
+package ai.chat2db.plugin.hive;
+
+import ai.chat2db.community.domain.api.config.DBConfig;
+import ai.chat2db.community.domain.api.model.metadata.Database;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HiveMetaDataTest {
+
+    @Test
+    void configExposesHiveNamespacesAsDatabases() {
+        DBConfig config = new HivePlugin().getDBConfig();
+
+        assertTrue(config.isSupportDatabase());
+        assertFalse(config.isSupportSchema());
+    }
+
+    @Test
+    void databasesReadsShowDatabasesResult() {
+        AtomicReference<String> executedSql = new AtomicReference<>();
+        Connection connection = connectionWithDatabaseRows(List.of("analytics", "default"), executedSql);
+
+        List<Database> databases = new HiveMetaData().databases(connection);
+
+        assertEquals("show databases", executedSql.get());
+        assertEquals(List.of("analytics", "default"), databases.stream().map(Database::getName).toList());
+    }
+
+    @Test
+    void schemasAreEmptyBecauseHiveHasNoSeparateSchemaNamespace() {
+        assertTrue(new HiveMetaData().schemas(null, "analytics").isEmpty());
+    }
+
+    @Test
+    void qualifiedTableNameKeepsHiveDatabasePrefix() {
+        HiveMetaData metaData = new HiveMetaData();
+
+        assertEquals("`analytics`.`events`", metaData.getQualifiedTableName("analytics", null, "events"));
+        assertEquals("`events`", metaData.getQualifiedTableName(null, null, "events"));
+    }
+
+    private static Connection connectionWithDatabaseRows(List<String> names, AtomicReference<String> executedSql) {
+        AtomicInteger row = new AtomicInteger(-1);
+        ResultSet resultSet = proxy(ResultSet.class, (proxy, method, args) -> switch (method.getName()) {
+            case "next" -> row.incrementAndGet() < names.size();
+            case "getString" -> names.get(row.get());
+            case "close" -> null;
+            default -> defaultValue(method.getReturnType());
+        });
+        PreparedStatement statement = proxy(PreparedStatement.class, (proxy, method, args) -> switch (method.getName()) {
+            case "execute" -> true;
+            case "getResultSet" -> resultSet;
+            case "close" -> null;
+            default -> defaultValue(method.getReturnType());
+        });
+        return proxy(Connection.class, (proxy, method, args) -> {
+            if ("prepareStatement".equals(method.getName())) {
+                executedSql.set((String) args[0]);
+                return statement;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0F;
+        }
+        return 0D;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Chat2DB.

PR title: type(scope): concise summary
Keep every section below. Use N/A when a section does not apply.
Do not include credentials, private URLs, production data, or generated build output.
-->

## Related issue

N/A (no issue number supplied)

<!-- Link the approved Issue that defines the problem or requirement. -->

## Summary

Expose Hive namespaces as database nodes instead of schema nodes. `SHOW DATABASES` now populates `Database` metadata, Hive schema metadata is empty, and Hive qualified table names preserve the database prefix. JDBC drivers that do not implement `DatabaseMetaData.getURL()` no longer make schema listing fail; ordering is skipped instead.

## Affected surfaces

<!-- Check every surface affected by this PR. -->

- [x] Frontend / Web
- [x] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

<!--
Provide exact commands and their results, plus any manual verification.
For UI changes, attach before/after screenshots or a short recording.
-->

- Commands and results:
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-hive -am -Dmaven.test.skip=false -DskipTests=false -Dtest=HiveMetaDataTest,HiveIdentifierProcessorTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test` -> 30 tests passed.
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-domain-core -am -Dmaven.test.skip=false -DskipTests=false -Dtest=DbDatabaseServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test` -> 1 test passed.
  - Hive module full test reactor with `-Dsurefire.includes=**/*Test.java` -> 36 Hive tests passed; reactor tests passed.
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-hive,:chat2db-community-domain-core -am -Dmaven.test.skip=true package` -> package compilation passed; tests intentionally skipped for this command.
  - `yarn exec tsx src/utils/databaseJudgments.test.ts` -> all assertions passed.
  - `yarn run lint` -> ESLint and Stylelint passed.
  - `yarn run build:web:community --app_version=0.0.0` -> Community regression tests, Webpack build, and production bundle verification passed.
- Manual verification:
  - Connected to the local HiveServer2 test container at `127.0.0.1:10000` with the supplied Hive JDBC driver and no credentials. `SHOW DATABASES` returned `default`.
  - The same driver successfully connected but `DatabaseMetaData.getURL()` returned `java.sql.SQLException: Method not supported`.
  - The built `HiveMetaData.databases()` implementation returned `[default]` over that real JDBC connection.
- UI evidence: N/A

## Risk and compatibility

<!-- Describe only the applicable risks. Use N/A with a short reason for the rest. -->

- Public API or stored data: N/A; response types are unchanged.
- Database or driver compatibility: Hive is now represented by its native database namespace; unsupported optional JDBC URL metadata is non-fatal.
- Network, privacy, or security: N/A; verification used only the local test container and no credentials.
- Community / Local / Pro boundary: Community source only; no Pro or Local code changed.
- Backward compatibility: Existing Hive cached schema entries are bypassed by the new database capability path; direct schema calls return an empty list as Hive has no separate schema namespace.

## Reviewer map

<!-- Point reviewers to the load-bearing change and provide an operational handoff. -->

- Start here: `chat2db-community-plugins/chat2db-community-hive/src/main/java/ai/chat2db/plugin/hive/HiveMetaData.java` and `chat2db-community-plugins/chat2db-community-hive/src/main/resources/ai/chat2db/plugin/hive/hive.json`.
- Failure condition: A driver that throws from optional `DatabaseMetaData.getURL()` must not prevent metadata lists from being returned.
- Rollback or disable path: Revert commit `a3687c63df908bc79533424ca8c4fa301252a452`; no migration or data rollback is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for implementation, tests, and verification.
