### PR TITLE
feat(task): show progress in execution log

### DIFF
--- a/chat2db-community-client/src/blocks/ImportAndExport/components/Log/index.tsx
+++ b/chat2db-community-client/src/blocks/ImportAndExport/components/Log/index.tsx
@@ -11,7 +11,7 @@ import {
 import { useSize } from 'ahooks';
 import VirtualList, { type ListRef } from 'rc-virtual-list';
 import { useStyles } from './style';
-import { Spin } from 'antd';
+import { Progress, Spin } from 'antd';
 import importExportServices from '@/service/importExport';
 import { ImportExportTaskDetails, ImportExportTaskEvent } from '@/typings/importExport';
 import { ACTIVE_TASK_STATUSES, ImportExportTaskStatus } from '@/constants/importExport';
@@ -274,7 +274,18 @@ const Log = (props: IProps) => {
         ]
       : [];
   const visibleEvents = events.length ? events : fallbackErrorEvent;
-
+  const progress =
+    taskDetails.status === ImportExportTaskStatus.SUCCESS
+      ? 100
+      : Math.min(100, Math.max(0, Number(taskDetails.progress) || 0));
+  const progressStatus =
+    taskDetails.status === ImportExportTaskStatus.SUCCESS
+      ? 'success'
+      : taskDetails.status === ImportExportTaskStatus.FAILED
+      ? 'exception'
+      : taskDetails.status === ImportExportTaskStatus.RUNNING
+      ? 'active'
+      : 'normal';
   return (
     <div className={styles.log}>
       {loadingOlder && (
@@ -316,6 +327,20 @@ const Log = (props: IProps) => {
         {!!visibleEvents.length && eventsLoadFailed && (
           <div className={styles.loadFailed}>{i18n('workspace.task.events.loadFailed')}</div>
         )}
+      </div>
+      <div className={styles.progressPanel}>
+        <div className={styles.progressHeader}>
+          <Progress
+            className={styles.progressBar}
+            percent={progress}
+            showInfo={false}
+            size="small"
+            status={progressStatus}
+          />
+          <span className={styles.progressValue} data-status={taskDetails.status}>
+            {progress}%
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/chat2db-community-client/src/blocks/ImportAndExport/components/Log/style.ts
+++ b/chat2db-community-client/src/blocks/ImportAndExport/components/Log/style.ts
@@ -38,6 +38,48 @@ export const useStyles = createStyles(({ css, token }) => {
       font-size: 12px;
       transform: translateX(-50%);
     `,
+    progressPanel: css`
+      flex: none;
+      padding: 8px 16px;
+      border-top: 1px solid ${token.colorBorderSecondary};
+      background: ${token.colorBgElevated};
+    `,
+    progressHeader: css`
+      display: flex;
+      width: 100%;
+      gap: 12px;
+      align-items: center;
+      min-width: 0;
+    `,
+    progressValue: css`
+      flex: none;
+      color: ${token.colorPrimary};
+      font-size: 14px;
+      font-variant-numeric: tabular-nums;
+      font-weight: 600;
+
+      &[data-status='SUCCESS'] {
+        color: ${token.colorSuccess};
+      }
+
+      &[data-status='FAILED'] {
+        color: ${token.colorError};
+      }
+
+      &[data-status='CANCELLED'] {
+        color: ${token.colorTextSecondary};
+      }
+    `,
+    progressBar: css`
+      min-width: 80px;
+      flex: 1;
+      line-height: 1;
+
+      :global(.ant-progress-inner),
+      :global(.ant-progress-bg) {
+        border-radius: 999px;
+      }
+    `,
     eventConsole: css`
       display: flex;
       min-height: 0;


### PR DESCRIPTION
## Related issue

Closes #2856

## Summary

Add the task's existing progress value to the execution log modal as a compact bottom status strip. The strip keeps the log as the primary surface, shows only the progress bar and percentage, clamps progress to 0-100, and uses semantic success/failure colors without duplicating messages already present in the log.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn install --frozen-lockfile` - passed; existing peer-dependency warnings only.
  - `yarn run lint` - passed.
  - `yarn test:task-center` - passed.
  - `yarn run build:web:community --app_version=0.0.0` - passed, including the pre-build regression suite and production-bundle verification.
  - `git diff --check` - passed.
- Manual verification: Verified in Community Web with a large query-result export. The modal updated while running, reached the 100% success state, retained the log viewport, and displayed the final compact progress-only footer requested during review.
- UI evidence: N/A - screenshots were reviewed locally and are not uploaded because they contain local datasource names.

## Risk and compatibility

- Public API or stored data: N/A - consumes existing `progress` and `status` task fields.
- Database or driver compatibility: N/A - no database or driver behavior changes.
- Network, privacy, or security: N/A - no new requests or data exposure.
- Community / Local / Pro boundary: Community frontend only; no commercial product code or runtime-mode changes.
- Backward compatibility: Existing task polling, log pagination, virtual scrolling, and task event rendering are unchanged.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/ImportAndExport/components/Log/index.tsx` for progress/status mapping, then `style.ts` for the compact footer layout.
- Failure condition: The footer does not update with task polling, displays a value outside 0-100, obscures the log, or repeats task status text.
- Rollback or disable path: Revert commit `f15b78e02` to restore the log-only modal.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with source analysis, implementation, review, and verification. The maintainer iterated on and approved the final UI behavior.
