### PR TITLE
fix(frontend): increase editor watermark density

### DIFF
--- a/chat2db-community-client/src/utils/dataSourceWatermark.test.ts
+++ b/chat2db-community-client/src/utils/dataSourceWatermark.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {
+  DENSE_WATERMARK_MIN_HEIGHT,
   getDataSourceWatermarkContent,
   getDataSourceWatermarkLayout,
   LARGE_WATERMARK_MIN_HEIGHT,
@@ -10,6 +11,16 @@ assert.deepEqual(getDataSourceWatermarkLayout(), { itemCount: 1, columns: 1, row
 assert.deepEqual(getDataSourceWatermarkLayout(480, 700), { itemCount: 1, columns: 1, rows: 1 });
 assert.deepEqual(getDataSourceWatermarkLayout(700, 240), { itemCount: 2, columns: 2, rows: 1 });
 assert.deepEqual(getDataSourceWatermarkLayout(LARGE_WATERMARK_MIN_WIDTH, LARGE_WATERMARK_MIN_HEIGHT), {
+  itemCount: 4,
+  columns: 2,
+  rows: 2,
+});
+assert.deepEqual(getDataSourceWatermarkLayout(LARGE_WATERMARK_MIN_WIDTH, DENSE_WATERMARK_MIN_HEIGHT), {
+  itemCount: 9,
+  columns: 3,
+  rows: 3,
+});
+assert.deepEqual(getDataSourceWatermarkLayout(LARGE_WATERMARK_MIN_WIDTH, DENSE_WATERMARK_MIN_HEIGHT - 1), {
   itemCount: 4,
   columns: 2,
   rows: 2,

--- a/chat2db-community-client/src/utils/dataSourceWatermark.ts
+++ b/chat2db-community-client/src/utils/dataSourceWatermark.ts
@@ -8,19 +8,23 @@ export interface DataSourceWatermarkContent {
 }
 
 export interface DataSourceWatermarkLayout {
-  itemCount: 1 | 2 | 4;
-  columns: 1 | 2;
-  rows: 1 | 2;
+  itemCount: 1 | 2 | 4 | 9;
+  columns: 1 | 2 | 3;
+  rows: 1 | 2 | 3;
 }
 
 export const LARGE_WATERMARK_MIN_WIDTH = 720;
 export const LARGE_WATERMARK_MIN_HEIGHT = 360;
+export const DENSE_WATERMARK_MIN_HEIGHT = 480;
 
 export function getDataSourceWatermarkLayout(width?: number, height?: number): DataSourceWatermarkLayout {
   const measuredWidth = width ?? 0;
   const measuredHeight = height ?? 0;
   if (!measuredWidth || !measuredHeight) {
     return { itemCount: 1, columns: 1, rows: 1 };
+  }
+  if (measuredWidth >= LARGE_WATERMARK_MIN_WIDTH && measuredHeight >= DENSE_WATERMARK_MIN_HEIGHT) {
+    return { itemCount: 9, columns: 3, rows: 3 };
   }
   if (measuredWidth >= LARGE_WATERMARK_MIN_WIDTH && measuredHeight >= LARGE_WATERMARK_MIN_HEIGHT) {
     return { itemCount: 4, columns: 2, rows: 2 };


### PR DESCRIPTION
## Related issue

N/A - maintainer-directed UI adjustment.

## Summary

- Increase the SQL editor watermark layout from 2 x 2 to 3 x 3 when the editor is at least 720 x 480.
- Preserve the existing 2 x 2 layout for the 720 x 360 intermediate size and existing behavior for smaller editors.
- Add boundary coverage for the dense layout threshold.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn test:data-source-watermark` - passed.
  - `yarn lint` - passed with zero warnings.
  - `yarn build:web:community --app_version=0.0.0` - passed, including all Community prebuild tests and production bundle verification.
  - `git diff --check` - passed.
- Manual verification: Playwright against Community Web at 1440 x 900 rendered nine watermark items in an 834 x 795 editor viewport, with three equal columns, three equal rows, and no transformed item overlap.
- UI evidence: Verified on the live Community editor; the large editor changed from four sparse marks to a balanced 3 x 3 layout.

## Risk and compatibility

- Public API or stored data: N/A - presentation-only layout selection.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Community frontend only; no Enterprise, Local, or backend behavior changed.
- Backward compatibility: Existing small and intermediate editor layouts are preserved.

## Reviewer map

- Start here: `chat2db-community-client/src/utils/dataSourceWatermark.ts`.
- Failure condition: Large editors render fewer or more than nine marks, or watermark items overlap at the 720 x 480 threshold.
- Rollback or disable path: Revert this commit to restore the previous 2 x 2 maximum layout.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A - maintainer-directed UI adjustment.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex assisted with implementation, tests, review, and verification.
