### PR TITLE
fix(frontend): strengthen datasource identity color backgrounds

### DIFF
--- a/chat2db-community-client/src/blocks/NewTree/dataSourceIdentity.test.ts
+++ b/chat2db-community-client/src/blocks/NewTree/dataSourceIdentity.test.ts
@@ -29,10 +29,10 @@ const decorated = decorateDataSourceIdentityTree([source], [identitySource]);
 assert.match(decorated?.[0].className || '', new RegExp(DATA_SOURCE_IDENTITY_NODE_CLASS));
 assert.match(decorated?.[0].className || '', new RegExp(DATA_SOURCE_IDENTITY_ROOT_CLASS));
 assert.equal(decorated?.[0].style?.['--chat2db-data-source-identity-color'], '#112233');
-assert.equal(decorated?.[0].style?.['--chat2db-data-source-identity-tint'], 'rgba(17, 34, 51, 0.1)');
+assert.equal(decorated?.[0].style?.['--chat2db-data-source-identity-tint'], 'rgba(17, 34, 51, 0.4)');
 assert.match(decorated?.[0].children?.[0].className || '', new RegExp(DATA_SOURCE_IDENTITY_NODE_CLASS));
 assert.equal(decorated?.[0].children?.[0].style?.['--chat2db-data-source-identity-color'], '#112233');
-assert.equal(decorated?.[0].children?.[0].style?.['--chat2db-data-source-identity-tint'], 'rgba(17, 34, 51, 0.06)');
+assert.equal(decorated?.[0].children?.[0].style?.['--chat2db-data-source-identity-tint'], 'rgba(17, 34, 51, 0.2)');
 assert.doesNotMatch(decorated?.[0].children?.[0].className || '', new RegExp(DATA_SOURCE_IDENTITY_ROOT_CLASS));
 assert.equal(source.style, undefined);
 

--- a/chat2db-community-client/src/blocks/NewTree/dataSourceIdentity.ts
+++ b/chat2db-community-client/src/blocks/NewTree/dataSourceIdentity.ts
@@ -84,7 +84,7 @@ export function decorateDataSourceIdentityTree(
     const style: IdentityTreeNodeStyle = {
       ...cleanNode.style,
       '--chat2db-data-source-identity-color': color,
-      '--chat2db-data-source-identity-tint': withIdentityColorAlpha(color, isDataSourceRoot ? 0.1 : 0.06),
+      '--chat2db-data-source-identity-tint': withIdentityColorAlpha(color, isDataSourceRoot ? 0.4 : 0.2),
     };
     const identityClassName = appendClassName(cleanNode.className, DATA_SOURCE_IDENTITY_NODE_CLASS);
     const className = isDataSourceRoot


### PR DESCRIPTION
## Related issue

N/A - direct user feedback; no repository issue was provided.

## Summary

Increase datasource identity background visibility while preserving the existing color picker, storage contract, and interaction styles.

- Raise datasource root tint opacity from 10% to 40%.
- Raise descendant tint opacity from 6% to 20%.
- Update the focused tree-decoration assertions.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - yarn install --frozen-lockfile - passed.
  - yarn test:data-source-identity - passed.
  - yarn run lint - passed with zero warnings.
  - yarn run build:web:community --app_version=0.0.0 - passed, including the complete Community prebuild test suite and production bundle verification.
  - git diff --check - passed.
- Manual verification: Playwright CLI against the Community Web runtime verified the red F5222D datasource in light and dark themes. The final 40% root / 20% descendant values remained readable; a 50% / 30% comparison was rejected because it was too heavy in dark mode. Existing hover and selected theme behavior is unchanged.
- UI evidence: Local Playwright screenshots were reviewed during validation and removed after verification; no generated artifact is committed.

## Risk and compatibility

- Public API or stored data: N/A - rendering-only change; stored identity colors remain six-digit hex values.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Community frontend rendering only; no edition branch or commercial surface changed.
- Backward compatibility: Existing saved colors continue to render without migration; only tint strength changes.

## Reviewer map

- Start here: chat2db-community-client/src/blocks/NewTree/dataSourceIdentity.ts
- Failure condition: datasource identity backgrounds remain too faint or become too saturated in either theme.
- Rollback or disable path: revert this commit to restore the previous 10% / 6% opacity values.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A - direct user feedback.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex traced the identity-color rendering path, adjusted the opacity values and test expectations, ran lint/tests/build checks, and performed Playwright CLI visual comparison.