### PR TITLE
fix(i18n): localize dynamic datasource forms

### DIFF
--- a/chat2db-community-client/src/components/ConnectionEdit/index.tsx
+++ b/chat2db-community-client/src/components/ConnectionEdit/index.tsx
@@ -35,6 +35,14 @@ const OSCAR_JDBC_URL_PREFIX = 'jdbc:oscar://';
 const OSCAR_DRIVER_CLASS = 'com.oscar.Driver';
 
 const connectionFormTranslations: Partial<Record<LangType, Record<string, string>>> = {
+  [LangType.ZH_CN]: {
+    'User&Password': '用户名和密码',
+    NONE: '无',
+  },
+  [LangType.JA_JP]: {
+    'User&Password': 'ユーザー名とパスワード',
+    NONE: 'なし',
+  },
   [LangType.ES_ES]: {
     'USE SSH': 'Usar SSH',
     'SSH Hostname': 'Host SSH',
@@ -67,6 +75,7 @@ const connectionFormTranslations: Partial<Record<LangType, Record<string, string
     Datatset: 'Conjunto de datos',
     'Google Service Account': 'Cuenta de servicio de Google',
     'User&Password': 'Usuario y contraseña',
+    NONE: 'Ninguno',
     LocalFile: 'Archivo local',
     Service: 'Servicio',
   },
@@ -102,6 +111,7 @@ const connectionFormTranslations: Partial<Record<LangType, Record<string, string
     Datatset: '데이터 세트',
     'Google Service Account': 'Google 서비스 계정',
     'User&Password': '사용자 및 비밀번호',
+    NONE: '없음',
     LocalFile: '로컬 파일',
     Service: '서비스',
   },

--- a/chat2db-community-client/src/utils/dynamicDatabaseRegistry.test.ts
+++ b/chat2db-community-client/src/utils/dynamicDatabaseRegistry.test.ts
@@ -67,6 +67,11 @@ const freshRegistries = () => ({
   assert.equal(byName('port').defaultValue, '8812');
   assert.equal(byName('host').defaultValue, 'localhost');
   assert.equal(byName('database').defaultValue, 'qdb');
+  assert.equal(byName('alias').labelName['zh-CN'], '名称');
+  assert.equal(byName('host').labelName['zh-CN'], '主机');
+  assert.equal(byName('authenticationType').labelName['zh-CN'], '身份验证');
+  assert.equal(byName('database').labelName['zh-CN'], '数据库');
+  assert.equal(byName('url').labelName['zh-CN'], 'URL');
   assert.equal(config.baseInfo.template, 'jdbc:postgresql://{host}:{port}/{database}');
   const match = 'jdbc:postgresql://myhost:5555/mydb'.match(config.baseInfo.pattern);
   assert.equal(match?.[1], 'myhost');

--- a/chat2db-community-client/src/utils/dynamicDatabaseRegistry.ts
+++ b/chat2db-community-client/src/utils/dynamicDatabaseRegistry.ts
@@ -1,5 +1,9 @@
 import { AuthenticationType, InputType } from '@/components/ConnectionEdit/config/enum';
-import type { IConnectionConfig, IFormItem } from '@/components/ConnectionEdit/config/types';
+import type {
+  IConnectionConfig,
+  IFormItem,
+  ILocalizedConnectionText,
+} from '@/components/ConnectionEdit/config/types';
 import type { ISupportedDatabaseSummary } from '@/service/supportedDatabase';
 import type { IDatabase } from '@/typings';
 
@@ -15,8 +19,73 @@ import type { IDatabase } from '@/typings';
 /** Fallback glyph from the shared colourful sprite; has a -dark variant. */
 export const DYNAMIC_DATABASE_ICON = 'icon-colourful-table';
 
-const localized = (text: string) =>
-  ({ 'en-US': text, 'zh-CN': text, 'ja-JP': text, 'es-ES': text, 'ko-KR': text }) as any;
+const CONNECTION_FORM_LABELS: Record<string, ILocalizedConnectionText> = {
+  Name: {
+    'en-US': 'Name',
+    'zh-CN': '名称',
+    'ja-JP': '名前',
+    'es-ES': 'Nombre',
+    'ko-KR': '이름',
+  },
+  Host: {
+    'en-US': 'Host',
+    'zh-CN': '主机',
+    'ja-JP': 'ホスト',
+    'es-ES': 'Host',
+    'ko-KR': '호스트',
+  },
+  Authentication: {
+    'en-US': 'Authentication',
+    'zh-CN': '身份验证',
+    'ja-JP': '認証',
+    'es-ES': 'Autenticación',
+    'ko-KR': '인증',
+  },
+  User: {
+    'en-US': 'User',
+    'zh-CN': '用户名',
+    'ja-JP': 'ユーザー名',
+    'es-ES': 'Usuario',
+    'ko-KR': '사용자',
+  },
+  Password: {
+    'en-US': 'Password',
+    'zh-CN': '密码',
+    'ja-JP': 'パスワード',
+    'es-ES': 'Contraseña',
+    'ko-KR': '비밀번호',
+  },
+  Database: {
+    'en-US': 'Database',
+    'zh-CN': '数据库',
+    'ja-JP': 'データベース',
+    'es-ES': 'Base de datos',
+    'ko-KR': '데이터베이스',
+  },
+  URL: {
+    'en-US': 'URL',
+    'zh-CN': 'URL',
+    'ja-JP': 'URL',
+    'es-ES': 'URL',
+    'ko-KR': 'URL',
+  },
+  File: {
+    'en-US': 'File',
+    'zh-CN': '文件',
+    'ja-JP': 'ファイル',
+    'es-ES': 'Archivo',
+    'ko-KR': '파일',
+  },
+};
+
+const localized = (text: string): ILocalizedConnectionText =>
+  CONNECTION_FORM_LABELS[text] || {
+    'en-US': text,
+    'zh-CN': text,
+    'ja-JP': text,
+    'es-ES': text,
+    'ko-KR': text,
+  };
 
 export interface SharedFormItems {
   envItem: IFormItem;


### PR DESCRIPTION
## Related issue

N/A - user-reported mixed-language labels in dynamic datasource connection forms.

## Summary

Dynamic datasource forms no longer copy English labels into every locale. Common connection fields now provide localized values for English, Chinese, Japanese, Spanish, and Korean, and authentication option labels are localized for the supported non-English locales.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn install --frozen-lockfile` - passed in the isolated Community worktree.
  - `yarn test:dynamic-database-registry` - passed.
  - `yarn test:i18n` - passed.
  - `yarn eslint src/utils/dynamicDatabaseRegistry.ts src/utils/dynamicDatabaseRegistry.test.ts src/components/ConnectionEdit/index.tsx --max-warnings=0` - passed.
- Manual verification:
  - Confirmed the generated dynamic form maps Name, Host, Authentication, User, Password, Database, URL, and File to locale-specific labels.
- UI evidence: N/A - local test dist was generated separately and is not included in the PR.

## Risk and compatibility

- Public API or stored data: N/A - frontend labels only.
- Database or driver compatibility: N/A - connection values and request contracts are unchanged.
- Network, privacy, or security: N/A - no network or credential behavior changed.
- Community / Local / Pro boundary: Shared Community connection editor; Studio consumes this source through its existing Community source lock.
- Backward compatibility: Unknown custom labels keep their original text as the explicit fallback.

## Reviewer map

- Start here: `chat2db-community-client/src/utils/dynamicDatabaseRegistry.ts` and `src/components/ConnectionEdit/index.tsx`.
- Failure condition: A dynamic datasource renders English labels while the selected locale is non-English, or an auth option loses its fallback text.
- Rollback or disable path: Revert this commit; no persisted data or API migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex performed the implementation, focused source review, test execution, and build verification under maintainer direction.
