### PR TITLE
perf(mysql): avoid full parse for ordinary completion scripts

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/completion/locate/MysqlSqlCompletionStatementLocator.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/completion/locate/MysqlSqlCompletionStatementLocator.java
@@ -113,6 +113,11 @@ public final class MysqlSqlCompletionStatementLocator implements ISqlCompletionS
                     SqlCompletionStatementWindowTypeEnum.EMPTY_STATEMENT.name());
         }
 
+        List<Token> tokens = MysqlSqlCompletionTokenUtil.tokens(parseSql);
+        if (canUseTokenWindow(tokens) && !hasUnsafeLexerErrors(sourceSql)) {
+            return tokenFallbackWindow(sourceSql, parseSql, cursor, tokens, List.of());
+        }
+
         ParserWindowResult rawResult = parseWindow(parseSql, cursor, StatementWindowAuthorityEnum.RAW_PARSE);
         if (rawResult.proof().isPresent() && rawResult.syntaxErrors() == 0) {
             return toWindow(sourceSql, parseSql, rawResult.proof().get(), cursor);
@@ -146,9 +151,16 @@ public final class MysqlSqlCompletionStatementLocator implements ISqlCompletionS
     }
 
     private SqlCompletionStatementWindow tokenFallbackWindow(String sourceSql, String parseSql, int cursor) {
-        CommonTokenStream tokenStream = MysqlSqlCompletionTokenUtil.tokenStream(parseSql);
-        List<Token> tokens = tokenStream.getTokens();
+        List<Token> tokens = MysqlSqlCompletionTokenUtil.tokens(parseSql);
         List<RoutineWindow> routineWindows = findRoutineWindows(tokens, parseSql);
+        return tokenFallbackWindow(sourceSql, parseSql, cursor, tokens, routineWindows);
+    }
+
+    private SqlCompletionStatementWindow tokenFallbackWindow(String sourceSql,
+                                                              String parseSql,
+                                                              int cursor,
+                                                              List<Token> tokens,
+                                                              List<RoutineWindow> routineWindows) {
         RoutineWindow routineWindow = containingRoutineWindow(routineWindows, cursor);
         if (Objects.nonNull(routineWindow)) {
             return new SqlCompletionStatementWindow(
@@ -183,6 +195,52 @@ public final class MysqlSqlCompletionStatementLocator implements ISqlCompletionS
                 windowEnd,
                 cursor - windowStart,
                 type.name());
+    }
+
+    private boolean canUseTokenWindow(List<Token> tokens) {
+        boolean hasStatementSeparator = false;
+        int parenthesisDepth = 0;
+        int topLevelStatementStarts = 0;
+        boolean balancedParentheses = true;
+        for (Token token : tokens) {
+            if (!MysqlSqlCompletionTokenUtil.isDefaultToken(token)) {
+                continue;
+            }
+            int tokenType = token.getType();
+            if (tokenType == MySqlLexer.SEMI) {
+                hasStatementSeparator = true;
+                continue;
+            }
+            if (tokenType == MySqlLexer.CREATE || tokenType == MySqlLexer.DELIMITER_STATEMENT) {
+                return false;
+            }
+            if (tokenType == MySqlLexer.LR_BRACKET) {
+                parenthesisDepth++;
+                continue;
+            }
+            if (tokenType == MySqlLexer.RR_BRACKET) {
+                if (parenthesisDepth == 0) {
+                    balancedParentheses = false;
+                } else {
+                    parenthesisDepth--;
+                }
+                continue;
+            }
+            if (parenthesisDepth == 0 && isSqlStatementStartToken(tokenType)) {
+                topLevelStatementStarts++;
+            }
+        }
+        return balancedParentheses && parenthesisDepth == 0
+                && (hasStatementSeparator || topLevelStatementStarts == 1);
+    }
+
+    private boolean hasUnsafeLexerErrors(String sourceSql) {
+        for (Token token : MysqlSqlCompletionTokenUtil.tokens(sourceSql)) {
+            if (token.getChannel() == MySqlLexer.ERRORCHANNEL && !"?".equals(token.getText())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private ParserWindowResult parseWindow(String sql, int cursor, StatementWindowAuthorityEnum authority) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/completion/MysqlSqlCompletionPerformanceTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/completion/MysqlSqlCompletionPerformanceTest.java
@@ -1,0 +1,201 @@
+package ai.chat2db.plugin.mysql.completion;
+
+import ai.chat2db.community.domain.api.enums.completion.SqlCompletionCandidateTypeEnum;
+import ai.chat2db.community.domain.api.model.completion.SqlCompletionCandidate;
+import ai.chat2db.community.domain.api.model.completion.request.DbSqlCompletionMetadataRequest;
+import ai.chat2db.community.domain.api.model.completion.request.DbSqlCompletionRequest;
+import ai.chat2db.community.domain.api.model.completion.result.SqlCompletionMetadataResponse;
+import ai.chat2db.community.domain.api.model.completion.result.SqlCompletionResponse;
+import ai.chat2db.community.domain.api.service.db.ISqlCompletionMetadataProvider;
+import ai.chat2db.spi.parser.completion.SqlCompletionDialectComponents;
+import ai.chat2db.spi.parser.completion.SqlCompletionPipelineState;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class MysqlSqlCompletionPerformanceTest {
+
+    private static final int WARMUP_RUNS = 1;
+    private static final int MEASURED_RUNS = 2;
+    private static final long MAX_SINGLE_COMPLETION_NANOS = TimeUnit.SECONDS.toNanos(5);
+
+    private final SqlCompletionDialectComponents components = new MysqlSqlCompletionDialect().components();
+
+    @Test
+    void largeSqlCompletionStaysWithinPerformanceBudget() {
+        List<PerformanceCase> cases = List.of(
+                new PerformanceCase("single_statement_200_lines_166_ids", singleStatement(200, 166), false),
+                new PerformanceCase("multi_statement_200_history_166_ids", multiStatement(200, 166), true),
+                new PerformanceCase("multi_statement_200_history_500_ids", multiStatement(200, 500), true),
+                new PerformanceCase("multi_statement_200_history_1000_ids", multiStatement(200, 1000), true));
+
+        for (PerformanceCase performanceCase : cases) {
+            CountingMetadataProvider metadataProvider = new CountingMetadataProvider();
+            DbSqlCompletionRequest request = DbSqlCompletionRequest.of(
+                    performanceCase.sql(), performanceCase.sql().length(), "MYSQL", 0, metadataProvider);
+            for (int index = 0; index < WARMUP_RUNS; index++) {
+                measure(request);
+            }
+            metadataProvider.reset();
+
+            PipelineMeasurement lastMeasurement = null;
+            for (int index = 0; index < MEASURED_RUNS; index++) {
+                lastMeasurement = measure(request);
+                Assertions.assertTrue(lastMeasurement.totalNanos() < MAX_SINGLE_COMPLETION_NANOS,
+                        performanceCase.name());
+            }
+
+            Assertions.assertNotNull(lastMeasurement);
+            Assertions.assertTrue(lastMeasurement.totalNanos() > 0, performanceCase.name());
+            Assertions.assertFalse(lastMeasurement.stageNanos().isEmpty(), performanceCase.name());
+            SqlCompletionResponse result = lastMeasurement.state().result();
+            Assertions.assertEquals("SUCCESS", result.getStatus(), performanceCase.name());
+            Assertions.assertFalse(result.getCandidates().isEmpty(), performanceCase.name());
+            Assertions.assertTrue(lastMeasurement.state().window().sourceSql().length() <= performanceCase.sql().length(),
+                    performanceCase.name());
+            if (performanceCase.hasHistory()) {
+                Assertions.assertTrue(lastMeasurement.state().window().sourceStartOffset() > 0,
+                        performanceCase.name());
+            }
+            Assertions.assertTrue(metadataProvider.totalCalls() > 0, performanceCase.name());
+        }
+    }
+
+    private PipelineMeasurement measure(DbSqlCompletionRequest request) {
+        Map<String, Long> stageNanos = new LinkedHashMap<>();
+        long totalStartedAtNanos = System.nanoTime();
+        SqlCompletionPipelineState state = SqlCompletionPipelineState.start(request);
+
+        long stageStartedAtNanos = System.nanoTime();
+        state = state.withInput(components.inputCleaner().clean(state));
+        stageNanos.put("input", elapsed(stageStartedAtNanos));
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withWindow(components.statementLocator().locate(state));
+        stageNanos.put("statementWindow", elapsed(stageStartedAtNanos));
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withCursorContext(components.cursorAnalyzer().analyze(state));
+        stageNanos.put("cursor", elapsed(stageStartedAtNanos));
+        if (state.cursorContext() == null) {
+            return new PipelineMeasurement(state.withResult(SqlCompletionResponse.empty()), stageNanos,
+                    elapsed(totalStartedAtNanos));
+        }
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withDummySql(components.dummyBuilder().build(state));
+        stageNanos.put("dummySql", elapsed(stageStartedAtNanos));
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withLocalContext(components.localContextCollector().collect(state));
+        stageNanos.put("localContext", elapsed(stageStartedAtNanos));
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withC3Result(components.c3Collector().collect(state));
+        stageNanos.put("c3", elapsed(stageStartedAtNanos));
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withRuleEvidence(components.ruleEvidenceCollector().collect(state));
+        stageNanos.put("ruleEvidence", elapsed(stageStartedAtNanos));
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withSlots(components.slotClassifier().classify(state));
+        stageNanos.put("slots", elapsed(stageStartedAtNanos));
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withIntents(components.intentResolver().resolve(state));
+        stageNanos.put("intents", elapsed(stageStartedAtNanos));
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withCandidatePlan(components.candidatePlanner().plan(state));
+        stageNanos.put("candidatePlan", elapsed(stageStartedAtNanos));
+
+        stageStartedAtNanos = System.nanoTime();
+        state = state.withResult(components.presentationProcessor().process(state));
+        stageNanos.put("presentation", elapsed(stageStartedAtNanos));
+        return new PipelineMeasurement(state, stageNanos, elapsed(totalStartedAtNanos));
+    }
+
+    private static long elapsed(long startedAtNanos) {
+        return Math.max(0L, System.nanoTime() - startedAtNanos);
+    }
+
+    private static String singleStatement(int targetLineCount, int idCount) {
+        StringBuilder sql = currentStatementPrefix(idCount);
+        int lineCount = 2 + idCount / 10;
+        while (lineCount < targetLineCount - 1) {
+            sql.append("-- filler\n");
+            lineCount++;
+        }
+        return sql.append("and na").toString();
+    }
+
+    private static String multiStatement(int historyStatementCount, int idCount) {
+        StringBuilder sql = new StringBuilder();
+        for (int index = 0; index < historyStatementCount; index++) {
+            sql.append("select * from archive_").append(index).append(";\n");
+        }
+        return sql.append(currentStatementPrefix(idCount)).append("and na").toString();
+    }
+
+    private static StringBuilder currentStatementPrefix(int idCount) {
+        StringBuilder sql = new StringBuilder("select * from orders where id in (\n");
+        for (int index = 0; index < idCount; index++) {
+            if (index > 0) {
+                sql.append(',');
+            }
+            sql.append(index);
+            if (index % 10 == 9) {
+                sql.append('\n');
+            }
+        }
+        return sql.append(")\n");
+    }
+
+    private record PerformanceCase(String name, String sql, boolean hasHistory) {
+    }
+
+    private record PipelineMeasurement(SqlCompletionPipelineState state,
+                                       Map<String, Long> stageNanos,
+                                       long totalNanos) {
+    }
+
+    private static final class CountingMetadataProvider implements ISqlCompletionMetadataProvider {
+
+        private final Map<String, Integer> counts = new LinkedHashMap<>();
+
+        @Override
+        public SqlCompletionMetadataResponse list(DbSqlCompletionMetadataRequest request) {
+            counts.merge(request.type(), 1, Integer::sum);
+            SqlCompletionCandidateTypeEnum type = SqlCompletionCandidateTypeEnum.from(request.type());
+            if (type == SqlCompletionCandidateTypeEnum.COLUMN) {
+                return SqlCompletionMetadataResponse.of(List.of(column("name"), column("status")));
+            }
+            if (type == SqlCompletionCandidateTypeEnum.DATABASE) {
+                return SqlCompletionMetadataResponse.of(List.of(
+                        SqlCompletionCandidate.of(SqlCompletionCandidateTypeEnum.DATABASE, "app")));
+            }
+            return SqlCompletionMetadataResponse.of(new ArrayList<>());
+        }
+
+        private static SqlCompletionCandidate column(String name) {
+            SqlCompletionCandidate candidate = SqlCompletionCandidate.of(SqlCompletionCandidateTypeEnum.COLUMN, name);
+            candidate.setColumnName(name);
+            candidate.setTableName("orders");
+            return candidate;
+        }
+
+        private int totalCalls() {
+            return counts.values().stream().mapToInt(Integer::intValue).sum();
+        }
+
+        private void reset() {
+            counts.clear();
+        }
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/completion/locate/MysqlSqlCompletionStatementLocatorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/test/java/ai/chat2db/plugin/mysql/completion/locate/MysqlSqlCompletionStatementLocatorTest.java
@@ -180,6 +180,98 @@ class MysqlSqlCompletionStatementLocatorTest {
     }
 
     @Test
+    void keepsNestedSelectInsideSingleStatementOnTheFastPath() {
+        String sql = "select * from orders where id in (select id from users where users.id = 1) and na";
+
+        SqlCompletionStatementWindow window = locate(sql);
+
+        assertCurrentWindow(window, sql, 0, sql.length());
+    }
+
+    @Test
+    void keepsUnionQueryTogetherWhenTopLevelSelectsRepeat() {
+        String sql = "select id from orders where na union select id from archived_orders where na";
+
+        SqlCompletionStatementWindow window = locate(sql);
+
+        assertCurrentWindow(window, sql, 0, sql.length());
+    }
+
+    @Test
+    void keepsInsertSelectTogetherWhenTopLevelStatementKeywordsRepeat() {
+        String sql = "insert into orders(id) select id from users where na";
+
+        SqlCompletionStatementWindow window = locate(sql);
+
+        assertCurrentWindow(window, sql, 0, sql.length());
+    }
+
+    @Test
+    void preservesCurrentWindowWhenLargeHistoryCursorIsBeforeSeparator() {
+        StringBuilder sqlBuilder = new StringBuilder();
+        for (int index = 0; index < 200; index++) {
+            sqlBuilder.append("select * from archive_").append(index).append(";\n");
+        }
+        int currentStart = sqlBuilder.length();
+        sqlBuilder.append("select * from orders where na; select * from next_table");
+        String sql = sqlBuilder.toString();
+        int cursor = currentStart + "select * from orders where na".length();
+
+        SqlCompletionStatementWindow window = locate(sql, cursor);
+
+        assertCurrentWindow(window, "select * from orders where na", currentStart, cursor);
+    }
+
+    @Test
+    void fallsBackToParserForUnclosedParentheses() {
+        String sql = "select coalesce(o.sta from app.orders o";
+
+        SqlCompletionStatementWindow window = locate(sql);
+
+        assertCurrentWindow(window, sql, 0, sql.length());
+    }
+
+    @Test
+    void fallsBackToParserForUnclosedStringLiteral() {
+        String sql = "select * from orders where name = 'unterminated; select * from users where na";
+
+        SqlCompletionStatementWindow window = locate(sql);
+
+        assertCurrentWindow(window, "select * from users where na", sql.lastIndexOf("select * from users"),
+                sql.length());
+    }
+
+    @Test
+    void fallsBackToParserForUnclosedBlockComment() {
+        String sql = "select * from orders /* unterminated; select * from users where na";
+
+        SqlCompletionStatementWindow window = locate(sql);
+
+        assertCurrentWindow(window, "select * from users where na", sql.lastIndexOf("select * from users"),
+                sql.length());
+    }
+
+    @Test
+    void keepsQuestionMarkParametersEligibleForTheFastPath() {
+        String sql = "select * from orders where id = ?; select * from users where na";
+
+        SqlCompletionStatementWindow window = locate(sql);
+
+        assertCurrentWindow(window, "select * from users where na", sql.lastIndexOf("select * from users"),
+                sql.length());
+    }
+
+    @Test
+    void doesNotUseFastPathForUnmatchedClosingParenthesis() {
+        String sql = "select * from orders where id = 1); select * from users where na";
+
+        SqlCompletionStatementWindow window = locate(sql);
+
+        assertCurrentWindow(window, "select * from users where na", sql.lastIndexOf("select * from users"),
+                sql.length());
+    }
+
+    @Test
     void keepsLargeScriptCurrentWindowBoundedByStatementSeparator() {
         StringBuilder sqlBuilder = new StringBuilder();
         for (int index = 0; index < 200; index++) {


### PR DESCRIPTION
## Related issue

N/A - no issue number was provided.

## Summary

Avoids parsing the entire MySQL editor script with the ANTLR root parser when lexer boundaries prove that the input is a balanced ordinary SQL script. Complex routines, DELIMITER scripts, malformed input, and ambiguous no-semicolon statements keep the existing parser/probe path. Adds boundary coverage and a large-SQL performance test for 200-line scripts and 166/500/1000-value IN lists.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-mysql -am -Dmaven.test.skip=false -DskipTests=false -Dtest='MysqlSqlCompletionProviderTest,MysqlSqlCompletionScenarioCoverageTest,MysqlSqlCompletionStatementProgressionTest,MysqlSqlCompletionDdlScenarioCoverageTest,MysqlSqlCompletionRuleRangeTest,MysqlSqlCompletionStatementLocatorTest,MysqlSqlCompletionPerformanceTest' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test` - 521 tests passed, 0 failures, 0 errors.
  - `git diff --check` - passed.
- Manual verification: N/A; this is a backend parser/completion change covered by focused tests.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: N/A; no public request or persistence contract changed.
- Database or driver compatibility: MySQL completion only. Stored procedures, triggers, functions, DELIMITER input, malformed input, and ambiguous statements retain the existing parser path.
- Network, privacy, or security: N/A; no SQL text is logged or sent to a new endpoint.
- Community / Local / Pro boundary: Community MySQL plugin only; no Studio or Enterprise code is changed.
- Backward compatibility: Existing completion scenarios remain covered; all 521 focused tests pass.

## Reviewer map

- Start here: `chat2db-community-server/chat2db-community-plugins/chat2db-community-mysql/src/main/java/ai/chat2db/plugin/mysql/completion/locate/MysqlSqlCompletionStatementLocator.java`
- Failure condition: `canUseTokenWindow` requires balanced parentheses, no CREATE/DELIMITER tokens, no unsafe lexer errors, and a proven separator or single top-level statement; otherwise the existing parser/probe path runs.
- Rollback or disable path: Revert this PR; no runtime flag or migration is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for code navigation, implementation, test design, performance measurement, and verification.
