### PR TITLE
fix(workspace): keep local files out of localStorage

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/FilePreviewTab.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/FilePreviewTab.tsx
@@ -268,6 +268,39 @@ const FilePreviewTab = memo(({ file, workspaceTabId }: FilePreviewTabProps) => {
   markdownContentRef.current = markdownContent;
   markdownPersistedContentRef.current = markdownPersistedContent;
 
+  useEffect(() => {
+    if (!isMarkdown || file.ddl !== undefined || !file.filePath) {
+      return;
+    }
+    void useWorkspaceStore
+      .getState()
+      .readFile(file.filePath, file.fileExtension, {
+        rootToken: file.fileRootToken,
+        relativePath: file.fileRelativePath,
+        charset: file.fileCharset,
+        workspaceTabId,
+      })
+      .catch((error) => console.error('Failed to restore local file content', error));
+  }, [
+    file.ddl,
+    file.fileCharset,
+    file.fileExtension,
+    file.filePath,
+    file.fileRelativePath,
+    file.fileRootToken,
+    isMarkdown,
+    workspaceTabId,
+  ]);
+
+  useEffect(() => {
+    if (!isMarkdown || file.ddl === undefined) {
+      return;
+    }
+    setMarkdownContent(file.ddl);
+    setMarkdownPreviewContent(file.ddl);
+    setMarkdownPersistedContent(file.ddl);
+  }, [file.ddl, file.filePath, isMarkdown]);
+
   const markdownSaveKeybinding = useMemo(() => {
     const shortcutConfig = getEffectiveShortcutConfigMap(shortcutOverrides as ShortcutOverrides);
     return shortcutBindingToMonacoKeybinding(shortcutConfig[ShortcutAction.SqlSave].binding, monaco) || undefined;

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
@@ -48,6 +48,7 @@ import TerminalTab from './TerminalTab';
 import { useWorkspaceStore } from '@/store/workspace';
 import { useGlobalStore } from '@/store/global';
 import { getPersistableActiveConsoleId } from '@/store/workspace/utils/workspaceTabPersistence';
+import { getRestoredLocalFileReadRequest } from '@/store/workspace/utils/localFileWorkspaceTab';
 import { isWorkspaceResultInspectorCode } from '@/store/workspace/utils/resultInspector';
 import { isConsoleTabNameCustomized } from '@/store/workspace/utils/consoleTabName';
 import { useTreeStore } from '@/store/tree';
@@ -271,14 +272,19 @@ function rebuildSqlExecuteTabData(item: IWorkspaceTab) {
     return uniqueData;
   }
 
-  if (
-    item.type === WorkspaceTabType.LocalSQLFile &&
-    uniqueData.ddl === undefined &&
-    uniqueData.filePath
-  ) {
+  const localFileReadRequest = getRestoredLocalFileReadRequest(item);
+  if (localFileReadRequest) {
     return {
       ...uniqueData,
-      loadSQL: () => jcefApi.readFile(uniqueData.filePath!, uniqueData.fileCharset).then((file) => file.content),
+      loadSQL: () =>
+        useWorkspaceStore
+          .getState()
+          .readFile(
+            localFileReadRequest.filePath,
+            localFileReadRequest.fileExtension,
+            localFileReadRequest.context,
+          )
+          .then((file) => file?.content || ''),
     };
   }
 

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
@@ -271,6 +271,17 @@ function rebuildSqlExecuteTabData(item: IWorkspaceTab) {
     return uniqueData;
   }
 
+  if (
+    item.type === WorkspaceTabType.LocalSQLFile &&
+    uniqueData.ddl === undefined &&
+    uniqueData.filePath
+  ) {
+    return {
+      ...uniqueData,
+      loadSQL: () => jcefApi.readFile(uniqueData.filePath!, uniqueData.fileCharset).then((file) => file.content),
+    };
+  }
+
   const { dataSourceId, databaseName, schemaName } = uniqueData;
 
   if (item.type === WorkspaceTabType.VIEW) {
@@ -887,6 +898,7 @@ const WorkspaceTabs = memo(() => {
     tabs: IWorkspaceTab[],
     layout: IWorkspaceTabSplitLayout | null | undefined = useWorkspaceStore.getState().workspaceTabSplitLayout,
     nextActiveConsoleId: string | number | null | undefined = useWorkspaceStore.getState().activeConsoleId,
+    nextRecentlyClosedWorkspaceTabs?: IWorkspaceTab[],
   ) => {
     const orderedTabs = orderPinnedWorkspaceTabsFirst(tabs);
     const orderedLayout = orderSplitLayoutPaneIdsByPinned(layout || null, orderedTabs);
@@ -901,6 +913,9 @@ const WorkspaceTabs = memo(() => {
     };
     if (!areWorkspaceTabSplitLayoutsEqual(currentState.workspaceTabSplitLayout, normalizedLayout)) {
       nextState.workspaceTabSplitLayout = normalizedLayout;
+    }
+    if (nextRecentlyClosedWorkspaceTabs !== undefined) {
+      nextState.recentlyClosedWorkspaceTabs = nextRecentlyClosedWorkspaceTabs;
     }
     useWorkspaceStore.setState(nextState);
   };
@@ -1018,25 +1033,22 @@ const WorkspaceTabs = memo(() => {
     });
   };
 
-  const rememberClosedWorkspaceTabs = (tabs: IWorkspaceTab[]) => {
+  const createRecentlyClosedWorkspaceTabs = (tabs: IWorkspaceTab[]) => {
+    const currentRecentlyClosed = useWorkspaceStore.getState().recentlyClosedWorkspaceTabs || [];
     if (!tabs.length) {
-      return;
+      return currentRecentlyClosed;
     }
     const currentEditorList = useWorkspaceStore.getState().editorList || {};
     const snapshots = tabs
       .map((tab) => createPersistableWorkspaceTabSnapshot(tab, currentEditorList[tab.id]?.getValue?.()))
       .filter(Boolean) as IWorkspaceTab[];
     if (!snapshots.length) {
-      return;
+      return currentRecentlyClosed;
     }
-    const currentRecentlyClosed = useWorkspaceStore.getState().recentlyClosedWorkspaceTabs || [];
-    const nextRecentlyClosedWorkspaceTabs = [...snapshots, ...currentRecentlyClosed].slice(
+    return [...snapshots, ...currentRecentlyClosed].slice(
       0,
       RECENTLY_CLOSED_WORKSPACE_TAB_LIMIT,
     );
-    useWorkspaceStore.setState({
-      recentlyClosedWorkspaceTabs: nextRecentlyClosedWorkspaceTabs,
-    });
   };
 
   const closeWorkspaceTabs = (tabs: IWorkspaceTab[]) => {
@@ -1053,8 +1065,13 @@ const WorkspaceTabs = memo(() => {
       layout: workspaceTabSplitLayout,
       orderedNextWorkspaceTabList,
     });
-    rememberClosedWorkspaceTabs(closableTabs);
-    setWorkspaceTabsState(orderedNextWorkspaceTabList, workspaceTabSplitLayout, nextActiveConsoleId);
+    const nextRecentlyClosedWorkspaceTabs = createRecentlyClosedWorkspaceTabs(closableTabs);
+    setWorkspaceTabsState(
+      orderedNextWorkspaceTabList,
+      workspaceTabSplitLayout,
+      nextActiveConsoleId,
+      nextRecentlyClosedWorkspaceTabs,
+    );
 
     if (closeTabIds.has(activeConsoleId as any)) {
       setActiveConsoleId(nextActiveConsoleId);

--- a/chat2db-community-client/src/store/workspace/store.ts
+++ b/chat2db-community-client/src/store/workspace/store.ts
@@ -1,5 +1,5 @@
 import { clientRuntime } from '@client-runtime';
-import { PersistOptions, devtools, persist } from 'zustand/middleware';
+import { createJSONStorage, PersistOptions, devtools, persist } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
 import { StateCreator } from 'zustand/vanilla';
@@ -13,6 +13,7 @@ import {
   getHydratedWorkspaceLayout,
   getPersistableWorkspaceLayout,
   getPersistableWorkspaceTabList,
+  createSafeWorkspaceStorage,
 } from './utils/workspaceTabPersistence';
 
 type WorkspaceAction = CommonAction & ConfigAction & ConsoleAction & ModalAction;
@@ -39,6 +40,7 @@ type GlobalPersist = Pick<
 // local-storage Options
 const persistOptions: PersistOptions<WorkspaceStore, GlobalPersist> = {
   name: clientRuntime.workspaceStoreName,
+  storage: createJSONStorage<GlobalPersist>(() => createSafeWorkspaceStorage(localStorage)),
   partialize: (state) => {
     const workspaceTabList = getPersistableWorkspaceTabList(state.workspaceTabList);
     return {
@@ -55,10 +57,17 @@ const persistOptions: PersistOptions<WorkspaceStore, GlobalPersist> = {
   },
   merge: (persistedState, currentState) => {
     const storedState = (persistedState || {}) as Partial<GlobalPersist>;
+    const workspaceTabList = getPersistableWorkspaceTabList(storedState.workspaceTabList);
     return {
       ...currentState,
       ...storedState,
       layout: getHydratedWorkspaceLayout(currentState.layout, storedState.layout),
+      workspaceTabList,
+      activeConsoleId: getPersistableActiveConsoleId({
+        activeConsoleId: storedState.activeConsoleId,
+        workspaceTabList,
+      }),
+      recentlyClosedWorkspaceTabs: getPersistableWorkspaceTabList(storedState.recentlyClosedWorkspaceTabs) || [],
     };
   },
 };

--- a/chat2db-community-client/src/store/workspace/store.ts
+++ b/chat2db-community-client/src/store/workspace/store.ts
@@ -14,6 +14,7 @@ import {
   getPersistableWorkspaceLayout,
   getPersistableWorkspaceTabList,
   createSafeWorkspaceStorage,
+  sanitizePersistedWorkspaceTabsState,
 } from './utils/workspaceTabPersistence';
 
 type WorkspaceAction = CommonAction & ConfigAction & ConsoleAction & ModalAction;
@@ -40,6 +41,7 @@ type GlobalPersist = Pick<
 // local-storage Options
 const persistOptions: PersistOptions<WorkspaceStore, GlobalPersist> = {
   name: clientRuntime.workspaceStoreName,
+  version: 1,
   storage: createJSONStorage<GlobalPersist>(() => createSafeWorkspaceStorage(localStorage)),
   partialize: (state) => {
     const workspaceTabList = getPersistableWorkspaceTabList(state.workspaceTabList);
@@ -55,19 +57,13 @@ const persistOptions: PersistOptions<WorkspaceStore, GlobalPersist> = {
       recentlyClosedWorkspaceTabs: getPersistableWorkspaceTabList(state.recentlyClosedWorkspaceTabs) || [],
     };
   },
+  migrate: (persistedState) => sanitizePersistedWorkspaceTabsState((persistedState || {}) as GlobalPersist),
   merge: (persistedState, currentState) => {
-    const storedState = (persistedState || {}) as Partial<GlobalPersist>;
-    const workspaceTabList = getPersistableWorkspaceTabList(storedState.workspaceTabList);
+    const storedState = sanitizePersistedWorkspaceTabsState((persistedState || {}) as Partial<GlobalPersist>);
     return {
       ...currentState,
       ...storedState,
       layout: getHydratedWorkspaceLayout(currentState.layout, storedState.layout),
-      workspaceTabList,
-      activeConsoleId: getPersistableActiveConsoleId({
-        activeConsoleId: storedState.activeConsoleId,
-        workspaceTabList,
-      }),
-      recentlyClosedWorkspaceTabs: getPersistableWorkspaceTabList(storedState.recentlyClosedWorkspaceTabs) || [],
     };
   },
 };

--- a/chat2db-community-client/src/store/workspace/utils/localFileWorkspaceTab.test.ts
+++ b/chat2db-community-client/src/store/workspace/utils/localFileWorkspaceTab.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { WorkspaceTabType } from '@/constants/workspace';
 import type { IBoundInfo, IWorkspaceTab } from '@/typings/workspace';
-import { refreshLocalFileWorkspaceTab } from './localFileWorkspaceTab';
+import { getRestoredLocalFileReadRequest, refreshLocalFileWorkspaceTab } from './localFileWorkspaceTab';
 
 const originalUniqueData = Object.freeze({
   filePath: '/tmp/report.pdf',
@@ -63,6 +63,43 @@ assert.equal(
   refreshLocalFileWorkspaceTab(duplicateTabs, '/tmp/report.pdf', nextUniqueData, 'closed-tab'),
   undefined,
   'a closed target tab must not fall back to another tab with the same path',
+);
+
+const restoredReadRequest = getRestoredLocalFileReadRequest({
+  id: 'restored-sql',
+  type: WorkspaceTabType.LocalSQLFile,
+  title: 'restored.sql',
+  uniqueData: {
+    filePath: '/tmp/root/restored.sql',
+    fileExtension: 'sql',
+    fileRootToken: 'root-token',
+    fileRelativePath: 'nested/restored.sql',
+    fileCharset: 'GB18030',
+  },
+});
+assert.deepEqual(
+  restoredReadRequest,
+  {
+    filePath: '/tmp/root/restored.sql',
+    fileExtension: 'sql',
+    context: {
+      rootToken: 'root-token',
+      relativePath: 'nested/restored.sql',
+      charset: 'GB18030',
+      workspaceTabId: 'restored-sql',
+    },
+  },
+  'restored local files must preserve directory access and encoding context',
+);
+assert.equal(
+  getRestoredLocalFileReadRequest({
+    id: 'live-sql',
+    type: WorkspaceTabType.LocalSQLFile,
+    title: 'live.sql',
+    uniqueData: { filePath: '/tmp/live.sql', ddl: 'select 1' },
+  }),
+  undefined,
+  'live local files with content must not be reloaded from disk',
 );
 
 console.log('local file workspace tab tests passed');

--- a/chat2db-community-client/src/store/workspace/utils/localFileWorkspaceTab.ts
+++ b/chat2db-community-client/src/store/workspace/utils/localFileWorkspaceTab.ts
@@ -1,4 +1,22 @@
 import type { IBoundInfo, IWorkspaceTab } from '@/typings/workspace';
+import { WorkspaceTabType } from '@/constants/workspace';
+
+export function getRestoredLocalFileReadRequest(tab: IWorkspaceTab) {
+  const file = tab.uniqueData;
+  if (tab.type !== WorkspaceTabType.LocalSQLFile || !file?.filePath || file.ddl !== undefined) {
+    return undefined;
+  }
+  return {
+    filePath: file.filePath,
+    fileExtension: file.fileExtension,
+    context: {
+      rootToken: file.fileRootToken,
+      relativePath: file.fileRelativePath,
+      charset: file.fileCharset,
+      workspaceTabId: tab.id,
+    },
+  };
+}
 
 export function refreshLocalFileWorkspaceTab(
   workspaceTabList: IWorkspaceTab[] | null | undefined,

--- a/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.test.ts
+++ b/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.test.ts
@@ -6,6 +6,7 @@ import {
   getPersistableActiveConsoleId,
   getPersistableWorkspaceLayout,
   getPersistableWorkspaceTabList,
+  createSafeWorkspaceStorage,
 } from './workspaceTabPersistence';
 
 const tabs: IWorkspaceTab[] = [
@@ -51,8 +52,43 @@ assert.deepEqual(
 );
 assert.deepEqual(
   getPersistableWorkspaceTabList(tabs)?.[0].uniqueData,
-  tabs[0].uniqueData,
-  'local file charset and BOM metadata must survive workspace persistence',
+  {
+    filePath: '/tmp/README.md',
+    fileExtension: 'md',
+    fileCharset: 'UTF-8',
+    fileBom: true,
+  },
+  'local file metadata must survive workspace persistence without its content',
+);
+assert.equal(tabs[0].uniqueData?.ddl, '# Hello', 'persistence filtering must not modify live editor state');
+
+const largeLocalFileContent = 'x'.repeat(Math.ceil(2.8 * 1024 * 1024));
+const largeLocalFileTabs: IWorkspaceTab[] = ['sql', 'md', 'txt', 'json'].map((extension) => ({
+  id: `large-${extension}`,
+  type: WorkspaceTabType.LocalSQLFile,
+  title: `large.${extension}`,
+  uniqueData: {
+    filePath: `/tmp/large.${extension}`,
+    fileExtension: extension,
+    fileCharset: 'UTF-8',
+    ddl: largeLocalFileContent,
+  },
+}));
+const persistedLargeLocalFiles = getPersistableWorkspaceTabList(largeLocalFileTabs);
+assert.deepEqual(
+  persistedLargeLocalFiles?.map((tab) => tab.uniqueData?.ddl),
+  [undefined, undefined, undefined, undefined],
+  'all local text file types must omit their content from workspace localStorage',
+);
+assert.equal(
+  JSON.stringify(persistedLargeLocalFiles).length < 4096,
+  true,
+  'large local files must persist only a small metadata payload',
+);
+assert.equal(
+  largeLocalFileTabs.every((tab) => tab.uniqueData?.ddl === largeLocalFileContent),
+  true,
+  'persistence filtering must preserve every live local editor value',
 );
 
 const consoleTabs: IWorkspaceTab[] = Array.from({ length: 101 }, (_, index) => ({
@@ -103,6 +139,31 @@ assert.deepEqual(
   sharedUniqueData,
   'shared non-circular values must remain available in each persisted tab',
 );
+
+const storageWriteErrors: unknown[] = [];
+let failStorageWrites = true;
+let storedWorkspaceValue: string | undefined;
+const safeStorage = createSafeWorkspaceStorage(
+  {
+    getItem: () => null,
+    setItem: (_name, value) => {
+      if (failStorageWrites) {
+        throw new DOMException('Quota exceeded', 'QuotaExceededError');
+      }
+      storedWorkspaceValue = value;
+    },
+    removeItem: () => undefined,
+  },
+  (error) => storageWriteErrors.push(error),
+);
+assert.doesNotThrow(
+  () => safeStorage.setItem('Chat2DB_Workspace_Store', '{}'),
+  'workspace persistence failures must not interrupt UI state updates',
+);
+assert.equal(storageWriteErrors.length, 1, 'workspace persistence failures must still be reported');
+failStorageWrites = false;
+safeStorage.setItem('Chat2DB_Workspace_Store', '{"state":{}}');
+assert.equal(storedWorkspaceValue, '{"state":{}}', 'workspace persistence must recover after a failed write');
 
 const circularPanelState: Record<string, unknown> = {};
 circularPanelState.self = circularPanelState;

--- a/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.test.ts
+++ b/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.test.ts
@@ -7,6 +7,7 @@ import {
   getPersistableWorkspaceLayout,
   getPersistableWorkspaceTabList,
   createSafeWorkspaceStorage,
+  sanitizePersistedWorkspaceTabsState,
 } from './workspaceTabPersistence';
 
 const tabs: IWorkspaceTab[] = [
@@ -164,6 +165,24 @@ assert.equal(storageWriteErrors.length, 1, 'workspace persistence failures must 
 failStorageWrites = false;
 safeStorage.setItem('Chat2DB_Workspace_Store', '{"state":{}}');
 assert.equal(storedWorkspaceValue, '{"state":{}}', 'workspace persistence must recover after a failed write');
+
+const sanitizedLegacyState = sanitizePersistedWorkspaceTabsState({
+  workspaceTabList: largeLocalFileTabs,
+  activeConsoleId: 'large-sql',
+  recentlyClosedWorkspaceTabs: largeLocalFileTabs,
+  currentConnectionDetails: { dataSourceId: 42 },
+});
+assert.equal(
+  JSON.stringify(sanitizedLegacyState).includes(largeLocalFileContent),
+  false,
+  'legacy workspace migration must remove local file content from open and recently closed tabs',
+);
+assert.equal(sanitizedLegacyState.activeConsoleId, 'large-sql', 'legacy workspace migration must retain the active tab');
+assert.deepEqual(
+  sanitizedLegacyState.currentConnectionDetails,
+  { dataSourceId: 42 },
+  'legacy workspace migration must preserve unrelated persisted state',
+);
 
 const circularPanelState: Record<string, unknown> = {};
 circularPanelState.self = circularPanelState;

--- a/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.ts
+++ b/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.ts
@@ -1,5 +1,6 @@
 import { WorkspaceTabType } from '@/constants/workspace';
 import { IWorkspaceTab } from '@/typings/workspace';
+import type { StateStorage } from 'zustand/middleware';
 import { initConfigState, type ConfigState } from '../slices/config/initialState';
 
 /**
@@ -13,6 +14,17 @@ const MAX_PERSISTED_TABS = 100;
 
 function capPersistedTabs(tabs: IWorkspaceTab[]): IWorkspaceTab[] {
   return tabs.length > MAX_PERSISTED_TABS ? tabs.slice(-MAX_PERSISTED_TABS) : tabs;
+}
+
+function stripLocalFileContent(tab: IWorkspaceTab): IWorkspaceTab {
+  if (tab.type !== WorkspaceTabType.LocalSQLFile || !tab.uniqueData) {
+    return tab;
+  }
+  const { ddl: _ddl, ...uniqueData } = tab.uniqueData;
+  return {
+    ...tab,
+    uniqueData,
+  };
 }
 
 function createPersistenceReplacer() {
@@ -76,9 +88,9 @@ export function getPersistableWorkspaceTabList(workspaceTabList?: IWorkspaceTab[
     return workspaceTabList || null;
   }
 
-  const persistableTabs = workspaceTabList.filter(
-    (tab) => tab.type !== WorkspaceTabType.Terminal && !tab.uniqueData?.filePreviewMimeType,
-  );
+  const persistableTabs = workspaceTabList
+    .filter((tab) => tab.type !== WorkspaceTabType.Terminal && !tab.uniqueData?.filePreviewMimeType)
+    .map(stripLocalFileContent);
   const cappedTabs = capPersistedTabs(persistableTabs);
 
   try {
@@ -90,6 +102,23 @@ export function getPersistableWorkspaceTabList(workspaceTabList?: IWorkspaceTab[
       title: tab.title,
     }));
   }
+}
+
+export function createSafeWorkspaceStorage(
+  storage: StateStorage,
+  onWriteError: (error: unknown) => void = (error) => console.error('Failed to persist workspace state', error),
+): StateStorage {
+  return {
+    getItem: (name) => storage.getItem(name),
+    setItem: (name, value) => {
+      try {
+        return storage.setItem(name, value);
+      } catch (error) {
+        onWriteError(error);
+      }
+    },
+    removeItem: (name) => storage.removeItem(name),
+  };
 }
 
 export function getPersistableActiveConsoleId(params: {

--- a/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.ts
+++ b/chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.ts
@@ -134,3 +134,22 @@ export function getPersistableActiveConsoleId(params: {
   }
   return workspaceTabList[0].id;
 }
+
+export interface PersistedWorkspaceTabsState {
+  workspaceTabList?: IWorkspaceTab[] | null;
+  activeConsoleId?: string | number | null;
+  recentlyClosedWorkspaceTabs?: IWorkspaceTab[] | null;
+}
+
+export function sanitizePersistedWorkspaceTabsState<T extends PersistedWorkspaceTabsState>(state: T) {
+  const workspaceTabList = getPersistableWorkspaceTabList(state.workspaceTabList);
+  return {
+    ...state,
+    workspaceTabList,
+    activeConsoleId: getPersistableActiveConsoleId({
+      activeConsoleId: state.activeConsoleId,
+      workspaceTabList,
+    }),
+    recentlyClosedWorkspaceTabs: getPersistableWorkspaceTabList(state.recentlyClosedWorkspaceTabs) || [],
+  };
+}


### PR DESCRIPTION
## Related issue

N/A - reported through a direct customer reproduction; no existing Issue was found.

## Summary

- keep local SQL, Markdown, and other text-file bodies out of the persisted workspace localStorage payload while preserving file metadata
- reload restored local text tabs through the existing workspace file reader with path, directory token, relative path, encoding, and tab identity
- migrate and immediately rewrite legacy persisted workspace state so open and recently closed local-file bodies are removed on hydration
- update closed-tab state atomically and prevent synchronous storage quota failures from interrupting UI state changes
- cover 2.8 MiB local files across SQL, Markdown, TXT, and JSON plus quota failure, recovery, legacy migration, and directory access metadata

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn install --frozen-lockfile` - passed; generated the isolated worktree Umi setup
  - `yarn test:local-file-encoding` - passed
  - `yarn test:saved-console-lifecycle` - passed
  - `yarn test:editor-close` - passed
  - `yarn run lint` - passed before and after rebasing onto current main
  - `yarn run build:web:community --app_version=0.0.0` - passed after each implementation round, including all prebuild contract tests and production-bundle verification
  - `CHAT2DB_FRONTEND_SRC_ROOT=<pr-community-src> yarn run build:web:desktop --app_version=0.0.0` in a clean Studio main worktree - passed at final PR head `88f4e8af`; Community source lock, API contract, and Pro composition bundle verified
- Manual verification: a Pro desktop dist was generated from final PR head `88f4e8af`; the final 200 MiB local-file runtime reproduction is pending user execution.
- UI evidence: N/A - persistence and recovery behavior has no visual design change.

## Risk and compatibility

- Public API or stored data: no API change; legacy workspace entries are migrated and rewritten without local file bodies, while local files on disk remain untouched.
- Database or driver compatibility: N/A - no database or driver behavior changed.
- Network, privacy, or security: local file bodies are no longer copied into browser localStorage; no network behavior changed.
- Community / Local / Pro boundary: implementation remains in the shared Community frontend; a clean Pro desktop composition build passed. Studio should update its Community ref only after this PR is merged.
- Backward compatibility: persisted tab metadata remains compatible; restored text tabs reread their path through the existing workspace file API. Existing behavior applies when a referenced file has been moved or deleted.

## Reviewer map

- Start here: `chat2db-community-client/src/store/workspace/utils/workspaceTabPersistence.ts`, then review versioned hydration in `store.ts` and the tested local-file reload request in `localFileWorkspaceTab.ts`.
- Failure condition: a local file body appears in the persisted workspace payload, quota failure escapes a workspace write, legacy payloads are not rewritten, or a restored text tab drops directory access metadata.
- Rollback or disable path: revert this PR.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex investigated the failure path, implemented the scoped frontend changes and regression tests, addressed automated review findings, reviewed the diff, and ran the reported verification commands.
