### PR TITLE
fix(workspace): smooth panel resizing and restore theme accents

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -83,7 +83,7 @@
     "test:sql-completion-context": "tsx src/components/SQLEditor/core/sqlCompletionContext.test.ts && tsx src/components/SQLEditor/core/sqlCompletionRequestError.test.ts",
     "test:sql-in-clipboard": "tsx src/utils/sqlInClipboard.test.ts && tsx src/components/SQLEditor/helper/sqlInsertValueDefaults.test.ts",
     "test:console-tab-name": "tsx src/store/workspace/utils/consoleTabName.test.ts && tsx src/utils/workspaceObjectTabTitle.test.ts",
-    "test:workspace-tab-scroll": "tsx src/store/workspace/utils/workspaceTabScrollRequest.test.ts && tsx src/components/Tabs/activeTabScroll.test.ts && tsx src/components/Tabs/wheelScroll.test.ts",
+    "test:workspace-tab-scroll": "tsx src/store/workspace/utils/workspaceTabScrollRequest.test.ts && tsx src/components/Tabs/activeTabScroll.test.ts && tsx src/components/Tabs/wheelScroll.test.ts && tsx src/components/Tabs/tabAccentColor.test.ts",
     "test:workspace-split-lifecycle": "tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabContentLayout.test.ts",
     "test:tree-title-highlight": "tsx src/blocks/NewTree/components/TitleRender/highlightSearchText.test.ts",
     "test:tree-search-lifecycle": "tsx src/pages/main/workspace/components/WorkspaceTreeSearch/lifecycle.test.ts && tsx src/pages/main/workspace/components/WorkspaceTreeSearch/refresh.test.ts",

--- a/chat2db-community-client/src/components/SQLEditor/editor/SQLEditorWithOperation/index.tsx
+++ b/chat2db-community-client/src/components/SQLEditor/editor/SQLEditorWithOperation/index.tsx
@@ -142,7 +142,7 @@ const SQLEditorWithOperation = forwardRef<ISQLEditorWithOperationRef, ISQLEditor
   const isSupportedRoutineEditor =
     isDatabaseCapabilitySupported(dbInfo.databaseType, DatabaseCapability.ROUTINE_OPERATION) &&
     [WorkspaceTabType.FUNCTION, WorkspaceTabType.PROCEDURE].includes(type as WorkspaceTabType);
-  const { styles } = useStyles();
+  const { styles, theme } = useStyles();
   const [modal, modalContextHolder] = Modal.useModal();
   const [contextMenuInfo, setContextMenuInfo] = useState<IContextMenuInfo>(contextMenuDefaultConfig);
   const [contextTableIdentifier, setContextTableIdentifier] = useState<EditorTableIdentifier | null>(null);
@@ -1164,7 +1164,7 @@ const SQLEditorWithOperation = forwardRef<ISQLEditorWithOperationRef, ISQLEditor
     isConsole && type === WorkspaceTabType.CONSOLE && dbInfo.dataSourceId
       ? getDataSourceWatermarkContent(dbInfo, dataSourceState)
       : undefined;
-  const watermarkColor = identityColor ? withIdentityColorAlpha(identityColor, 0.4) : undefined;
+  const watermarkColor = withIdentityColorAlpha(identityColor || theme.colorPrimary, 0.4);
   const watermarkLayout = getDataSourceWatermarkLayout(editorViewportSize?.width, editorViewportSize?.height);
 
   return (

--- a/chat2db-community-client/src/components/SQLEditor/editor/SQLEditorWithOperation/style.ts
+++ b/chat2db-community-client/src/components/SQLEditor/editor/SQLEditorWithOperation/style.ts
@@ -25,6 +25,19 @@ export const useStyles = createStyles(({ css, token }) => {
       width: 100%;
       height: 0px;
       border-top: 1px solid ${colorBorderLayout};
+
+      > .monaco-editor {
+        width: 100% !important;
+      }
+
+      > .monaco-editor > .overflow-guard {
+        width: 100% !important;
+      }
+
+      > .monaco-editor .editor-scrollable {
+        right: 0 !important;
+        width: auto !important;
+      }
     `,
     watermarkLayer: css`
       position: absolute;

--- a/chat2db-community-client/src/components/Tabs/index.tsx
+++ b/chat2db-community-client/src/components/Tabs/index.tsx
@@ -32,6 +32,7 @@ import {
   registerCloseActiveResultTabHandler,
 } from '@/service/resultTabShortcut';
 import { shouldProcessTabScrollRequest, type ProcessedTabScrollRequest } from './activeTabScroll';
+import { getTabAccentStyle } from './tabAccentColor';
 import { getTabWheelScrollAmount } from './wheelScroll';
 
 export interface ITabItem {
@@ -708,9 +709,7 @@ export default memo<IProps>((props) => {
 
     const tabStyle = {
       ...t.styles,
-      ...(t.accentColor !== undefined
-        ? ({ '--chat2db-tab-accent-color': t.accentColor || 'transparent' } as React.CSSProperties)
-        : {}),
+      ...getTabAccentStyle(t.accentColor),
     };
     const tabNode = enableReorder ? (
       <SortableTabItem

--- a/chat2db-community-client/src/components/Tabs/tabAccentColor.test.ts
+++ b/chat2db-community-client/src/components/Tabs/tabAccentColor.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { getTabAccentStyle } from './tabAccentColor';
+
+assert.deepEqual(getTabAccentStyle('#12AB34'), { '--chat2db-tab-accent-color': '#12AB34' });
+assert.deepEqual(getTabAccentStyle(null), {});
+assert.deepEqual(getTabAccentStyle(undefined), {});
+assert.deepEqual(getTabAccentStyle(''), {});
+
+console.log('Tab accent color tests passed');

--- a/chat2db-community-client/src/components/Tabs/tabAccentColor.ts
+++ b/chat2db-community-client/src/components/Tabs/tabAccentColor.ts
@@ -1,0 +1,9 @@
+import type { CSSProperties } from 'react';
+
+type TabAccentStyle = CSSProperties & {
+  '--chat2db-tab-accent-color'?: string;
+};
+
+export function getTabAccentStyle(accentColor?: string | null): TabAccentStyle {
+  return accentColor ? { '--chat2db-tab-accent-color': accentColor } : {};
+}

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendBody/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendBody/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { extendConfig, isWorkspaceRecordCode } from '../config';
 import { useWorkspaceStore } from '@/store/workspace';
 import { useStyles } from './style';
@@ -10,7 +10,7 @@ import {
 } from '@/store/workspace/utils/resultInspector';
 import WorkspaceRecordSwitcher from '../WorkspaceRecordSwitcher';
 
-export default () => {
+export default memo(() => {
   const { styles } = useStyles();
 
   const currentWorkspaceExtend = useWorkspaceStore((state) => state.currentWorkspaceExtend);
@@ -43,4 +43,4 @@ export default () => {
   ) : (
     false
   );
-};
+});

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceRight/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceRight/index.tsx
@@ -66,8 +66,10 @@ const WorkspaceRight = memo(() => {
           maxSize={maxPanelSize}
           primary="second"
           allowResize={panelRight}
-          onChange={(newSize) => {
-            setPanelRightWidth(newSize);
+          onDragFinished={(newSize) => {
+            if (Number.isFinite(newSize) && newSize !== panelRightWidth) {
+              setPanelRightWidth(newSize);
+            }
           }}
         >
           <div className={styles.masterScope}>

--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceTabs/index.tsx
@@ -107,6 +107,7 @@ const SplitPaneAny = SplitPane as any;
 const MAIN_WORKSPACE_TAB_PANE: WorkspaceTabPaneId = 'main';
 const SPLIT_WORKSPACE_TAB_PANE: WorkspaceTabPaneId = 'split';
 const WORKSPACE_TAB_PANE_DROPPABLE_PREFIX = 'workspace-tab-pane:';
+const WORKSPACE_TAB_HEADER_HEIGHT = 36;
 const WORKSPACE_TAB_WIDTH = 200;
 const WORKSPACE_TAB_HORIZONTAL_RESIZE_CLASS = 'WorkspaceTabHorizontalResizing';
 const WORKSPACE_TAB_VERTICAL_RESIZE_CLASS = 'WorkspaceTabVerticalResizing';
@@ -841,6 +842,9 @@ const WorkspaceTabs = memo(() => {
   // The split box does not exist in an empty workspace. Re-run when the first
   // tab mounts even if the normalized split layout remains null.
   useLayoutEffect(() => {
+    if (!workspaceTabSplitLayout) {
+      return;
+    }
     const container = splitTabBoxRef.current;
     if (!container) {
       return;
@@ -2087,7 +2091,7 @@ const WorkspaceTabs = memo(() => {
         }}
       >
         <CustomTabs
-          height={36}
+          height={WORKSPACE_TAB_HEADER_HEIGHT}
           hideAdd={hideAdd}
           className={styles.tabHeaderBox}
           onChange={(key) => onPaneTabChange(paneId, key)}
@@ -2172,16 +2176,25 @@ const WorkspaceTabs = memo(() => {
           const paneId = activeTabPaneIds.get(item.key);
           const bounds = paneId ? paneContentBounds[paneId] : undefined;
           const isActive = paneId !== undefined;
+          const fillsSinglePane = isActive && !workspaceTabSplitLayout;
+          const isVisible = fillsSinglePane || !!bounds;
           if (item.destroyOnHide && !isActive) {
             return null;
           }
           return (
             <div
               key={item.key}
-              aria-hidden={!bounds}
-              className={`${styles.workspaceTabContentItem} ${bounds ? styles.workspaceTabContentItemActive : ''}`}
+              aria-hidden={!isVisible}
+              className={`${styles.workspaceTabContentItem} ${isVisible ? styles.workspaceTabContentItemActive : ''}`}
               style={
-                bounds
+                fillsSinglePane
+                  ? {
+                      top: WORKSPACE_TAB_HEADER_HEIGHT,
+                      right: 0,
+                      bottom: 0,
+                      left: 0,
+                    }
+                  : bounds
                   ? {
                       left: bounds.left,
                       top: bounds.top,

--- a/chat2db-community-client/src/pages/main/workspace/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect } from 'react';
+import { memo } from 'react';
 import SplitPane from 'react-split-pane';
 import { useWorkspaceStore } from '@/store/workspace';
 import WorkspaceLeft from './components/WorkspaceLeft';
@@ -14,31 +14,20 @@ const workspacePage = memo(() => {
       setPanelLeftWidth: state.setPanelLeftWidth,
     };
   });
-  const [size, setSize] = React.useState(panelLeftWidth);
-
-  useEffect(() => {
-    if (size !== panelLeftWidth) {
-      setSize(panelLeftWidth);
-    }
-  }, [panelLeftWidth]);
-
   return (
     <div className={styles.workspaceRoot} data-workspace-shortcut-surface="true">
       <SplitPane
         split="vertical"
-        className={cx({ ['ResizerSizeIsZeroRight']: size === 0 })}
+        className={cx({ ['ResizerSizeIsZeroRight']: panelLeftWidth === 0 })}
         pane1Style={{ zIndex: 2 }}
         pane2Style={{ zIndex: 1 }}
-        onChange={(newSize) => {
-          if (newSize < 100) {
-            setSize(0);
-            setPanelLeftWidth(0);
-            return;
+        onDragFinished={(newSize) => {
+          const nextWidth = newSize < 100 ? 0 : newSize;
+          if (Number.isFinite(nextWidth) && nextWidth !== panelLeftWidth) {
+            setPanelLeftWidth(nextWidth);
           }
-          setSize(newSize);
-          setPanelLeftWidth(newSize);
         }}
-        size={size}
+        size={panelLeftWidth}
         minSize={0}
         primary="first"
       >


### PR DESCRIPTION
## Related issue

N/A - requested and validated directly as a workspace interaction fix.

## Summary

- Commit outer workspace panel sizes only after dragging finishes so continuous pointer movement does not serialize the persisted workspace state.
- Keep unsplit workspace content and Monaco's internal viewport attached to their live container edges during sidebar resizing, while preserving the existing split-editor measurement path.
- Preserve the default theme accent when a datasource has no custom identity color, and use the same theme fallback for enabled editor watermarks.
- Keep explicit datasource identity colors authoritative for tree decoration, tab accents, selector marks, and watermarks.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn install --frozen-lockfile` - passed.
  - `yarn test:workspace-tab-scroll` - passed, including the new null/undefined/empty accent fallback coverage.
  - `yarn test:data-source-identity` - passed.
  - `yarn test:data-source-watermark` - passed.
  - `yarn lint` - passed.
  - `yarn build:web:community --app_version=0.0.0` - passed, including all configured prebuild tests and production bundle verification.
- Manual verification:
  - Playwright CLI covered 2048x1060 and 1024x768 viewports, a real 23-database tree, a real Monaco SQL editor, 40 mocked history records, panel collapse/reopen, reload persistence, and vertical/horizontal editor splits.
  - A 270-frame reversing left drag, 180-frame right drag, and 161-frame narrow drag kept tree nodes, content bounds, Monaco, and the right scrollbar at 0 px geometry drift; each completed drag persisted the workspace once and produced no long tasks.
  - With no custom datasource color, workspace and query-result active tabs used the live theme primary color and an enabled watermark used that color at 40% opacity. With `#F5222D`, the explicit color overrode tabs, tree decoration, selector mark, and watermark.
  - No unexpected console errors, page errors, or failed requests were observed.
- UI evidence: Playwright CLI computed-style, DOM-geometry, persistence-count, and runtime-error assertions are summarized above; no generated binary evidence was committed.

## Risk and compatibility

- Public API or stored data: N/A - no API, schema, storage key, or persisted payload shape changes.
- Database or driver compatibility: N/A - no database or driver code changes.
- Network, privacy, or security: N/A - no network or data-access behavior changes.
- Community / Local / Pro boundary: Community shared frontend only; Studio has no overrides for the changed components and will inherit the behavior after its Community ref is updated from the merged commit.
- Backward compatibility: Existing panel widths, custom identity colors, editor split layouts, and datasource color persistence remain compatible.

## Reviewer map

- Start here: `chat2db-community-client/src/pages/main/workspace/index.tsx`, `WorkspaceRight/index.tsx`, `WorkspaceTabs/index.tsx`, then `src/components/Tabs/tabAccentColor.ts`.
- Failure condition: panel drag writes the workspace store more than once, the tree or Monaco edges drift during resize, or a null datasource color makes the active tab accent transparent.
- Rollback or disable path: revert commits `b8aa245a6` and `3ca2412b1`.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A - no Issue was supplied.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex traced the resize and color flows, implemented the changes, added the focused regression test, and ran the reported automated and Playwright CLI verification. The resulting diff was reviewed before submission.
