### PR TITLE
 fix(frontend): constrain custom model test errors to modal

### DIFF
--- a/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/index.tsx
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/index.tsx
@@ -181,7 +181,10 @@ export default function AIModelConfigModal({ open, onClose, onChanged }: AIModel
     } catch (error: any) {
       modal.error({
         title: i18n('setting.modelConfig.testFailed'),
-        content: error?.errorMessage || error?.message || String(error),
+        content: (
+          <pre className={styles.testResult}>{error?.errorMessage || error?.message || String(error)}</pre>
+        ),
+        width: 680,
       });
     } finally {
       setTesting(false);

--- a/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/style.ts
+++ b/chat2db-community-client/src/blocks/AI/components/AIModelConfigModal/style.ts
@@ -117,6 +117,7 @@ export const useStyles = createStyles(({ css, token }) => {
     `,
     testResult: css`
       max-height: 320px;
+      overflow-y: auto;
       margin: 0;
       white-space: pre-wrap;
       word-break: break-word;


### PR DESCRIPTION
 ## Related issue

  Closes #2872

  ## Summary

  Constrain long custom model connection-test error responses to the modal
  boundary.

  Previously, error responses such as complete HTML pages could continue
  rendering below the modal. This change makes the error details vertically
  scrollable after reaching the existing maximum height.

  It also applies the same formatted error container and modal width to
  errors raised by the request itself, keeping both failure paths visually
  consistent.

  ## Affected surfaces

  - [x] Frontend / Web
  - [ ] Backend / API / Storage
  - [ ] Database plugin / Driver
  - [ ] JCEF / Desktop packaging
  - [ ] CI / Build / Release
  - [ ] Documentation only

  ## Verification

  - Commands and results:
    - `corepack yarn run test:ai-model-config` — passed
    - `corepack yarn run lint` — passed
    - `corepack yarn run build:web:community --app_version=0.0.0` — passed,
    including the configured pre-build regression tests and production bundle
    verification
    - `git diff --check` — passed
  - Manual verification:
    - Triggered a custom model connection failure with a long HTML response.
    - Confirmed that the error details remain inside the modal and can be
    viewed using the internal vertical scrollbar.
  - UI evidence:
    - Before: see the reproduction screenshot in #2872.
    - After:

<img width="959" height="586" alt="image" src="https://github.com/user-attachments/assets/3f5af9e3-6139-4b9b-b478-e9aff7dbae77" />


  ## Risk and compatibility

  - Public API or stored data: N/A — this change only affects error
  presentation in the frontend.
  - Database or driver compatibility: N/A — no database or driver behavior
  changed.
  - Network, privacy, or security: No network behavior changed. The existing
  error response is only displayed inside a bounded, scrollable container.
  - Community / Local / Pro boundary: No edition detection or product
  boundary behavior changed.
  - Backward compatibility: Fully compatible; no API, storage, configuration,
  or migration changes are required.

  ## Reviewer map

  - Start here: `chat2db-community-client/src/blocks/AI/components/
  AIModelConfigModal/style.ts`, particularly the `testResult` overflow
  behavior. Then review the request exception path in `index.tsx`.
  - Failure condition: Long connection-test responses render outside the
  modal, or request exceptions do not use the same bounded error
  presentation.
  - Rollback or disable path: Revert this PR. No data or configuration
  rollback is required.

  ## Contributor declaration

  - [x] I linked the Issue that defines this change.
  - [x] I tested the affected behavior and reported the actual results above.
  - [x] I did not include credentials, private data, or generated build
  output.
  - [x] I disclosed substantial AI assistance below, or this PR contains no
  substantial AI-generated code.

  AI assistance: OpenAI Codex was used to diagnose the overflow behavior,
  implement the scoped frontend fix, and help prepare verification and PR
  documentation. The resulting diff and verification output were reviewed by
  the contributor.