### PR TITLE
fix(spi): preserve JDBC transaction ownership in batch imports

### DIFF
--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java
@@ -1730,6 +1730,11 @@ public class DefaultSQLExecutor implements ICommandExecutor {
         return false;
     }
 
+    /**
+     * Statements per JDBC batch executed by {@link #executeBatchInsert}.
+     */
+    public static final int BATCH_INSERT_CHUNK_SIZE = 500;
+
     public void executeBatchInsert(Connection connection, List<String> sqlCacheList) {
         executeBatchInsert(connection, sqlCacheList, null, null);
     }
@@ -1737,21 +1742,93 @@ public class DefaultSQLExecutor implements ICommandExecutor {
     public void executeBatchInsert(Connection connection, List<String> sqlCacheList,
                                    ISqlExecutionStatementListener statementListener,
                                    Runnable cancellationChecker) {
+        if (sqlCacheList == null || sqlCacheList.isEmpty()) {
+            return;
+        }
+        boolean manageTransaction;
         try {
-            for (String sql : sqlCacheList) {
+            manageTransaction = connection.getAutoCommit();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        boolean transactionStarted = false;
+        boolean chunkOpen = false;
+        boolean discardRequired = false;
+        Exception failure = null;
+        try {
+            if (manageTransaction) {
+                connection.setAutoCommit(false);
+                transactionStarted = true;
+            }
+            for (int start = 0; start < sqlCacheList.size(); start += BATCH_INSERT_CHUNK_SIZE) {
+                chunkOpen = manageTransaction;
                 checkTaskCancellation(cancellationChecker);
-                PreparedStatement stmt = connection.prepareStatement(sql);
-                try (stmt) {
-                    notifyStatementCreated(statementListener, stmt);
-                    checkTaskCancellation(cancellationChecker);
-                    stmt.executeUpdate();
-                } finally {
-                    notifyStatementClosed(statementListener, stmt);
+                List<String> chunk = sqlCacheList.subList(start,
+                        Math.min(sqlCacheList.size(), start + BATCH_INSERT_CHUNK_SIZE));
+                executeInsertChunk(connection, chunk, statementListener, cancellationChecker);
+                if (manageTransaction) {
+                    connection.commit();
+                    chunkOpen = false;
                 }
             }
-        } catch (SQLException e) {
-            checkTaskCancellation(cancellationChecker);
-            throw new RuntimeException(e);
+        } catch (Exception e) {
+            failure = e;
+        }
+
+        if (failure != null && chunkOpen) {
+            try {
+                connection.rollback();
+            } catch (SQLException rollbackFailure) {
+                failure.addSuppressed(rollbackFailure);
+                discardRequired = true;
+            }
+        }
+
+        if (transactionStarted && !discardRequired) {
+            try {
+                connection.setAutoCommit(true);
+            } catch (SQLException restoreFailure) {
+                if (failure == null) {
+                    failure = restoreFailure;
+                } else {
+                    failure.addSuppressed(restoreFailure);
+                }
+                discardRequired = true;
+            }
+        }
+
+        if (discardRequired) {
+            discardConnection(connection, failure);
+        }
+        if (failure != null) {
+            try {
+                checkTaskCancellation(cancellationChecker);
+            } catch (RuntimeException cancellation) {
+                if (cancellation != failure) {
+                    cancellation.addSuppressed(failure);
+                }
+                throw cancellation;
+            }
+            throw failure instanceof RuntimeException runtime
+                    ? runtime : new RuntimeException(failure);
+        }
+    }
+
+    private void executeInsertChunk(Connection connection, List<String> chunk,
+                                    ISqlExecutionStatementListener statementListener,
+                                    Runnable cancellationChecker) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            notifyStatementCreated(statementListener, statement);
+            try {
+                checkTaskCancellation(cancellationChecker);
+                for (String sql : chunk) {
+                    statement.addBatch(sql);
+                }
+                statement.executeBatch();
+            } finally {
+                notifyStatementClosed(statementListener, statement);
+            }
         }
     }
 

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/sql/DefaultSQLExecutorTaskCancellationTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/sql/DefaultSQLExecutorTaskCancellationTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,55 +44,68 @@ class DefaultSQLExecutorTaskCancellationTest {
     }
 
     @Test
-    void cancellationBeforeNextPrepareStopsRemainingBatch() throws Exception {
+    void cancellationBetweenChunksStopsTheRemainingChunks() throws Exception {
+        // 501 rows forces two chunks with the 500-statement chunk size.
+        List<String> sqls = new java.util.ArrayList<>();
+        for (int value = 1; value <= 501; value++) {
+            sqls.add("INSERT INTO records VALUES (" + value + ")");
+        }
         try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:cancel_batch;DB_CLOSE_DELAY=-1")) {
             createTable(connection);
             AtomicInteger checks = new AtomicInteger();
             CountingStatementListener listener = new CountingStatementListener();
 
             assertThrows(CancellationException.class,
-                    () -> DefaultSQLExecutor.getInstance().executeBatchInsert(connection, List.of(
-                                    "INSERT INTO records VALUES (1)",
-                                    "INSERT INTO records VALUES (2)"),
+                    () -> DefaultSQLExecutor.getInstance().executeBatchInsert(connection, sqls,
                             listener, () -> {
                                 if (checks.incrementAndGet() >= 3) {
-                                    throw new CancellationException("cancelled between statements");
+                                    throw new CancellationException("cancelled between chunks");
                                 }
                             }));
 
-            assertEquals(1, countRows(connection));
+            assertEquals(500, countRows(connection));
             assertEquals(1, listener.created.get());
             assertEquals(1, listener.closed.get());
         }
     }
 
     @Test
-    void stopCancelsExecutingStatementAndPreventsNextStatement() throws Exception {
-        AtomicInteger prepareCalls = new AtomicInteger();
-        AtomicInteger executeCalls = new AtomicInteger();
+    void stopCancelsExecutingBatchAndPreventsTheNextChunk() throws Exception {
+        List<String> sqls = new java.util.ArrayList<>();
+        for (int value = 1; value <= 501; value++) {
+            sqls.add("INSERT INTO records VALUES (" + value + ")");
+        }
+        AtomicInteger createCalls = new AtomicInteger();
         AtomicInteger cancelCalls = new AtomicInteger();
         CountDownLatch executeStarted = new CountDownLatch(1);
-        CountDownLatch cancelled = new CountDownLatch(1);
-        PreparedStatement statement = blockingStatement(executeCalls, cancelCalls, executeStarted, cancelled);
-        Connection connection = connection(statement, prepareCalls);
         TestCancellation cancellation = new TestCancellation();
         ExecutorService executor = Executors.newSingleThreadExecutor();
 
-        try {
-            var execution = executor.submit(() -> DefaultSQLExecutor.getInstance().executeBatchInsert(
-                    connection, List.of("first", "second"), cancellation, cancellation::checkCancelled));
-            assertTrue(executeStarted.await(5, TimeUnit.SECONDS), "statement did not start executing");
+        try (Connection real = DriverManager.getConnection("jdbc:h2:mem:cancel_running;DB_CLOSE_DELAY=-1")) {
+            createTable(real);
+            Connection connection = (Connection) Proxy.newProxyInstance(
+                    DefaultSQLExecutorTaskCancellationTest.class.getClassLoader(),
+                    new Class<?>[]{Connection.class}, (proxy, method, args) -> {
+                        Object value = method.invoke(real, args);
+                        if ("createStatement".equals(method.getName()) && value instanceof Statement statement) {
+                            createCalls.incrementAndGet();
+                            value = blockingStatement(statement, cancelCalls, executeStarted);
+                        }
+                        return value;
+                    });
+
+            var execution = executor.submit(
+                    () -> DefaultSQLExecutor.getInstance().executeBatchInsert(connection, sqls,
+                            cancellation, cancellation::checkCancelled));
+            assertTrue(executeStarted.await(5, TimeUnit.SECONDS), "batch did not start executing");
 
             assertTrue(cancellation.stop());
 
-            ExecutionException failure = assertThrows(ExecutionException.class,
-                    () -> execution.get(5, TimeUnit.SECONDS));
-            assertInstanceOf(CancellationException.class, failure.getCause());
-            assertEquals(1, prepareCalls.get());
-            assertEquals(1, executeCalls.get());
+            assertThrows(ExecutionException.class, () -> execution.get(10, TimeUnit.SECONDS));
+            assertEquals(1, createCalls.get(), "the second chunk must never open a statement");
             assertEquals(1, cancelCalls.get());
+            assertEquals(0, countRows(real), "the cancelled chunk rolls back with its transaction");
         } finally {
-            cancelled.countDown();
             executor.shutdownNow();
         }
     }
@@ -129,6 +143,43 @@ class DefaultSQLExecutorTaskCancellationTest {
         }
     }
 
+    @Test
+    void callerOwnedTransactionKeepsAutoCommitDisabled() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:caller_owned")) {
+            createTable(connection);
+            connection.setAutoCommit(false);
+            DefaultSQLExecutor.getInstance().executeBatchInsert(connection,
+                    List.of("INSERT INTO records VALUES (1)"));
+            assertFalse(connection.getAutoCommit());
+            connection.rollback();
+            assertEquals(0, countRows(connection));
+        }
+    }
+
+    @Test
+    void failedBatchDoesNotRollbackCallerOwnedWork() throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                "jdbc:h2:mem:caller_owned_failure")) {
+            createTable(connection);
+            connection.setAutoCommit(false);
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("INSERT INTO records VALUES (99)");
+            }
+            assertThrows(RuntimeException.class,
+                    () -> DefaultSQLExecutor.getInstance().executeBatchInsert(connection,
+                            List.of("INSERT INTO records VALUES (1)",
+                                    "INSERT INTO records VALUES (1)")));
+            assertFalse(connection.getAutoCommit());
+            try (Statement statement = connection.createStatement();
+                 ResultSet resultSet = statement.executeQuery(
+                         "SELECT COUNT(*) FROM records WHERE id = 99")) {
+                resultSet.next();
+                assertEquals(1, resultSet.getInt(1));
+            }
+            connection.rollback();
+        }
+    }
+
     private static void createTable(Connection connection) throws SQLException {
         try (Statement statement = connection.createStatement()) {
             statement.execute("CREATE TABLE records(id INT PRIMARY KEY)");
@@ -143,28 +194,15 @@ class DefaultSQLExecutorTaskCancellationTest {
         }
     }
 
-    private static Connection connection(PreparedStatement statement, AtomicInteger prepareCalls) {
-        return (Connection) Proxy.newProxyInstance(
+    private static Statement blockingStatement(Statement real, AtomicInteger cancelCalls,
+            CountDownLatch executeStarted) {
+        CountDownLatch cancelled = new CountDownLatch(1);
+        return (Statement) Proxy.newProxyInstance(
                 DefaultSQLExecutorTaskCancellationTest.class.getClassLoader(),
-                new Class<?>[]{Connection.class}, (proxy, method, args) -> {
-                    if ("prepareStatement".equals(method.getName())) {
-                        prepareCalls.incrementAndGet();
-                        return statement;
-                    }
-                    return defaultValue(method.getReturnType());
-                });
-    }
-
-    private static PreparedStatement blockingStatement(
-            AtomicInteger executeCalls, AtomicInteger cancelCalls,
-            CountDownLatch executeStarted, CountDownLatch cancelled) {
-        return (PreparedStatement) Proxy.newProxyInstance(
-                DefaultSQLExecutorTaskCancellationTest.class.getClassLoader(),
-                new Class<?>[]{PreparedStatement.class}, (proxy, method, args) -> {
-                    if ("executeUpdate".equals(method.getName())) {
-                        executeCalls.incrementAndGet();
+                new Class<?>[]{Statement.class}, (proxy, method, args) -> {
+                    if ("executeBatch".equals(method.getName())) {
                         executeStarted.countDown();
-                        if (!cancelled.await(5, TimeUnit.SECONDS)) {
+                        if (!cancelled.await(10, TimeUnit.SECONDS)) {
                             throw new SQLException("timed out waiting for cancellation");
                         }
                         throw new SQLException("statement cancelled");
@@ -172,8 +210,9 @@ class DefaultSQLExecutorTaskCancellationTest {
                     if ("cancel".equals(method.getName())) {
                         cancelCalls.incrementAndGet();
                         cancelled.countDown();
+                        return null;
                     }
-                    return defaultValue(method.getReturnType());
+                    return method.invoke(real, args);
                 });
     }
 


### PR DESCRIPTION
## Related issue

N/A. Review unit 1 of 7 for the split import/export contribution.

Rebased onto official `main` at `e83b5a185aa7b70b7dd9848934f23dc2e8b1f11b`. Each numbered branch contains one additional semantic commit over its predecessor. Official submissions remain sequential: the next official PR is submitted after the previous one merges.

## Summary

Preserve JDBC transaction ownership in batch imports. The executor processes bounded chunks, commits and rolls back only transactions it opened, preserves caller-managed transactions, and discards connections whose state cannot be restored safely.

This PR contains only the shared SPI transaction boundary. Import tasks, storage, exporters, database opt-ins, and frontend changes remain in later review units.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- `DefaultSQLExecutorTaskCancellationTest` and `DefaultSQLExecutorTransactionTest`: 13 tests, 0 failures, 0 errors, 0 skips.
- Reviewed cancellation precedence, rollback failure handling, transaction ownership, and connection restoration.
- Maven tests ran with Java 17, `-Dmaven.test.skip=false -DskipTests=false`, explicit `-Dtest` selectors, `-Dsurefire.failIfNoSpecifiedTests=false`, and `-Dmaven.test.failure.ignore=false`.
- The final stack packaged successfully across all 48 backend reactor modules with `mvn -B -f chat2db-community-server/pom.xml -pl chat2db-community-start -am -Dmaven.test.skip=true -Dchat2db.finalName=chat2db-community package`. This package command skipped tests; the focused tests below ran separately.
- `git diff --check` passed.

## Risk and compatibility

No public API or storage schema change. Caller-owned transactions remain caller-owned. No Community runtime, network, or credential behavior changes. Community runtime identity, loopback binding, and offline defaults are preserved.

## Reviewer map

- Start here: `chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultSQLExecutor.java`
- Failure condition: The executor commits or rolls back a caller-owned transaction, masks cancellation, or returns an unusable connection to the pool.
- Rollback: Revert this semantic commit before accepting dependent batches.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below.

AI assistance: Substantial AI assistance was used for implementation, test design, review, and commit decomposition. Maintainer review is required.

