### PR TITLE
fix(result-set): isolate table edits from query execution options

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -52,7 +52,7 @@
     "test:label-rotation": "tsx src/blocks/BI/Chart/components/EChartsContainer/hooks/useLabelRotate.test.ts",
     "test:redis-explorer": "tsx src/blocks/RedisAllData/redisExplorer.test.ts",
     "test:result-markdown": "tsx src/blocks/SearchResult/components/ResultSetTable/event/onContextmenuCell/handleCopyAsMarkdown.test.ts",
-    "test:result-set-ui": "tsx src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts",
+    "test:result-set-ui": "tsx src/blocks/SearchResult/components/ResultSet/resultSetUi.test.ts && tsx src/blocks/SearchResult/components/SQLPreviewExecute/updateSql.test.ts",
     "test:result-table-layout": "tsx src/blocks/SearchResult/components/ResultSetTable/layoutOptions.test.ts && tsx src/blocks/SearchResult/components/ResultSetTable/rowHeight.test.ts",
     "test:result-status": "tsx src/blocks/SearchResult/components/StatusBar/resultSummary.test.ts",
     "test:runtime-storage": "tsx src/store/indexDB/storageKey.test.ts && tsx src/pages/main/workspace/components/WorkspaceLeft/desktopBridge.test.ts",

--- a/chat2db-community-client/src/blocks/SearchResult/components/SQLPreviewExecute/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/SQLPreviewExecute/index.tsx
@@ -4,7 +4,6 @@ import { Modal } from 'antd';
 import i18n from '@/i18n';
 import ExecuteSQL, { IExecuteSQLRef } from '@/components/ExecuteSQL';
 import executeSql from '@/service/executeSql';
-import useSqlExecutor from '@/hooks/useSqlExecutor';
 import { getRequestErrorMessage, resolveUpdateExecuteParams } from './updateSql';
 
 interface IProps {
@@ -26,15 +25,8 @@ const SQLPreviewExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLPrevie
   const [executeSqlParams, setExecuteSqlParams] = useState<any>(null);
   const executeSQLRef = useRef<IExecuteSQLRef>();
   const executePendingRef = useRef(false);
-  const { executeSQL, canExecuteSQL } = useSqlExecutor();
 
   const getUpdateDataSql = ({ operations, resultData }) => {
-    if (!operations.length) {
-      return Promise.resolve({
-        ...(resultData.executeSqlParams || {}),
-        sql: '',
-      });
-    }
     return resolveUpdateExecuteParams({
       operations,
       resultData,
@@ -52,21 +44,21 @@ const SQLPreviewExecute = forwardRef((props: IProps, ref: ForwardedRef<SQLPrevie
   };
 
   const handleExecuteSql = ({ operations, resultData, callback }) => {
-    if (executePendingRef.current || !canExecuteSQL()) {
+    if (executePendingRef.current) {
       return;
     }
     executePendingRef.current = true;
     callback?.(true);
     Promise.resolve()
       .then(() => getUpdateDataSql({ operations, resultData }))
-      .then((res) => executeSQL(res))
+      .then((res) => executeSql.executeUpdateDataSql(res))
       .then((_res) => {
-        if (_res?.[0]?.success === true) {
+        if (_res?.success === true) {
           onExecuteSuccess?.();
           setViewUpdateDataSqlModal(false);
           setUpdateDataSql('');
         } else {
-          onExecuteError?.(_res?.[0]?.message || '');
+          onExecuteError?.(_res?.message || '');
         }
       })
       .catch((error) => {

--- a/chat2db-community-client/src/blocks/SearchResult/components/SQLPreviewExecute/updateSql.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/SQLPreviewExecute/updateSql.test.ts
@@ -22,6 +22,15 @@ const resultData = {
     databaseType: 'MYSQL',
     dataSourceId: 46,
     databaseName: 'enterprise_gateway_dev',
+    schemaName: 'test_schema',
+    sql: 'SELECT * FROM ai_chat_message',
+    single: true,
+    explain: true,
+    errorContinue: true,
+    pageNo: 3,
+    pageSize: 50,
+    consoleId: 12,
+    applyId: 13,
     resultSetId: 1,
   },
   dataList: [
@@ -58,12 +67,14 @@ assertEqual(
 assertEqual(
   buildUpdateSqlRequestParams([operationWithOldDataList], resultData),
   {
-    ...resultData.executeSqlParams,
+    dataSourceId: 46,
+    databaseName: 'enterprise_gateway_dev',
+    schemaName: 'test_schema',
     tableName: 'ai_chat_message',
     headerList: resultData.headerList,
     operations: [operationWithOldDataList],
   },
-  'update SQL request keeps table metadata and operation payload together',
+  'update SQL generation uses connection context and table edits without query execution options',
 );
 
 assertEqual(
@@ -99,6 +110,49 @@ async function main() {
     `UPDATE ai_chat_message set \`content\` = '${changedMultilineSql}' where \`id\` = '42' LIMIT 1;`,
     'resolved execute params keep the full multiline generated SQL',
   );
+
+  assertEqual(
+    resolved,
+    {
+      dataSourceId: 46,
+      databaseName: 'enterprise_gateway_dev',
+      schemaName: 'test_schema',
+      sql: resolved.sql,
+    },
+    'table edits only inherit connection context from the original query',
+  );
+
+  const batchSql = 'UPDATE example_table SET value = 904 WHERE id = 1;\nUPDATE example_table SET value = 904 WHERE id = 2;';
+  const batch = await resolveUpdateExecuteParams({
+    operations: [operationWithOldDataList, { ...operationWithOldDataList, rowId: 'row-2' }],
+    resultData,
+    getUpdateDataSql: async () => batchSql,
+  });
+  assertEqual(
+    batch,
+    { dataSourceId: 46, databaseName: 'enterprise_gateway_dev', schemaName: 'test_schema', sql: batchSql },
+    'multi-row edits preserve the generated script without inheriting single-statement mode',
+  );
+
+  const empty = await resolveUpdateExecuteParams({
+    operations: [],
+    resultData,
+    getUpdateDataSql: async () => { throw new Error('empty edits must not request SQL generation'); },
+  });
+  assertEqual(empty.sql, '', 'empty edits do not execute the original query');
+
+  let generationCalled = false;
+  try {
+    await resolveUpdateExecuteParams({
+      operations: [operationWithOldDataList],
+      resultData: { ...resultData, executeSqlParams: undefined },
+      getUpdateDataSql: async () => { generationCalled = true; return batchSql; },
+    });
+    throw new Error('missing connection context must be rejected');
+  } catch (error) {
+    assertEqual(getRequestErrorMessage(error), 'dataSourceId is required', 'missing connection is rejected');
+  }
+  assertEqual(generationCalled, false, 'missing connection cannot generate or execute SQL');
 
   console.log('SQLPreviewExecute update SQL tests passed');
 }

--- a/chat2db-community-client/src/blocks/SearchResult/components/SQLPreviewExecute/updateSql.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/SQLPreviewExecute/updateSql.ts
@@ -1,3 +1,5 @@
+import type { IDataSourceExecutionContext, ITableEditExecuteRequest } from '@/service/dmlRequest';
+
 export interface UpdateSqlOperation {
   rowId?: string | number;
   type?: string;
@@ -9,7 +11,7 @@ export interface UpdateSqlResultData {
   tableName?: string;
   headerList?: any[];
   dataList?: Array<Array<{ value?: any } | null | undefined>>;
-  executeSqlParams?: Record<string, any>;
+  executeSqlParams?: Partial<IDataSourceExecutionContext>;
 }
 
 export function appendMissingOldDataList(operations: UpdateSqlOperation[], resultData: UpdateSqlResultData) {
@@ -26,8 +28,14 @@ export function appendMissingOldDataList(operations: UpdateSqlOperation[], resul
 }
 
 export function buildUpdateSqlRequestParams(operations: UpdateSqlOperation[], resultData: UpdateSqlResultData) {
+  const { dataSourceId, databaseName, schemaName } = resultData.executeSqlParams || {};
+  if (dataSourceId == null) {
+    throw new Error('dataSourceId is required');
+  }
   return {
-    ...(resultData.executeSqlParams || {}),
+    dataSourceId,
+    databaseName,
+    schemaName,
     tableName: resultData.tableName,
     headerList: resultData.headerList,
     operations: appendMissingOldDataList(operations, resultData),
@@ -38,10 +46,13 @@ export async function resolveUpdateExecuteParams(params: {
   operations: UpdateSqlOperation[];
   resultData: UpdateSqlResultData;
   getUpdateDataSql: (requestParams: any) => Promise<string>;
-}) {
-  const sql = await params.getUpdateDataSql(buildUpdateSqlRequestParams(params.operations, params.resultData));
+}): Promise<ITableEditExecuteRequest> {
+  const request = buildUpdateSqlRequestParams(params.operations, params.resultData);
+  const sql = params.operations.length ? await params.getUpdateDataSql(request) : '';
   return {
-    ...(params.resultData.executeSqlParams || {}),
+    dataSourceId: request.dataSourceId,
+    databaseName: request.databaseName,
+    schemaName: request.schemaName,
     sql,
   };
 }

--- a/chat2db-community-client/src/service/executeSql.ts
+++ b/chat2db-community-client/src/service/executeSql.ts
@@ -75,7 +75,7 @@ const executeUpdateDataSql = createRequest<
   { success: boolean; message: string; sql: string }
 >(
   '/api/rdb/dml/execute_update',
-  { method: 'post', errorLevel: false },
+  { method: 'post', errorLevel: false, timeout: false },
 );
 
 const viewTable = createRequest<ITableBrowseRequest, IManageResultData[]>('/api/rdb/dml/execute_table', {


### PR DESCRIPTION
<!--
Thank you for contributing to Chat2DB.

PR title: type(scope): concise summary
Keep every section below. Use N/A when a section does not apply.
Do not include credentials, private URLs, production data, or generated build output.
-->

## Related issue

Closes #2876

## Summary

Editing multiple rows in a result produced by a current-statement query could inherit `single=true`, causing the generated updates to be sent as one statement. This fails on MySQL connections with multi-statement execution disabled while the same SQL succeeds when run as a script in the editor.

Build result-edit requests from datasource, database and schema context only, and use the existing table-edit update API for direct submission, matching SQL-preview execution. Preserve pending-request protection and the direct desktop submission's disabled timeout. Add parameter-isolation regression coverage to the existing result-set test command.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

The CI/build change only adds the regression test to an existing package script; no workflow or packaging implementation changes.

## Verification

- Commands and results: `yarn test:result-set-ui`, `yarn lint`, `yarn run build:web:community --app_version=0.0.0`, and `git diff --check` passed locally. The result-set tests and lint were also run in the isolated PR worktree.
- Manual verification: Playwright CLI against a disposable Community backend and MySQL with `allowMultiQueries=false`. Verified current-statement SELECT (`single=true`), two-row updates, direct and SQL-preview execution, preview cancellation without a write, second-statement failure feedback with edits retained, rapid double-click producing exactly one request, Cmd+S submission, and values after refresh. Inspected request bodies, responses and actual database rows; browser console had no errors. All temporary browser/server/database fixtures were removed.
- UI evidence: No layout change. Runtime screenshots were inspected during verification and removed with the temporary fixtures. Network evidence showed the update request contained only `dataSourceId`, `databaseName` and the generated SQL for the tested schema-less connection; no query execution options were forwarded.

## Risk and compatibility

- Public API or stored data: Reuses the existing `/api/rdb/dml/execute_update` contract; no schema or stored-data migration.
- Database or driver compatibility: Shared frontend behavior, with no database-specific branch. MySQL was exercised against a real driver; other database engines were not individually retested. The existing update endpoint executes statements sequentially and may retain earlier successful writes if a later statement fails; this PR does not add a transaction guarantee.
- Network, privacy, or security: No new external destination or credential handling. Query execution flags and identifiers are not forwarded to result editing.
- Community / Local / Pro boundary: Shared Community frontend used by Studio. No commercial implementation or runtime-boundary changes; synchronize Studio's Community source lock after merge.
- Backward compatibility: Uses an API already used by the SQL-preview dialog. Native Windows packaging was not rerun for this frontend change.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/SearchResult/components/SQLPreviewExecute/updateSql.ts` for the explicit request boundary, then `index.tsx` for the dedicated execution API. `src/service/executeSql.ts` retains the direct desktop submission timeout behavior.
- Failure condition: Start with a result from `single=true`, edit at least two rows, and ensure neither SQL generation nor execution inherits `single`, pagination, `explain`, `errorContinue`, console, approval or result identifiers. A later-statement failure must not report success.
- Rollback or disable path: Revert this PR; no data migration or configuration rollback is required.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex implemented the change and performed source review, automated checks and Playwright CLI verification under maintainer direction.
