### PR TITLE
fix(ui): enable horizontal scrolling in filter popovers

### DIFF
--- a/chat2db-community-client/src/components/NodeFiltering/index.tsx
+++ b/chat2db-community-client/src/components/NodeFiltering/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { Tree, Checkbox } from 'antd';
 import SearchBar from '@/components/SearchBar';
 import { useStyles } from './style';
@@ -30,10 +30,23 @@ export interface NodeFilteringRef {
 const NodeFiltering = (props: IProps) => {
   const { data, filterTitle, selectedKeys, onChangeSelect } = props;
   const { styles } = useStyles();
+  const treeBoxRef = useRef<HTMLDivElement>(null);
+  // rc-virtual-list enables horizontal wheel handling from the initial scrollWidth.
+  const [scrollWidth, setScrollWidth] = useState(1);
   const [treeData, setTreeData] = useState<IData[]>(data);
   const [checkedKeys, setCheckedKeys] = useState<string[]>(
     selectedKeys?.map((item) => createChat2dbSpecificSymbolIdentifier(item)) || [],
   );
+
+  const measureScrollWidth = () => {
+    const nodes = treeBoxRef.current?.querySelectorAll<HTMLElement>('.ant-tree-treenode');
+    return Array.from(nodes || []).reduce((width, node) => Math.max(width, node.scrollWidth), 1);
+  };
+
+  useLayoutEffect(() => {
+    const frame = requestAnimationFrame(() => setScrollWidth(measureScrollWidth()));
+    return () => cancelAnimationFrame(frame);
+  }, [treeData]);
 
   const onCheck = (_checkedKeys, halfChecked) => {
     const { key, checked } = halfChecked.node;
@@ -129,10 +142,12 @@ const NodeFiltering = (props: IProps) => {
             {i18n('workspace.text.clearFilter')}
           </div>
         </div>
-        <div className={styles.treeBox}>
+        <div ref={treeBoxRef} className={styles.treeBox}>
           {!!treeData?.length && (
             <Tree
               height={279}
+              scrollWidth={scrollWidth}
+              onScroll={() => setScrollWidth((width) => Math.max(width, measureScrollWidth()))}
               className={styles.treeSelect}
               checkable
               switcherIcon={null}

--- a/chat2db-community-client/src/components/NodeFiltering/style.tsx
+++ b/chat2db-community-client/src/components/NodeFiltering/style.tsx
@@ -64,6 +64,7 @@ export const useStyles = createStyles(({ css, token }) => {
       padding: 0px 8px;
       display: flex;
       align-items: center;
+      white-space: nowrap;
     `,
     treeTitleCount: css`
       color: ${token.colorTextSecondary};


### PR DESCRIPTION
<!--
Thank you for contributing to Chat2DB.

PR title: type(scope): concise summary
Keep every section below. Use N/A when a section does not apply.
Do not include credentials, private URLs, production data, or generated build output.
-->

## Related issue

N/A - requested and manually accepted by the maintainer.

<!-- Link the approved Issue that defines the problem or requirement. -->

## Summary

Long database, schema, and result-filter values were clipped inside the filter popover. Enable the Tree's horizontal scrolling so their full text can be inspected while the search and selection controls stay fixed.

Measure rendered rows after filtering, extend the scroll range when longer virtualized rows appear, and keep horizontal wheel handling enabled from the first render. Labels remain on one line and vertical virtualization is preserved.

## Affected surfaces

<!-- Check every surface affected by this PR. -->

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

<!--
Provide exact commands and their results, plus any manual verification.
For UI changes, attach before/after screenshots or a short recording.
-->

- Commands and results:
  - `yarn install --frozen-lockfile --offline`: passed in the isolated PR worktree.
  - `yarn run lint`: passed in the isolated PR worktree.
  - `yarn run build:web:community --app_version=0.0.0`: passed, including the configured prebuild tests and production bundle checks, in the isolated PR worktree.
  - `git diff --check`: passed.
- Manual verification: Maintainer accepted the change in Community Web. Playwright CLI checks on the actual filter component passed for first-open horizontal wheel scrolling, Shift+wheel, scrollbar dragging, longer rows reached by vertical scrolling, fixed header geometry, narrow viewport overflow, selection, select all, clearing, search range reduction, and recovery from empty search results. The isolated component harness substituted the search input and translation lookup; it did not validate backend persistence.
- UI evidence: N/A - temporary Playwright screenshots were inspected locally and cleaned up after verification; no screenshots are retained for attachment.

## Risk and compatibility

<!-- Describe only the applicable risks. Use N/A with a short reason for the rest. -->

- Public API or stored data: N/A - no API or persistence changes.
- Database or driver compatibility: N/A - no database or driver changes.
- Network, privacy, or security: N/A - no network or permission changes.
- Community / Local / Pro boundary: N/A - no product-boundary changes.
- Backward compatibility: The shared filter component also serves result column filters. Existing selection callbacks and vertical virtualization remain unchanged. Width measurement uses the current Ant Design Tree row markup.

## Reviewer map

<!-- Point reviewers to the load-bearing change and provide an operational handoff. -->

- Start here: `chat2db-community-client/src/components/NodeFiltering/index.tsx` for measurement and the Tree `scrollWidth` prop; `style.tsx` for single-line labels.
- Failure condition: A long name cannot scroll fully into view, the header moves horizontally, or filtering to short values leaves an unnecessary horizontal scrollbar.
- Rollback or disable path: Revert this commit; no migration is needed.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex implemented the change and ran the reported automated checks. The maintainer reviewed the Community Web behavior.
