### PR TITLE
fix(kingbase): export table DDL from catalog metadata

### DIFF
--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/KingBaseMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/KingBaseMetaData.java
@@ -236,6 +236,7 @@ public class KingBaseMetaData extends DefaultMetaService implements IDbMetaData 
                     }
                     return parentTableInfo;
                 });
+        StringBuilder autoIncrementDDL = new StringBuilder();
         int columnCount;
         if (!partitionInfo[0]) {
             columnCount = DefaultSQLExecutor.getInstance().preExecute(connection, COLUMN_SQL, new String[]{schemaName, tableName}, resultSet -> {
@@ -256,7 +257,9 @@ public class KingBaseMetaData extends DefaultMetaService implements IDbMetaData 
                     String identity = attributes.contains("attidentity") ? resultSet.getString("attidentity") : "";
                     String generated = attributes.contains("attgenerated") ? resultSet.getString("attgenerated") : "";
                     ddlBuilder.append("\t").append(format(columnName)).append("  \t").append(dataType);
-                    if (StringUtils.isNotBlank(identity)) {
+                    if ("i".equals(identity)) {
+                        appendAutoIncrement(connection, formatTableName, columnName, autoIncrementDDL);
+                    } else if (StringUtils.isNotBlank(identity)) {
                         String generation = switch (identity) {
                             case "a" -> "always";
                             case "d" -> "by default";
@@ -355,6 +358,7 @@ public class KingBaseMetaData extends DefaultMetaService implements IDbMetaData 
             });
         }
 
+        ddlBuilder.append(autoIncrementDDL);
         List<Table> tables = this.tables(connection, databaseName, schemaName, tableName);
         if (CollectionUtils.isNotEmpty(tables) && tables.size() == 1) {
             Table table = tables.get(0);
@@ -412,13 +416,45 @@ public class KingBaseMetaData extends DefaultMetaService implements IDbMetaData 
             if (!resultSet.next()) {
                 throw new SQLException("Identity sequence metadata is missing");
             }
-            ddl.append(" (start with ").append(resultSet.getLong("seqstart"))
-                    .append(" increment by ").append(resultSet.getLong("seqincrement"))
-                    .append(" minvalue ").append(resultSet.getLong("seqmin"))
-                    .append(" maxvalue ").append(resultSet.getLong("seqmax"))
-                    .append(" cache ").append(resultSet.getLong("seqcache"))
-                    .append(resultSet.getBoolean("seqcycle") ? " cycle)" : " no cycle)");
+            ddl.append(" (");
+            appendSequenceOptions(resultSet, ddl);
+            ddl.append(")");
         });
+    }
+
+    private void appendAutoIncrement(Connection connection, String tableName, String columnName, StringBuilder ddl) {
+        DefaultSQLExecutor.getInstance().preExecute(connection, IDENTITY_SEQUENCE_SQL, new String[]{tableName, columnName}, resultSet -> {
+            if (!resultSet.next()) {
+                throw new SQLException("Auto-increment sequence metadata is missing");
+            }
+            String sequenceName = getMetaDataName(resultSet.getString("sequence_schema"), resultSet.getString("sequence_name"));
+            // Match sys_dump: attach AUTO_INCREMENT after keys, then restore its current counter.
+            ddl.append("alter table ").append(tableName).append(" alter column ").append(format(columnName))
+                    .append(" add auto_increment (sequence name ").append(sequenceName).append(" ");
+            appendSequenceOptions(resultSet, ddl);
+            ddl.append(")");
+            DefaultSQLExecutor.getInstance().execute(connection, SEQUENCE_STATE_SQL.formatted(sequenceName), state -> {
+                if (!state.next()) {
+                    throw new SQLException("Auto-increment sequence state is missing");
+                }
+                long nextValue = state.getLong("next_value");
+                if (nextValue > 0) {
+                    ddl.append(", auto_increment = ").append(nextValue);
+                }
+                ddl.append(";\nselect pg_catalog.setval('").append(getSQLIdentifierProcessor().escapeString(sequenceName))
+                        .append("', ").append(state.getLong("last_value")).append(", ")
+                        .append(state.getBoolean("is_called")).append(");\n");
+            });
+        });
+    }
+
+    private void appendSequenceOptions(ResultSet resultSet, StringBuilder ddl) throws SQLException {
+        ddl.append("start with ").append(resultSet.getLong("seqstart"))
+                .append(" increment by ").append(resultSet.getLong("seqincrement"))
+                .append(" minvalue ").append(resultSet.getLong("seqmin"))
+                .append(" maxvalue ").append(resultSet.getLong("seqmax"))
+                .append(" cache ").append(resultSet.getLong("seqcache"))
+                .append(resultSet.getBoolean("seqcycle") ? " cycle" : " no cycle");
     }
 
     @Override

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/KingBaseMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/KingBaseMetaData.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -238,156 +239,43 @@ public class KingBaseMetaData extends DefaultMetaService implements IDbMetaData 
         int columnCount;
         if (!partitionInfo[0]) {
             columnCount = DefaultSQLExecutor.getInstance().preExecute(connection, COLUMN_SQL, new String[]{schemaName, tableName}, resultSet -> {
+                // Catalog attributes vary by server capability; a.* never references absent attributes.
+                Set<String> attributes = new HashSet<>();
+                ResultSetMetaData metadata = resultSet.getMetaData();
+                for (int i = 1; i <= metadata.getColumnCount(); i++) {
+                    attributes.add(metadata.getColumnLabel(i).toLowerCase(Locale.ROOT));
+                }
                 int total = 0;
                 while (resultSet.next()) {
-                    total++;
-                    String columnName = resultSet.getString("column_name");
+                    if (total++ > 0) {
+                        ddlBuilder.append(",\n");
+                    }
+                    String columnName = resultSet.getString("attname");
                     String dataType = resultSet.getString("data_type");
                     String columnDefault = resultSet.getString("column_default");
-                    String udtName = resultSet.getString("udt_name");
-                    String identityGeneration = resultSet.getString("identity_generation");
-                    boolean isNullable = "YES".equals(resultSet.getString("is_nullable"));
-                    boolean isIdentity = "YES".equals(resultSet.getString("is_identity"));
-                    int identityIncrement = resultSet.getInt("identity_increment");
-                    int identityStart = resultSet.getInt("identity_start");
-                    int characterMaximumLength = resultSet.getInt("character_maximum_length");
-                    int numericPrecision = resultSet.getInt("numeric_precision");
-                    int numericScale = resultSet.getInt("numeric_scale");
-                    int datetimePrecision = resultSet.getInt("datetime_precision");
-                    ddlBuilder.append("\t").append(columnName).append("  ").append("\t");
-
-
-                    if ("ARRAY".equals(dataType)) {
-                        if (udtName.contains(KingBaseColumnTypeEnum.INT4.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.INTEGER.getColumnType().getTypeName().toLowerCase()).append("[]");
-                        }
-
-
- else if (udtName.contains(KingBaseColumnTypeEnum.TEXT.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.TEXT.getColumnType().getTypeName().toLowerCase()).append("[]");
-                        }
-
- else if (udtName.substring(1).equals(KingBaseColumnTypeEnum.BIT.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.BIT.getColumnType().getTypeName().toLowerCase()).append("[]");
-                        } else if (udtName.substring(1).equals(KingBaseColumnTypeEnum.TIME.name().toLowerCase())) {
-                            ddlBuilder.append("time without time zone").append("[]");
-                        } else if (udtName.substring(1).equals(KingBaseColumnTypeEnum.TIMESTAMP.name().toLowerCase())) {
-                            ddlBuilder.append("timestamp without time zone").append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.TIMETZ.name().toLowerCase())) {
-                            ddlBuilder.append("time with time zone").append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.TIMESTAMPTZ.name().toLowerCase())) {
-                            ddlBuilder.append("timestamp with time zone").append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.PATH.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.PATH.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.POINT.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.POINT.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.LINE.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.LINE.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.BOX.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.BOX.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.LSEG.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.LSEG.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.POLYGON.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.POLYGON.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.CIRCLE.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.CIRCLE.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.CIDR.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.CIDR.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.INET.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.INET.name().toLowerCase()).append("[]");
-                        } else if (udtName.substring(1).equals(KingBaseColumnTypeEnum.MACADDR.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.MACADDR.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains("macaddr8")) {
-                            ddlBuilder.append("macaddr8").append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.XML.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.XML.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.TSQUERY.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.TSQUERY.name().toLowerCase()).append("[]");
-                        } else if (udtName.contains(KingBaseColumnTypeEnum.TSVECTOR.name().toLowerCase())) {
-                            ddlBuilder.append(KingBaseColumnTypeEnum.TSVECTOR.name().toLowerCase()).append("[]");
-                        } else {
-                            ddlBuilder.append(dataType);
-                        }
-                    } else if (dataType.equalsIgnoreCase("bpchar")) {
-                        ddlBuilder.append(KingBaseColumnTypeEnum.CHAR.name().toLowerCase());
-                        if (characterMaximumLength > 0 && characterMaximumLength != 1) {
-                            ddlBuilder.append("(").append(characterMaximumLength).append(")");
-                        }
-                    } else if (dataType.equalsIgnoreCase("pg_catalog.bit")) {
-                        ddlBuilder.append(KingBaseColumnTypeEnum.BIT.name().toLowerCase());
-                        if (characterMaximumLength > 0 && characterMaximumLength != 1) {
-                            ddlBuilder.append("(").append(characterMaximumLength).append(")");
-                        }
-                    } else if (KingBaseColumnTypeEnum.BIT.name().toLowerCase().equals(dataType)) {
-                        ddlBuilder.append(udtName);
-                        if (characterMaximumLength > 0 && characterMaximumLength != 1) {
-                            ddlBuilder.append("(").append(characterMaximumLength).append(")");
-                        }
-                    }
-
-
- else if ("USER-DEFINED".equals(dataType)) {
-                        dataType = format(udtName);
-                        ddlBuilder.append(dataType);
-
-                    } else if (KingBaseColumnTypeEnum.TIMETZ.getColumnType().getTypeName().toLowerCase().equals(udtName)) {
-                        if (datetimePrecision >= 0 && datetimePrecision != 6) {
-                            dataType = "time" + "(" + datetimePrecision + ")" + " with time zone";
-                        }
-                        ddlBuilder.append(dataType);
-
-                    } else if (KingBaseColumnTypeEnum.TIMESTAMPTZ.getColumnType().getTypeName().toLowerCase().equals(udtName)) {
-                        if (datetimePrecision >= 0 && datetimePrecision != 6) {
-                            dataType = "timestamp" + "(" + datetimePrecision + ")" + " with time zone";
-                        }
-                        ddlBuilder.append(dataType);
-                    } else if (KingBaseColumnTypeEnum.TIMESTAMP.name().toLowerCase().equals(udtName)) {
-                        ddlBuilder.append(udtName);
-                        if (datetimePrecision >= 0 && datetimePrecision != 6) {
-                            ddlBuilder.append("(").append(datetimePrecision).append(")");
-                        }
-                    } else if (KingBaseColumnTypeEnum.INTERVAL.name().toLowerCase().equals(udtName)) {
-                        ddlBuilder.append(udtName);
-                        if (datetimePrecision >= 0 && datetimePrecision != 6) {
-                            ddlBuilder.append("(").append(datetimePrecision).append(")");
-                        }
-                    } else if (KingBaseColumnTypeEnum.TIME.name().toLowerCase().equals(udtName)) {
-                        ddlBuilder.append(udtName);
-                        if (datetimePrecision >= 0 && datetimePrecision != 6) {
-                            ddlBuilder.append("(").append(datetimePrecision).append(")");
-                        }
-                    } else if (KingBaseColumnTypeEnum.CHARACTER.name().toLowerCase().equals(dataType)) {
-                        ddlBuilder.append(KingBaseColumnTypeEnum.CHAR.name().toLowerCase());
-                        if (characterMaximumLength > 1) {
-                            ddlBuilder.append("(").append(characterMaximumLength).append(")");
-                        }
-                    } else if (KingBaseColumnTypeEnum.NUMERIC.name().toLowerCase().equals(dataType)) {
-                        ddlBuilder.append(dataType);
-                        if (numericPrecision > 0) {
-                            ddlBuilder.append("(").append(numericPrecision);
-                            if (numericScale != 0) {
-                                ddlBuilder.append(",").append(numericScale);
-                            }
-                            ddlBuilder.append(")");
-                        }
-                    } else {
-                        ddlBuilder.append(dataType);
-                        if (isIdentity) {
-                            ddlBuilder.append(" generated ").append(identityGeneration.toLowerCase()).append(" as identity");
-                            if (!(identityStart == 1 && identityIncrement == 1)) {
-                                ddlBuilder.append(" (start with ").append(identityStart).append(" increment by ").append(identityIncrement).append(")");
-                            }
-                        }
-                    }
-                    if (StringUtils.isNotBlank(columnDefault) && !isIdentity) {
+                    String identity = attributes.contains("attidentity") ? resultSet.getString("attidentity") : "";
+                    String generated = attributes.contains("attgenerated") ? resultSet.getString("attgenerated") : "";
+                    ddlBuilder.append("\t").append(format(columnName)).append("  \t").append(dataType);
+                    if (StringUtils.isNotBlank(identity)) {
+                        String generation = switch (identity) {
+                            case "a" -> "always";
+                            case "d" -> "by default";
+                            default -> throw new SQLException("Unsupported identity kind: " + identity);
+                        };
+                        ddlBuilder.append(" generated ").append(generation).append(" as identity");
+                        appendIdentityOptions(connection, formatTableName, columnName, ddlBuilder);
+                    } else if (StringUtils.isNotBlank(generated)) {
+                        String storage = switch (generated) {
+                            case "s" -> "stored";
+                            case "v" -> "virtual";
+                            default -> throw new SQLException("Unsupported generated column kind: " + generated);
+                        };
+                        ddlBuilder.append(" generated always as (").append(columnDefault).append(") ").append(storage);
+                    } else if (StringUtils.isNotBlank(columnDefault)) {
                         ddlBuilder.append(" default ").append(columnDefault);
                     }
-                    if (!isNullable && !isIdentity) {
+                    if (resultSet.getBoolean("attnotnull")) {
                         ddlBuilder.append(" not null");
-                    }
-
-                    if (!resultSet.isLast()) {
-                        ddlBuilder.append(",\n");
                     }
                 }
                 return total;
@@ -518,6 +406,20 @@ public class KingBaseMetaData extends DefaultMetaService implements IDbMetaData 
     }
 
 
+
+    private void appendIdentityOptions(Connection connection, String tableName, String columnName, StringBuilder ddl) {
+        DefaultSQLExecutor.getInstance().preExecute(connection, IDENTITY_SEQUENCE_SQL, new String[]{tableName, columnName}, resultSet -> {
+            if (!resultSet.next()) {
+                throw new SQLException("Identity sequence metadata is missing");
+            }
+            ddl.append(" (start with ").append(resultSet.getLong("seqstart"))
+                    .append(" increment by ").append(resultSet.getLong("seqincrement"))
+                    .append(" minvalue ").append(resultSet.getLong("seqmin"))
+                    .append(" maxvalue ").append(resultSet.getLong("seqmax"))
+                    .append(" cache ").append(resultSet.getLong("seqcache"))
+                    .append(resultSet.getBoolean("seqcycle") ? " cycle)" : " no cycle)");
+        });
+    }
 
     @Override
     public List<TableIndex> indexes(Connection connection, String databaseName, String schemaName, String tableName) {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/constant/SqlConstant.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/constant/SqlConstant.java
@@ -235,13 +235,26 @@ public class SqlConstant {
                                                             AND n.nspname = ?
                                                             AND c.relname = ?
                                                           ORDER BY 2 desc;""";
+    // MySQL enums (typtype 'l') owned by a column need their name preserved for default casts.
     public static final String COLUMN_SQL = """
                                             SELECT a.*,
-                                                   pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+                                                   CASE WHEN t.typtype = 'l' AND EXISTS (
+                                                       SELECT 1 FROM pg_catalog.pg_depend dep
+                                                       WHERE dep.classid = 'pg_catalog.pg_type'::pg_catalog.regclass
+                                                         AND dep.objid = t.oid
+                                                         AND dep.refclassid = 'pg_catalog.pg_class'::pg_catalog.regclass
+                                                         AND dep.refobjid = a.attrelid AND dep.refobjsubid = a.attnum
+                                                         AND dep.deptype = 'a'
+                                                   ) THEN pg_catalog.format('ENUM(%s) NAMES %I.%I',
+                                                       (SELECT pg_catalog.string_agg(pg_catalog.quote_literal(e.enumlabel), ', ' ORDER BY e.enumsortorder)
+                                                        FROM pg_catalog.pg_enum e WHERE e.enumtypid = t.oid), tn.nspname, t.typname)
+                                                   ELSE pg_catalog.format_type(a.atttypid, a.atttypmod) END AS data_type,
                                                    pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS column_default
                                             FROM pg_catalog.pg_attribute a
                                             JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
                                             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                                            JOIN pg_catalog.pg_type t ON t.oid = a.atttypid
+                                            JOIN pg_catalog.pg_namespace tn ON tn.oid = t.typnamespace
                                             LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
                                             WHERE n.nspname = ? AND c.relname = ?
                                               AND a.attnum > 0 AND NOT a.attisdropped
@@ -249,10 +262,14 @@ public class SqlConstant {
                                                    OR pg_catalog.has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'))
                                             ORDER BY a.attnum;""";
     public static final String IDENTITY_SEQUENCE_SQL = """
-                                                       SELECT seqstart, seqincrement, seqmin, seqmax, seqcache, seqcycle
-                                                       FROM pg_catalog.pg_sequence
+                                                       SELECT seqstart, seqincrement, seqmin, seqmax, seqcache, seqcycle,
+                                                              n.nspname AS sequence_schema, c.relname AS sequence_name
+                                                       FROM pg_catalog.pg_sequence s
+                                                       JOIN pg_catalog.pg_class c ON c.oid = s.seqrelid
+                                                       JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
                                                        WHERE seqrelid = pg_catalog.pg_get_serial_sequence(?, ?)::pg_catalog.regclass;
                                                        """;
+    public static final String SEQUENCE_STATE_SQL = "SELECT last_value, next_value, is_called FROM %s";
     public static final String TABLE_INDEX_COMMENT_SQL = """
                                                          SELECT quote_ident(n.nspname)                           as schema_name,
                                                                 quote_ident(t.relname)                           AS table_name,

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/constant/SqlConstant.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/main/java/ai/chat2db/plugin/kingbase/constant/SqlConstant.java
@@ -236,29 +236,23 @@ public class SqlConstant {
                                                             AND c.relname = ?
                                                           ORDER BY 2 desc;""";
     public static final String COLUMN_SQL = """
-                                            SELECT quote_ident(c.column_name) as column_name ,
-                                                   c.data_type,
-                                                   c.udt_name,
-                                                   quote_ident(c.udt_schema) as udt_schema,
-                                                   c.character_maximum_length,
-                                                   c.is_nullable,
-                                                   c.column_default,
-                                                   c.numeric_precision,
-                                                   c.numeric_scale,
-                                                   c.datetime_precision,
-                                                   c.is_identity,
-                                                   c.identity_start,
-                                                   c.identity_increment,
-                                                   c.identity_maximum,
-                                                   c.identity_minimum,
-                                                   c.identity_cycle,
-                                                   c.identity_generation,
-                                                   c.is_generated,
-                                                   c.generation_expression,
-                                                   c.identity_increment
-                                            FROM information_schema.columns c
-                                            WHERE (table_schema, table_name) = (?, ?)
-                                            ORDER BY ordinal_position;""";
+                                            SELECT a.*,
+                                                   pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+                                                   pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS column_default
+                                            FROM pg_catalog.pg_attribute a
+                                            JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+                                            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                                            LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+                                            WHERE n.nspname = ? AND c.relname = ?
+                                              AND a.attnum > 0 AND NOT a.attisdropped
+                                              AND (pg_catalog.pg_has_role(c.relowner, 'USAGE')
+                                                   OR pg_catalog.has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'))
+                                            ORDER BY a.attnum;""";
+    public static final String IDENTITY_SEQUENCE_SQL = """
+                                                       SELECT seqstart, seqincrement, seqmin, seqmax, seqcache, seqcycle
+                                                       FROM pg_catalog.pg_sequence
+                                                       WHERE seqrelid = pg_catalog.pg_get_serial_sequence(?, ?)::pg_catalog.regclass;
+                                                       """;
     public static final String TABLE_INDEX_COMMENT_SQL = """
                                                          SELECT quote_ident(n.nspname)                           as schema_name,
                                                                 quote_ident(t.relname)                           AS table_name,

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/test/java/ai/chat2db/plugin/kingbase/KingBaseTableDDLTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/test/java/ai/chat2db/plugin/kingbase/KingBaseTableDDLTest.java
@@ -31,6 +31,42 @@ class KingBaseTableDDLTest {
     private static final String[] SEQUENCE_COLUMNS = {"seqstart", "seqincrement", "seqmin", "seqmax", "seqcache", "seqcycle"};
 
     @Test
+    void mysqlAutoIncrementPreservesSequenceNameAndCounterAfterKeys() throws Exception {
+        for (boolean called : List.of(false, true)) {
+            Fixture fixture = new Fixture(rows(IDENTITY_COLUMNS, new Object[]{"id", "bigint", null, true, "i"}));
+            fixture.results.put(IDENTITY_SEQUENCE_SQL, rows(new String[]{"seqstart", "seqincrement", "seqmin", "seqmax",
+                            "seqcache", "seqcycle", "sequence_schema", "sequence_name"},
+                    new Object[]{1L, 1L, 1L, Long.MAX_VALUE, 1L, false, "sch\"ema", "seq'\"name"}));
+            String stateQuery = SEQUENCE_STATE_SQL.formatted("\"sch\"\"ema\".\"seq'\"\"name\"");
+            fixture.results.put(stateQuery, rows(new String[]{"last_value", "next_value", "is_called"},
+                    new Object[]{3_000_000_000L, 4_000_000_000L, called}));
+            String indexDDL = "CREATE INDEX id_idx ON \"app\".\"orders\" (id)";
+            fixture.results.put(INDEX_SQL, rows(new String[]{"INDEXNAME", "INDEXDEF"}, new Object[]{"id_idx", indexDDL}));
+
+            String ddl = fixture.export("app", "orders");
+
+            String attach = "alter table \"app\".\"orders\" alter column \"id\" add auto_increment"
+                    + " (sequence name \"sch\"\"ema\".\"seq'\"\"name\" start with 1 increment by 1 minvalue 1"
+                    + " maxvalue 9223372036854775807 cache 1 no cycle), auto_increment = 4000000000;";
+            assertTrue(ddl.contains(attach), ddl);
+            assertTrue(ddl.indexOf(indexDDL) < ddl.indexOf(attach), ddl);
+            assertTrue(ddl.contains("select pg_catalog.setval('\"sch\"\"ema\".\"seq''\"\"name\"', 3000000000, " + called + ");"), ddl);
+            assertTrue(fixture.executed.contains(stateQuery));
+        }
+    }
+
+    @Test
+    void preservesAttachedEnumNameAndDefaultCast() throws Exception {
+        String type = "ENUM('open', 'O''Brien') NAMES public.\"Enum_123\"";
+        Fixture fixture = new Fixture(rows(BASIC_COLUMNS,
+                new Object[]{"state", type, "'open'::public.\"Enum_123\"", false}));
+
+        String ddl = fixture.export("app", "orders");
+
+        assertTrue(ddl.contains("\"state\"  \t" + type + " default 'open'::public.\"Enum_123\""), ddl);
+    }
+
+    @Test
     void exportsTypesAndDefaultsWithoutInformationSchemaOrOptionalCatalogAttributes() throws Exception {
         Fixture fixture = new Fixture(rows(BASIC_COLUMNS,
                 new Object[]{"select", "character varying(37)", "'O''Brien'::character varying", true},
@@ -190,7 +226,7 @@ class KingBaseTableDDLTest {
         }
 
         private PreparedStatement statement(String sql) throws SQLException {
-            assertTrue(QUERIES.contains(sql), "Unexpected query: " + sql);
+            assertTrue(QUERIES.contains(sql) || results.containsKey(sql), "Unexpected query: " + sql);
             assertFalse(sql.contains("information_schema.columns"), "The compatibility view must not be required");
             ResultSet result = results.containsKey(sql) ? results.get(sql) : rows(new String[]{"unused"});
             List<String> bindings = new ArrayList<>();

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/test/java/ai/chat2db/plugin/kingbase/KingBaseTableDDLTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-kingbase/src/test/java/ai/chat2db/plugin/kingbase/KingBaseTableDDLTest.java
@@ -1,0 +1,214 @@
+package ai.chat2db.plugin.kingbase;
+
+import ai.chat2db.community.domain.api.model.metadata.Table;
+import ai.chat2db.community.domain.api.model.metadata.TableColumn;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.rowset.CachedRowSet;
+import javax.sql.rowset.RowSetMetaDataImpl;
+import javax.sql.rowset.RowSetProvider;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static ai.chat2db.plugin.kingbase.constant.SqlConstant.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class KingBaseTableDDLTest {
+    private static final String[] BASIC_COLUMNS = {"attname", "data_type", "column_default", "attnotnull"};
+    private static final String[] IDENTITY_COLUMNS = {"attname", "data_type", "column_default", "attnotnull", "attidentity"};
+    private static final String[] GENERATED_COLUMNS = {"attname", "data_type", "column_default", "attnotnull", "attgenerated"};
+    private static final String[] SEQUENCE_COLUMNS = {"seqstart", "seqincrement", "seqmin", "seqmax", "seqcache", "seqcycle"};
+
+    @Test
+    void exportsTypesAndDefaultsWithoutInformationSchemaOrOptionalCatalogAttributes() throws Exception {
+        Fixture fixture = new Fixture(rows(BASIC_COLUMNS,
+                new Object[]{"select", "character varying(37)", "'O''Brien'::character varying", true},
+                new Object[]{"amount", "numeric(18,4)", "0.1250", false},
+                new Object[]{"tags", "integer[]", null, false},
+                new Object[]{"state", "\"Types\".\"OrderState\"", null, true},
+                new Object[]{"created_at", "timestamp(3) with time zone", "CURRENT_TIMESTAMP", false},
+                new Object[]{"serial_id", "bigint", "nextval('app.id_seq'::regclass)", true}));
+
+        String ddl = fixture.export("app", "orders");
+
+        assertTrue(ddl.contains("\"select\"  \tcharacter varying(37) default 'O''Brien'::character varying not null,\n"), ddl);
+        assertTrue(ddl.contains("\"amount\"  \tnumeric(18,4) default 0.1250,\n"), ddl);
+        assertTrue(ddl.contains("\"tags\"  \tinteger[],\n"), ddl);
+        assertTrue(ddl.contains("\"state\"  \t\"Types\".\"OrderState\" not null,\n"), ddl);
+        assertTrue(ddl.contains("\"created_at\"  \ttimestamp(3) with time zone default CURRENT_TIMESTAMP,\n"), ddl);
+        assertTrue(ddl.contains("\"serial_id\"  \tbigint default nextval('app.id_seq'::regclass) not null\n)"), ddl);
+        assertFalse(fixture.executed.contains(IDENTITY_SEQUENCE_SQL));
+        assertEquals(List.of("app", "orders"), fixture.parameters.get(COLUMN_SQL));
+    }
+
+    @Test
+    void preservesIdentityModeAndLargeSequenceOptionsWithQuotedIdentifiers() throws Exception {
+        for (String identity : List.of("a", "d")) {
+            Fixture fixture = new Fixture(rows(IDENTITY_COLUMNS,
+                    new Object[]{"id\"value", "bigint", null, true, identity}));
+            fixture.results.put(IDENTITY_SEQUENCE_SQL, rows(SEQUENCE_COLUMNS,
+                    new Object[]{3_000_000_000L, -2L, -9_000_000_000L, 9_000_000_000L, 32L, true}));
+
+            String ddl = fixture.export("sch\"ema", "tab'le");
+
+            assertTrue(ddl.startsWith("create table \"sch\"\"ema\".\"tab'le\""), ddl);
+            assertTrue(ddl.contains("\"id\"\"value\"  \tbigint generated "
+                    + (identity.equals("a") ? "always" : "by default")
+                    + " as identity (start with 3000000000 increment by -2 minvalue -9000000000"
+                    + " maxvalue 9000000000 cache 32 cycle) not null"), ddl);
+            assertEquals(List.of("\"sch\"\"ema\".\"tab'le\"", "id\"value"), fixture.parameters.get(IDENTITY_SEQUENCE_SQL));
+        }
+    }
+
+    @Test
+    void detectsUppercaseMetadataLabelsAndPreservesNonCyclingIdentity() throws Exception {
+        Fixture fixture = new Fixture(rows(new String[]{"ATTNAME", "DATA_TYPE", "COLUMN_DEFAULT", "ATTNOTNULL", "ATTIDENTITY"},
+                new Object[]{"id", "integer", null, true, "d"}));
+        fixture.results.put(IDENTITY_SEQUENCE_SQL, rows(SEQUENCE_COLUMNS,
+                new Object[]{1L, 1L, 1L, 2_147_483_647L, 1L, false}));
+
+        assertTrue(fixture.export("app", "orders").contains("cache 1 no cycle) not null"));
+    }
+
+    @Test
+    void preservesGeneratedExpressionsInsteadOfExportingThemAsDefaults() throws Exception {
+        for (String generated : List.of("s", "v")) {
+            Fixture fixture = new Fixture(rows(GENERATED_COLUMNS,
+                    new Object[]{"total", "numeric(18,4)", "(price * quantity)", true, generated}));
+
+            String ddl = fixture.export("app", "orders");
+
+            assertTrue(ddl.contains("generated always as ((price * quantity)) "
+                    + (generated.equals("s") ? "stored" : "virtual") + " not null"), ddl);
+            assertFalse(ddl.contains(" default "), ddl);
+            assertFalse(fixture.executed.contains(IDENTITY_SEQUENCE_SQL));
+        }
+    }
+
+    @Test
+    void preservesConstraintsAfterTheLastColumn() throws Exception {
+        Fixture fixture = new Fixture(rows(BASIC_COLUMNS, new Object[]{"id", "integer", null, true}));
+        fixture.results.put(CONSTRAINT_SQL_VERSION_UNDER_ELEVEN,
+                rows(new String[]{"CONSTRAINT_NAME", "CONSTRAINT_DEFINITION"}, new Object[]{"orders_pk", "PRIMARY KEY (id)"}));
+
+        String ddl = fixture.export("app", "orders");
+
+        assertTrue(ddl.contains("\"id\"  \tinteger not null,\n\t constraint \"orders_pk\" PRIMARY KEY (id)"), ddl);
+    }
+
+    @Test
+    void failsWhenIdentitySequenceCannotBeReadInsteadOfChangingItsDefinition() throws Exception {
+        Fixture fixture = new Fixture(rows(IDENTITY_COLUMNS, new Object[]{"id", "integer", null, true, "a"}));
+
+        RuntimeException error = assertThrows(RuntimeException.class, () -> fixture.export("app", "orders"));
+
+        Throwable cause = error;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        assertEquals("Identity sequence metadata is missing", cause.getMessage());
+    }
+
+    private static CachedRowSet rows(String[] columns, Object[]... values) throws SQLException {
+        CachedRowSet rows = RowSetProvider.newFactory().createCachedRowSet();
+        RowSetMetaDataImpl metadata = new RowSetMetaDataImpl();
+        metadata.setColumnCount(columns.length);
+        for (int i = 0; i < columns.length; i++) {
+            metadata.setColumnName(i + 1, columns[i]);
+            metadata.setColumnLabel(i + 1, columns[i]);
+            Object sample = values.length == 0 ? null : values[0][i];
+            metadata.setColumnType(i + 1, sample instanceof Boolean ? Types.BOOLEAN : sample instanceof Long ? Types.BIGINT : Types.VARCHAR);
+        }
+        rows.setMetaData(metadata);
+        for (int i = values.length - 1; i >= 0; i--) {
+            rows.moveToInsertRow();
+            for (int j = 0; j < columns.length; j++) {
+                if (values[i][j] == null) {
+                    rows.updateNull(j + 1);
+                } else {
+                    rows.updateObject(j + 1, values[i][j]);
+                }
+            }
+            rows.insertRow();
+            rows.moveToCurrentRow();
+        }
+        rows.beforeFirst();
+        return rows;
+    }
+
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler));
+    }
+
+    private static final class Fixture {
+        private static final Set<String> QUERIES = Set.of(COLUMN_SQL, IDENTITY_SEQUENCE_SQL, TABLE_OPTION_SQL,
+                CONSTRAINT_SQL_VERSION_UNDER_ELEVEN, TABLE_OWNER_SQL, TABLE_PRIVILEGE_SQL, has_parent_table_sql,
+                INDEX_SQL, TABLE_INDEX_COMMENT_SQL);
+        private final Map<String, ResultSet> results = new HashMap<>();
+        private final Map<String, List<String>> parameters = new HashMap<>();
+        private final List<String> executed = new ArrayList<>();
+
+        private Fixture(ResultSet columns) {
+            results.put(COLUMN_SQL, columns);
+        }
+
+        private String export(String schema, String table) {
+            DatabaseMetaData metadata = proxy(DatabaseMetaData.class, (p, method, args) -> {
+                if (method.getName().equals("getDatabaseProductVersion")) {
+                    return "9.0";
+                }
+                throw new UnsupportedOperationException(method.getName());
+            });
+            Connection connection = proxy(Connection.class, (p, method, args) -> switch (method.getName()) {
+                case "getMetaData" -> metadata;
+                case "prepareStatement" -> statement((String) args[0]);
+                default -> throw new UnsupportedOperationException(method.getName());
+            });
+            KingBaseMetaData kingbase = new KingBaseMetaData() {
+                @Override
+                public List<Table> tables(Connection connection, String databaseName, String schemaName, String tableName) {
+                    return List.of();
+                }
+
+                @Override
+                public List<TableColumn> columns(Connection connection, String databaseName, String schemaName, String tableName) {
+                    return List.of();
+                }
+            };
+            return kingbase.tableDDL(connection, "test", schema, table);
+        }
+
+        private PreparedStatement statement(String sql) throws SQLException {
+            assertTrue(QUERIES.contains(sql), "Unexpected query: " + sql);
+            assertFalse(sql.contains("information_schema.columns"), "The compatibility view must not be required");
+            ResultSet result = results.containsKey(sql) ? results.get(sql) : rows(new String[]{"unused"});
+            List<String> bindings = new ArrayList<>();
+            parameters.put(sql, bindings);
+            return proxy(PreparedStatement.class, (p, method, args) -> switch (method.getName()) {
+                case "setString" -> {
+                    assertEquals(bindings.size() + 1, args[0]);
+                    bindings.add((String) args[1]);
+                    yield null;
+                }
+                case "execute" -> {
+                    executed.add(sql);
+                    yield true;
+                }
+                case "getResultSet" -> result;
+                case "close" -> null;
+                default -> throw new UnsupportedOperationException(method.getName());
+            });
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Chat2DB.

PR title: type(scope): concise summary
Keep every section below. Use N/A when a section does not apply.
Do not include credentials, private URLs, production data, or generated build output.
-->

## Related issue

N/A - this fix follows a direct error report. No matching open issue was found.

<!-- Link the approved Issue that defines the problem or requirement. -->

## Summary

<!-- Explain what changed, why it is needed, and any important design decision. -->

Exporting a Kingbase table's DDL fails with `column c.udt_name does not exist` when `information_schema.columns` omits PostgreSQL-style fields. Read column metadata from the system catalogs and use `format_type` and `pg_get_expr` to retain complete type definitions and expressions.

Detect optional identity and generated-column attributes from JDBC result metadata. Preserve identity generation mode and sequence options, quote column names, and retain the column-privilege filter. For MySQL-compatible Kingbase builds, use the same reconstruction rules as `sys_dump`: attach `AUTO_INCREMENT` after keys, restore the sequence's `last_value`, `next_value` and `is_called` state, and declare attached enums with `ENUM ... NAMES ...` so their defaults remain valid. Existing comment escaping and ownership/grant output are retained. Add eight regression tests covering these cases and the original catalog compatibility behavior.

## Affected surfaces

<!-- Check every surface affected by this PR. -->

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [x] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

<!--
Provide exact commands and their results, plus any manual verification.
For UI changes, attach before/after screenshots or a short recording.
-->

- Commands and results: Java 17, run in the isolated PR worktree; 27 tests passed, zero failures/errors/skips, and the plugin plus reactor dependencies packaged successfully.

```sh
mvn -B -f chat2db-community-server/pom.xml \
  -pl :chat2db-community-kingbase -am \
  -Dmaven.test.skip=false -DskipTests=false \
  -Dtest=KingBaseTableDDLTest,KingBaseSQLIdentifierProcessorTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dmaven.test.failure.ignore=false package
git diff --check
```

- Manual verification: Deployed the official `KingbaseES_V009R003C018B0003_aarch64_Docker.tar` image locally and confirmed `KingbaseES V009R003C018`, `database_mode=mysql`. Used the repository's default `kingbase8-8.6.0.jar` driver and directly invoked the PR's compiled `KingBaseMetaData.tableDDL`. Reproduced the original missing-`udt_name` error. Seven integration scenarios passed export/recreation and data or metadata checks: ordinary columns/defaults/precision, auto-increment, stored generated columns, an unused `AUTO_INCREMENT=3000000000` starting value, enum defaults, arrays, and quoted column names/comments/indexes/grants. Test schemas, roles and attached enum types were removed; all three leftover counts were zero.
- Kingbase PG-mode verification: Deployed the official `KingbaseES_V009R001C010B0004_aarch64_Docker.tar` image and confirmed `KingbaseES V009R001C010`, `database_mode=pg`. Direct invocation of the unchanged PR's `KingBaseMetaData.tableDDL` with the default Kingbase JDBC driver passed eight integration scenarios: ordinary columns/defaults/precision, ALWAYS identity with a 3000000000 start and nondefault sequence options, BY DEFAULT identity with a 5000000000 start, arrays, schema-qualified PostgreSQL enums, domain-typed columns, stored generated columns, and quoted names/comments/indexes/grants. Each scenario recreated the table from the exported DDL and checked metadata and inserts. Explicit values were rejected for ALWAYS identity and accepted for BY DEFAULT identity; domain NOT NULL remained enforced. PostgreSQL enums did not use the MySQL `NAMES` clause. Cleanup left zero test schemas or roles.
- Additional verification: The final catalog queries passed PostgreSQL 17.10 checks for standalone enum references and identity metadata; the temporary schema was rolled back. Earlier PostgreSQL checks also covered dropped columns and column privileges.
- Server capability limit: This Kingbase build rejects `VIRTUAL` generated-column syntax when creating a fixture; that scenario is explicitly not counted as an integration pass.
- UI evidence: N/A - database metadata generation only.

## Risk and compatibility

<!-- Describe only the applicable risks. Use N/A with a short reason for the rest. -->

- Public API or stored data: N/A - no API or application-storage changes; exported column DDL now uses the database's complete type spelling.
- Database or driver compatibility: Real Kingbase validation used `V009R003C018` in MySQL mode and `V009R001C010` in PG mode, both with the configured default JDBC driver. The exact reported `V009R003C011PS021` patch build remains untested.
- Network, privacy, or security: Metadata reads retain column access checks and bound table/schema filters. Sequence identifiers are quoted and escaped; exporting does not modify the source database. The emitted SQL restores the destination auto-increment state.
- Community / Local / Pro boundary: N/A - no edition-specific behavior changes.
- Backward compatibility: Catalog results without `attidentity` or `attgenerated` remain supported. Identity sequence lookup is only performed for identity columns; unavailable sequence metadata raises an error instead of silently changing the definition.

## Reviewer map

<!-- Point reviewers to the load-bearing change and provide an operational handoff. -->

- Start here: `SqlConstant.COLUMN_SQL`, `IDENTITY_SEQUENCE_SQL` and `SEQUENCE_STATE_SQL`, then `KingBaseMetaData.tableDDL`, `appendIdentityOptions` and `appendAutoIncrement`; regression coverage is in `KingBaseTableDDLTest`.
- Failure condition: Table DDL export against a compatibility view without `udt_name`; also verify complete type/default/identity definitions on the target Kingbase version.
- Rollback or disable path: Revert this PR. No migration or stored-data rollback is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex implemented the change, added regression tests, reviewed the diff, and ran the reported verification. Real Kingbase V9R3C18 MySQL mode, V9R1C10 PG mode, and PostgreSQL 17 verification is described above; the exact reported patch build remains unverified.
