### PR TITLE
fix(table): confirm copy names and quote identifiers once

### DIFF
--- a/chat2db-community-client/src/blocks/NewTree/functions/copyTable.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/functions/copyTable.tsx
@@ -1,0 +1,79 @@
+import { createRef, forwardRef, useImperativeHandle } from 'react';
+import { Form, Input, type FormInstance } from 'antd';
+import { staticModal } from '@chat2db/ui';
+import i18n from '@/i18n';
+import sqlService, { type ICopyTableParams } from '@/service/sql';
+
+interface CopyTableValues {
+  newName: string;
+}
+
+interface CopyTableContentProps {
+  defaultName: string;
+  onSubmit: () => void;
+}
+
+const CopyTableContent = forwardRef<FormInstance<CopyTableValues>, CopyTableContentProps>(
+  ({ defaultName, onSubmit }, ref) => {
+    const [form] = Form.useForm<CopyTableValues>();
+    useImperativeHandle(ref, () => form, [form]);
+
+    return (
+      <Form form={form} layout="vertical" initialValues={{ newName: defaultName }}>
+        <Form.Item
+          name="newName"
+          label={i18n('common.text.tableName')}
+          rules={[{ required: true, whitespace: true, message: i18n('common.form.error.required') }]}
+        >
+          <Input
+            onFocus={(event) => event.target.select()}
+            onPressEnter={(event) => {
+              event.preventDefault();
+              if (event.nativeEvent.isComposing) return;
+              onSubmit();
+            }}
+          />
+        </Form.Item>
+      </Form>
+    );
+  },
+);
+
+export const openCopyTableModal = async (params: Omit<ICopyTableParams, 'newName'>, onSuccess: () => void) => {
+  const defaultName = await sqlService.prepareCopyTable(params);
+  const form = createRef<FormInstance<CopyTableValues>>();
+  let pending: Promise<void> | undefined;
+
+  const submit = (): Promise<void> => {
+    if (pending) return pending;
+    pending = (async () => {
+      const values = await form.current!.validateFields();
+      modal.update({ confirmLoading: true, cancelButtonProps: { disabled: true }, keyboard: false, closable: false });
+      await sqlService.copyTable({ ...params, newName: values.newName });
+      onSuccess();
+      modal.destroy();
+    })().finally(() => {
+      pending = undefined;
+      modal.update({ confirmLoading: false, cancelButtonProps: { disabled: false }, keyboard: true, closable: true });
+    });
+    return pending;
+  };
+
+  const modal = staticModal.confirm({
+    title: i18n(params.copyData ? 'workspace.menu.copyStructureData' : 'workspace.menu.copyStructure'),
+    icon: null,
+    autoFocusButton: null,
+    afterOpenChange: (open) => {
+      if (open) form.current?.focusField('newName', { focus: true });
+    },
+    content: <CopyTableContent ref={form} defaultName={defaultName} onSubmit={() => void submit().catch(() => {})} />,
+    okText: i18n('common.button.confirm'),
+    cancelText: i18n('common.button.cancel'),
+    confirmLoading: false,
+    cancelButtonProps: { disabled: false },
+    maskClosable: false,
+    closable: true,
+    keyboard: true,
+    onOk: submit,
+  });
+};

--- a/chat2db-community-client/src/blocks/NewTree/hooks/useCreateRightClickMenu.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/hooks/useCreateRightClickMenu.tsx
@@ -32,6 +32,7 @@ import sqlService from '@/service/sql';
 import { copyToClipboard, getParentNode } from '@/utils';
 import { staticMessage, staticModal } from '@chat2db/ui';
 import { deleteTable } from '../functions/deleteTable';
+import { openCopyTableModal } from '../functions/copyTable';
 import { generateJavaClass } from '../functions/generateJavaClass';
 import { neatenMoveToGroup } from '../functions/moveToGroup';
 import { editView, openFunction, openProcedure, openTrigger, openView } from '../functions/openAsyncSql';
@@ -269,6 +270,16 @@ export const useCreateRightClickMenu = () => {
       handleLoadData(treeNodeData, {
         refresh: true,
       });
+    };
+
+    const handleCopyTable = (copyData: boolean) => {
+      void openCopyTableModal(
+        { dataSourceId: dataSourceId!, databaseName: databaseName!, schemaName, tableName: tableName!, copyData },
+        () => {
+          const parentNode = getParentNode(treeNodeData.key, treeData);
+          if (parentNode) handleLoadData(parentNode, { refresh: true });
+        },
+      ).catch(() => {});
     };
 
     const renderDeleteInputConfirmLabel = (labelKey: string, confirmName: string) => {
@@ -1207,46 +1218,12 @@ export const useCreateRightClickMenu = () => {
           {
             text: i18n('workspace.menu.copyStructure'),
             requiredOperations: ['CREATE'],
-            handle: () => {
-              sqlService
-                .copyTable({
-                  dataSourceId: dataSourceId!,
-                  databaseName: databaseName!,
-                  schemaName,
-                  tableName: tableName!,
-                  copyData: false,
-                })
-                .then(() => {
-                  const parentNode = getParentNode(treeNodeData.key, treeData);
-                  if (parentNode) {
-                    handleLoadData(parentNode, {
-                      refresh: true,
-                    });
-                  }
-                });
-            },
+            handle: () => handleCopyTable(false),
           },
           {
             text: i18n('workspace.menu.copyStructureData'),
             requiredOperations: ['CREATE', 'SELECT', 'INSERT'],
-            handle: () => {
-              sqlService
-                .copyTable({
-                  dataSourceId: dataSourceId!,
-                  databaseName: databaseName!,
-                  schemaName,
-                  tableName: tableName!,
-                  copyData: true,
-                })
-                .then(() => {
-                  const parentNode = getParentNode(treeNodeData.key, treeData);
-                  if (parentNode) {
-                    handleLoadData(parentNode, {
-                      refresh: true,
-                    });
-                  }
-                });
-            },
+            handle: () => handleCopyTable(true),
           },
         ],
         requiredOperations: ['CREATE'],

--- a/chat2db-community-client/src/service/sql.ts
+++ b/chat2db-community-client/src/service/sql.ts
@@ -430,7 +430,10 @@ const truncateTable = createRequest<ITableParams, void>('/api/rdb/table/truncate
 
 export interface ICopyTableParams extends ITableParams {
   copyData: boolean;
+  newName: string;
 }
+
+const prepareCopyTable = createRequest<ITableParams, string>('/api/rdb/table/copy/prepare', { method: 'get' });
 
 // Copy table
 const copyTable = createRequest<ICopyTableParams, void>('/api/rdb/table/copy', { method: 'post' });
@@ -506,6 +509,7 @@ const getDataSourceList = createRequest<IPageParams, IPageResponse<IConnectionDe
 
 export default {
   copyTable,
+  prepareCopyTable,
   downloadLargeCellValue,
   getLargeCellValue,
   truncateTable,

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/service/db/IDbTableService.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/service/db/IDbTableService.java
@@ -158,5 +158,7 @@ public interface IDbTableService {
      *
      * @param dbTableCopyRequest table copy parameters.
      */
+    String prepareCopyTable(String tableName);
+
     void copyTable(DbTableCopyRequest dbTableCopyRequest);
 }

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/service/db/IDbTableService.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-api/src/main/java/ai/chat2db/community/domain/api/service/db/IDbTableService.java
@@ -153,12 +153,13 @@ public interface IDbTableService {
      */
     void truncateTable(DbTableQueryRequest dbTableQueryRequest);
 
+    /** Returns a suggested target name without creating a table or copying data. */
+    String prepareCopyTable(String tableName);
+
     /**
      * Copies a table in the current connection scope.
      *
      * @param dbTableCopyRequest table copy parameters.
      */
-    String prepareCopyTable(String tableName);
-
     void copyTable(DbTableCopyRequest dbTableCopyRequest);
 }

--- a/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbTableServiceImpl.java
+++ b/chat2db-community-server/chat2db-community-domain/chat2db-community-domain-core/src/main/java/ai/chat2db/community/domain/core/impl/db/DbTableServiceImpl.java
@@ -20,6 +20,7 @@ import ai.chat2db.community.domain.core.cache.MemoryCacheManage;
 import ai.chat2db.community.domain.core.impl.db.extension.MetadataAccessPolicyManager;
 import ai.chat2db.community.domain.core.util.ListSorter;
 import ai.chat2db.community.tools.exception.BusinessException;
+import ai.chat2db.community.tools.util.ExceptionUtils;
 import ai.chat2db.spi.IDbManager;
 import ai.chat2db.spi.IDbMetaData;
 import ai.chat2db.spi.ISqlBuilder;
@@ -333,11 +334,9 @@ public class DbTableServiceImpl implements IDbTableService {
     @Override
     public void truncateTable(DbTableQueryRequest param) {
         try {
-            IDbMetaData metaData = Chat2DBContext.getDbMetaData();
             Connection connection = Chat2DBContext.getConnection();
-            String name = metaData.getMetaDataName(param.getTableName());
             String sql = Chat2DBContext.getDbManager()
-                    .truncateTable(connection, param.getDatabaseName(), param.getSchemaName(), name);
+                    .truncateTable(connection, param.getDatabaseName(), param.getSchemaName(), param.getTableName());
             DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> null);
         } catch (Exception e) {
             log.error("truncate table error", e);
@@ -346,24 +345,26 @@ public class DbTableServiceImpl implements IDbTableService {
     }
 
     @Override
+    public String prepareCopyTable(String tableName) {
+        String suffix = "_copy_" + DateUtil.format(new Date(), "MMddHHmmss");
+        return StringUtils.left(tableName, 32 - suffix.length()) + suffix;
+    }
+
+    @Override
     public void copyTable(DbTableCopyRequest param) {
         try {
-            IDbMetaData metaData = Chat2DBContext.getDbMetaData();
             String newName = param.getNewName();
             if (StringUtils.isBlank(newName)) {
-                newName = param.getTableName() + "_copy_" + DateUtil.format(new Date(), "MMddHHmmss");
-                if (newName.length() > 32) {
-                    newName = newName.substring(0, 32);
-                }
+                newName = prepareCopyTable(param.getTableName());
             }
-            String tableName = metaData.getMetaDataName(param.getTableName());
-            String newTableName = metaData.getMetaDataName(newName);
             Chat2DBContext.getDbManager().copyTable(
                     Chat2DBContext.getConnection(),
-                    param.getDatabaseName(), param.getSchemaName(), tableName, newTableName, param.isCopyData());
+                    param.getDatabaseName(), param.getSchemaName(), param.getTableName(), newName, param.isCopyData());
         } catch (Exception e) {
             log.error("copy table error", e);
-            throw new BusinessException("copy table error", new Object[]{e.getMessage()}, e);
+            Throwable cause = ExceptionUtils.getRootCause(e);
+            String reason = StringUtils.defaultIfBlank(cause.getMessage(), cause.getClass().getSimpleName());
+            throw new BusinessException("table.copy.failed", new Object[]{reason}, e);
         }
     }
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/ClickHouseDBManager.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/main/java/ai/chat2db/plugin/clickhouse/ClickHouseDBManager.java
@@ -118,12 +118,12 @@ public class ClickHouseDBManager extends DefaultDBManager implements IDbManager 
 
     @Override
     public String dropTable(Connection connection, String databaseName, String schemaName, String tableName) {
-        return "DROP TABLE IF EXISTS " + qualifiedTableName(databaseName, schemaName, tableName, false);
+        return "DROP TABLE IF EXISTS " + qualifiedTableName(databaseName, schemaName, tableName);
     }
 
     @Override
     public String truncateTable(Connection connection, String databaseName, String schemaName, String tableName) {
-        return "TRUNCATE TABLE " + qualifiedTableName(databaseName, schemaName, tableName, true);
+        return "TRUNCATE TABLE " + qualifiedTableName(databaseName, schemaName, tableName);
     }
 
     @Override
@@ -135,8 +135,8 @@ public class ClickHouseDBManager extends DefaultDBManager implements IDbManager 
 
     static List<String> buildCopyTableStatements(String databaseName, String schemaName, String tableName,
                                                   String newTableName, boolean copyData) {
-        String source = qualifiedTableName(databaseName, schemaName, tableName, true);
-        String target = qualifiedTableName(databaseName, schemaName, newTableName, true);
+        String source = qualifiedTableName(databaseName, schemaName, tableName);
+        String target = qualifiedTableName(databaseName, schemaName, newTableName);
         List<String> statements = new ArrayList<>();
         statements.add("CREATE TABLE " + target + " AS " + source);
         if (copyData) {
@@ -145,21 +145,13 @@ public class ClickHouseDBManager extends DefaultDBManager implements IDbManager 
         return statements;
     }
 
-    private static String qualifiedTableName(String databaseName, String schemaName, String tableName,
-                                             boolean normalizeQuotedTable) {
+    private static String qualifiedTableName(String databaseName, String schemaName, String tableName) {
         String qualifier = StringUtils.isNotBlank(schemaName) ? schemaName : databaseName;
-        String normalizedTable = normalizeQuotedTable ? normalizeQuotedIdentifier(tableName) : tableName;
         if (StringUtils.isBlank(qualifier)) {
-            return ClickHouseIdentifierProcessor.INSTANCE.quoteIdentifierAlways(normalizedTable);
+            return ClickHouseIdentifierProcessor.INSTANCE.quoteIdentifierAlways(tableName);
         }
         return ClickHouseIdentifierProcessor.INSTANCE.quoteIdentifierAlways(qualifier)
-                + "." + ClickHouseIdentifierProcessor.INSTANCE.quoteIdentifierAlways(normalizedTable);
+                + "." + ClickHouseIdentifierProcessor.INSTANCE.quoteIdentifierAlways(tableName);
     }
 
-    private static String normalizeQuotedIdentifier(String identifier) {
-        if (ClickHouseIdentifierProcessor.INSTANCE.isQuoteIdentifier(identifier)) {
-            return ClickHouseIdentifierProcessor.INSTANCE.removeIdentifierQuote(identifier);
-        }
-        return identifier;
-    }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/test/java/ai/chat2db/plugin/clickhouse/ClickHouseIdentifierProcessorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-clickhouse/src/test/java/ai/chat2db/plugin/clickhouse/ClickHouseIdentifierProcessorTest.java
@@ -450,19 +450,17 @@ class ClickHouseIdentifierProcessorTest {
     @Test
     void shouldBuildSchemaQualifiedManagerStatementsOnce() throws Exception {
         ClickHouseDBManager manager = new ClickHouseDBManager();
-        String source = ClickHouseIdentifierProcessor.INSTANCE.quoteIdentifierAlways("ord`ers");
-        String target = ClickHouseIdentifierProcessor.INSTANCE.quoteIdentifierAlways("ord`ers_copy");
 
         assertEquals("DROP TABLE IF EXISTS `analytics`.`ord``ers`",
                 manager.dropTable(null, null, "analytics", "ord`ers"));
         assertEquals("DROP TABLE IF EXISTS ```analytics```.```orders```",
                 manager.dropTable(null, null, "`analytics`", "`orders`"));
         assertEquals("TRUNCATE TABLE `analytics`.`ord``ers`",
-                manager.truncateTable(null, null, "analytics", source));
+                manager.truncateTable(null, null, "analytics", "ord`ers"));
         assertEquals(List.of(
                         "CREATE TABLE `analytics`.`ord``ers_copy` AS `analytics`.`ord``ers`",
                         "INSERT INTO `analytics`.`ord``ers_copy` SELECT * FROM `analytics`.`ord``ers`"),
-                ClickHouseDBManager.buildCopyTableStatements(null, "analytics", source, target, true));
+                ClickHouseDBManager.buildCopyTableStatements(null, "analytics", "ord`ers", "ord`ers_copy", true));
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-dm/src/main/java/ai/chat2db/plugin/dm/DMDBManager.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-dm/src/main/java/ai/chat2db/plugin/dm/DMDBManager.java
@@ -242,8 +242,8 @@ public class DMDBManager extends DefaultDBManager implements IDbManager {
     @Override
     public void copyTable(Connection connection, String databaseName, String schemaName, String tableName,
                           String newTableName, boolean copyData) throws SQLException {
-        String source = qualifiedName(schemaName, tableName, true);
-        String target = qualifiedName(schemaName, newTableName, true);
+        String source = qualifiedName(schemaName, tableName);
+        String target = qualifiedName(schemaName, newTableName);
         String sql;
         if (copyData) {
             sql = "CREATE TABLE " + target + " AS SELECT * FROM " + source;
@@ -255,27 +255,20 @@ public class DMDBManager extends DefaultDBManager implements IDbManager {
 
     @Override
     public String dropTable(Connection connection, String databaseName, String schemaName, String tableName) {
-        return String.format(SQL_DROP_TABLE_EXISTS, qualifiedName(schemaName, tableName, false));
+        return String.format(SQL_DROP_TABLE_EXISTS, qualifiedName(schemaName, tableName));
     }
 
     @Override
     public String truncateTable(Connection connection, String databaseName, String schemaName, String tableName) {
-        return "TRUNCATE TABLE " + qualifiedName(schemaName, tableName, true);
+        return "TRUNCATE TABLE " + qualifiedName(schemaName, tableName);
     }
 
-    private static String qualifiedName(String schemaName, String objectName, boolean normalizeQuotedObject) {
-        String normalizedObject = normalizeQuotedObject ? normalizeQuotedIdentifier(objectName) : objectName;
-        String quotedObject = DMIdentifierProcessor.INSTANCE.quoteIdentifierAlways(normalizedObject);
+    private static String qualifiedName(String schemaName, String objectName) {
+        String quotedObject = DMIdentifierProcessor.INSTANCE.quoteIdentifierAlways(objectName);
         if (StringUtils.isBlank(schemaName)) {
             return quotedObject;
         }
         return DMIdentifierProcessor.INSTANCE.quoteIdentifierAlways(schemaName) + "." + quotedObject;
     }
 
-    private static String normalizeQuotedIdentifier(String identifier) {
-        if (DMIdentifierProcessor.INSTANCE.isQuoteIdentifier(identifier)) {
-            return DMIdentifierProcessor.INSTANCE.removeIdentifierQuote(identifier);
-        }
-        return identifier;
-    }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-dm/src/test/java/ai/chat2db/plugin/dm/DMIdentifierProcessorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-dm/src/test/java/ai/chat2db/plugin/dm/DMIdentifierProcessorTest.java
@@ -128,7 +128,7 @@ class DMIdentifierProcessorTest {
         assertEquals("DROP TABLE IF EXISTS \"SA\"\"LES\".\"ORDERS\"",
                 manager.dropTable(null, "ignored_database", "SA\"LES", "ORDERS"));
         assertEquals("TRUNCATE TABLE \"SA\"\"LES\".\"OR\"\"DERS\"",
-                manager.truncateTable(null, "ignored_database", "SA\"LES", "\"OR\"\"DERS\""));
+                manager.truncateTable(null, "ignored_database", "SA\"LES", "OR\"DERS"));
         assertEquals("DROP TABLE IF EXISTS \"T\"\"; DROP TABLE U; --\"",
                 manager.dropTable(null, null, null, "T\"; DROP TABLE U; --"));
     }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/OracleDBManager.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/main/java/ai/chat2db/plugin/oracle/OracleDBManager.java
@@ -77,7 +77,7 @@ public class OracleDBManager extends DefaultDBManager implements IDbManager {
             boolean containData, TaskExecutionContext context) throws SQLException {
         String tableDDL = Chat2DBContext.getDbMetaData().tableDDL(connection,
                 new TableMetadataRequest(databaseName, schemaName, tableName));
-        String sqlBuilder = "DROP TABLE " + qualifiedName(schemaName, tableName, false) + ";\n" + tableDDL + "\n";
+        String sqlBuilder = "DROP TABLE " + qualifiedName(schemaName, tableName) + ";\n" + tableDDL + "\n";
         context.write(sqlBuilder);
         if (containData) {
             exportTableData(connection, databaseName, schemaName, tableName, context);
@@ -169,8 +169,8 @@ public class OracleDBManager extends DefaultDBManager implements IDbManager {
 
     @Override
     public void copyTable(Connection connection, String databaseName, String schemaName, String tableName, String newTableName, boolean copyData) throws SQLException {
-        String source = qualifiedName(schemaName, tableName, true);
-        String target = qualifiedName(schemaName, newTableName, true);
+        String source = qualifiedName(schemaName, tableName);
+        String target = qualifiedName(schemaName, newTableName);
         String sql;
         if (copyData) {
             sql = "CREATE TABLE " + target + " AS SELECT * FROM " + source;
@@ -182,12 +182,12 @@ public class OracleDBManager extends DefaultDBManager implements IDbManager {
 
     @Override
     public String dropTable(Connection connection, String databaseName, String schemaName, String tableName) {
-        return "DROP TABLE " + qualifiedName(schemaName, tableName, false);
+        return "DROP TABLE " + qualifiedName(schemaName, tableName);
     }
 
     @Override
     public String truncateTable(Connection connection, String databaseName, String schemaName, String tableName) {
-        return "TRUNCATE TABLE " + qualifiedName(schemaName, tableName, true);
+        return "TRUNCATE TABLE " + qualifiedName(schemaName, tableName);
     }
 
     @Override
@@ -197,23 +197,16 @@ public class OracleDBManager extends DefaultDBManager implements IDbManager {
 
     @Override
     public void dropView(Connection connection, String databaseName, String schemaName, String viewName) {
-        String sql = "DROP VIEW " + qualifiedName(schemaName, viewName, false);
+        String sql = "DROP VIEW " + qualifiedName(schemaName, viewName);
         DefaultSQLExecutor.getInstance().execute(connection, sql, (resultSet) -> null);
     }
 
-    private static String qualifiedName(String schemaName, String objectName, boolean normalizeQuotedObject) {
-        String normalizedObject = normalizeQuotedObject ? normalizeQuotedIdentifier(objectName) : objectName;
-        String quotedObject = OracleIdentifierProcessor.INSTANCE.quoteIdentifierAlways(normalizedObject);
+    private static String qualifiedName(String schemaName, String objectName) {
+        String quotedObject = OracleIdentifierProcessor.INSTANCE.quoteIdentifierAlways(objectName);
         if (StringUtils.isBlank(schemaName)) {
             return quotedObject;
         }
         return OracleIdentifierProcessor.INSTANCE.quoteIdentifierAlways(schemaName) + "." + quotedObject;
     }
 
-    private static String normalizeQuotedIdentifier(String identifier) {
-        if (OracleIdentifierProcessor.INSTANCE.isQuoteIdentifier(identifier)) {
-            return OracleIdentifierProcessor.INSTANCE.removeIdentifierQuote(identifier);
-        }
-        return identifier;
-    }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/test/java/ai/chat2db/plugin/oracle/OracleIdentifierProcessorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-oracle/src/test/java/ai/chat2db/plugin/oracle/OracleIdentifierProcessorTest.java
@@ -145,12 +145,12 @@ class OracleIdentifierProcessorTest {
     }
 
     @Test
-    void dbManagerQualifiesRawAndServicePrequotedNames() throws Exception {
+    void dbManagerQualifiesRawNames() throws Exception {
         OracleDBManager manager = new OracleDBManager();
         assertEquals("DROP TABLE \"SA\"\"LES\".\"ORDERS\"",
                 manager.dropTable(null, "ignored_database", "SA\"LES", "ORDERS"));
         assertEquals("TRUNCATE TABLE \"SA\"\"LES\".\"OR\"\"DERS\"",
-                manager.truncateTable(null, "ignored_database", "SA\"LES", "\"OR\"\"DERS\""));
+                manager.truncateTable(null, "ignored_database", "SA\"LES", "OR\"DERS"));
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/PostgreSQLDBManager.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/main/java/ai/chat2db/plugin/postgresql/PostgreSQLDBManager.java
@@ -66,7 +66,7 @@ public class PostgreSQLDBManager extends DefaultDBManager implements IDbManager 
                 if (StringUtils.isBlank(sequenceName)) {
                     continue;
                 }
-                String quotedSequenceName = qualifiedTableName(schemaName, sequenceName, false);
+                String quotedSequenceName = qualifiedTableName(schemaName, sequenceName);
                 sqlBuilder.append(SQL_DROP_SEQUENCE_EXISTS).append(quotedSequenceName).append(";\n");
                 sqlBuilder.append(SQL_CREATE_SEQUENCE).append(quotedSequenceName).append("\n")
                         .append(" START WITH ").append(startValue).append("\n")
@@ -89,7 +89,7 @@ public class PostgreSQLDBManager extends DefaultDBManager implements IDbManager 
         DefaultSQLExecutor.getInstance().preExecute(connection, ENUM_TYPE_DDL_SQL, new String[]{schemaName}, resultSet -> {
             while (resultSet.next()) {
                 typeBuilder.append(SQL_DROP_TYPE_EXISTS)
-                        .append(qualifiedTableName(schemaName, resultSet.getString("type_name"), false))
+                        .append(qualifiedTableName(schemaName, resultSet.getString("type_name")))
                         .append(";\n");
                 typeBuilder.append(resultSet.getString("ddl")).append("\n");
                 context.write(typeBuilder.toString());
@@ -98,7 +98,7 @@ public class PostgreSQLDBManager extends DefaultDBManager implements IDbManager 
         typeBuilder.setLength(0);
         DefaultSQLExecutor.getInstance().preExecute(connection, UDT_SQL, new String[]{schemaName}, resultSet -> {
             while (resultSet.next()) {
-                String typeName = qualifiedTableName(schemaName, resultSet.getString("type_name"), false);
+                String typeName = qualifiedTableName(schemaName, resultSet.getString("type_name"));
                 typeBuilder.append(SQL_DROP_TYPE_EXISTS).append(typeName).append(";\n");
                 typeBuilder.append(resultSet.getString("create_type_statement")).append("\n");
                 context.write(typeBuilder.toString());
@@ -123,7 +123,7 @@ public class PostgreSQLDBManager extends DefaultDBManager implements IDbManager 
                 new TableMetadataRequest(databaseName, schemaName, tableName));
         StringBuilder sqlBuilder = new StringBuilder();
         sqlBuilder.append("\n").append(SQL_DROP_TABLE_EXISTS)
-                .append(qualifiedTableName(schemaName, tableName, false)).append(";").append("\n")
+                .append(qualifiedTableName(schemaName, tableName)).append(";").append("\n")
                 .append(tableDDL).append("\n");
         context.write(sqlBuilder.toString());
         if (containData) {
@@ -140,7 +140,7 @@ public class PostgreSQLDBManager extends DefaultDBManager implements IDbManager 
                 StringBuilder sqlBuilder = new StringBuilder();
                 String viewName = resultSet.getString("table_name");
                 String viewDefinition = resultSet.getString("view_definition");
-                String quotedObjectName = qualifiedTableName(schemaName, viewName, false);
+                String quotedObjectName = qualifiedTableName(schemaName, viewName);
                 sqlBuilder.append(SQL_DROP_VIEW_EXISTS).append(quotedObjectName).append(";\n");
                 sqlBuilder.append(SQL_CREATE_REPLACE_VIEW).append(quotedObjectName).append(" AS ").append(viewDefinition).append("\n");
                 context.write(sqlBuilder.toString());
@@ -221,12 +221,12 @@ public class PostgreSQLDBManager extends DefaultDBManager implements IDbManager 
 
     @Override
     public String dropTable(Connection connection, String databaseName, String schemaName, String tableName) {
-        return "DROP TABLE " + qualifiedTableName(schemaName, tableName, false);
+        return "DROP TABLE " + qualifiedTableName(schemaName, tableName);
     }
 
     @Override
     public String truncateTable(Connection connection, String databaseName, String schemaName, String tableName) {
-        return "TRUNCATE TABLE " + qualifiedTableName(schemaName, tableName, true);
+        return "TRUNCATE TABLE " + qualifiedTableName(schemaName, tableName);
     }
 
     @Override
@@ -251,8 +251,8 @@ public class PostgreSQLDBManager extends DefaultDBManager implements IDbManager 
 
     static String buildCopyTableSql(String schemaName, String tableName, String newTableName,
                                     boolean copyData) {
-        String source = qualifiedTableName(schemaName, tableName, true);
-        String target = qualifiedTableName(schemaName, newTableName, true);
+        String source = qualifiedTableName(schemaName, tableName);
+        String target = qualifiedTableName(schemaName, newTableName);
         return "CREATE TABLE " + target + " AS TABLE " + source
                 + (copyData ? " WITH DATA" : " WITH NO DATA");
     }
@@ -265,14 +265,12 @@ public class PostgreSQLDBManager extends DefaultDBManager implements IDbManager 
 
     @Override
     public void dropView(Connection connection, String databaseName, String schemaName, String viewName) {
-        String sql = "DROP VIEW " + qualifiedTableName(schemaName, viewName, false);
+        String sql = "DROP VIEW " + qualifiedTableName(schemaName, viewName);
         DefaultSQLExecutor.getInstance().execute(connection, sql, resultSet -> null);
     }
 
-    private static String qualifiedTableName(String schemaName, String tableName,
-                                             boolean normalizeQuotedTable) {
-        String normalizedTable = normalizeQuotedTable ? normalizeQuotedIdentifier(tableName) : tableName;
-        String quotedTable = PostgreSQLIdentifierProcessor.INSTANCE.quoteIdentifierAlways(normalizedTable);
+    private static String qualifiedTableName(String schemaName, String tableName) {
+        String quotedTable = PostgreSQLIdentifierProcessor.INSTANCE.quoteIdentifierAlways(tableName);
         if (StringUtils.isBlank(schemaName)) {
             return quotedTable;
         }
@@ -280,10 +278,4 @@ public class PostgreSQLDBManager extends DefaultDBManager implements IDbManager 
                 + "." + quotedTable;
     }
 
-    private static String normalizeQuotedIdentifier(String identifier) {
-        if (PostgreSQLIdentifierProcessor.INSTANCE.isQuoteIdentifier(identifier)) {
-            return PostgreSQLIdentifierProcessor.INSTANCE.removeIdentifierQuote(identifier);
-        }
-        return identifier;
-    }
 }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/test/java/ai/chat2db/plugin/postgresql/PostgreSQLDBManagerTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-postgresql/src/test/java/ai/chat2db/plugin/postgresql/PostgreSQLDBManagerTest.java
@@ -32,18 +32,16 @@ class PostgreSQLDBManagerTest {
     @Test
     void buildsSchemaQualifiedTableStatementsWithoutDoubleQuotingServiceNames() throws Exception {
         PostgreSQLDBManager manager = new PostgreSQLDBManager();
-        String source = PostgreSQLIdentifierProcessor.INSTANCE.quoteIdentifierAlways("ord\"ers");
-        String target = PostgreSQLIdentifierProcessor.INSTANCE.quoteIdentifierAlways("ord\"ers_copy");
 
         assertEquals("DROP TABLE \"analytics\".\"ord\"\"ers\"",
                 manager.dropTable(null, "ignored_database", "analytics", "ord\"ers"));
         assertEquals("TRUNCATE TABLE \"analytics\".\"ord\"\"ers\"",
-                manager.truncateTable(null, "ignored_database", "analytics", source));
+                manager.truncateTable(null, "ignored_database", "analytics", "ord\"ers"));
         assertEquals("CREATE TABLE \"analytics\".\"ord\"\"ers_copy\" AS TABLE "
                         + "\"analytics\".\"ord\"\"ers\" WITH DATA",
-                PostgreSQLDBManager.buildCopyTableSql("analytics", source, target, true));
+                PostgreSQLDBManager.buildCopyTableSql("analytics", "ord\"ers", "ord\"ers_copy", true));
         assertEquals("CREATE TABLE \"ord\"\"ers_copy\" AS TABLE \"ord\"\"ers\" WITH NO DATA",
-                PostgreSQLDBManager.buildCopyTableSql(null, source, target, false));
+                PostgreSQLDBManager.buildCopyTableSql(null, "ord\"ers", "ord\"ers_copy", false));
     }
 
     private static class TestPostgreSQLDBManager extends PostgreSQLDBManager {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/SqlServerDBManager.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/main/java/ai/chat2db/plugin/sqlserver/SqlServerDBManager.java
@@ -203,8 +203,6 @@ public class SqlServerDBManager extends DefaultDBManager implements IDbManager {
 
     @Override
     public void copyTable(Connection connection, String databaseName, String schemaName, String tableName, String newTableName, boolean copyData) throws SQLException {
-        tableName = unquoteIdentifier(tableName);
-        newTableName = unquoteIdentifier(newTableName);
         String ddl = Chat2DBContext.getDbMetaData().tableDDL(connection,
                 new TableMetadataRequest(databaseName, schemaName, tableName));
         List<String> batches = prepareCopyDdlBatches(ddl, databaseName, schemaName, tableName, newTableName);
@@ -582,18 +580,7 @@ public class SqlServerDBManager extends DefaultDBManager implements IDbManager {
         if (StringUtils.isBlank(identifier)) {
             return identifier;
         }
-        return SqlServerIdentifierProcessor.INSTANCE.quoteIdentifierAlways(unquoteIdentifier(identifier));
-    }
-
-    static String unquoteIdentifier(String identifier) {
-        if (StringUtils.isBlank(identifier)) {
-            return identifier;
-        }
-        String value = identifier;
-        if (value.length() >= 2 && value.startsWith("[") && value.endsWith("]")) {
-            value = value.substring(1, value.length() - 1).replace("]]", "]");
-        }
-        return value;
+        return SqlServerIdentifierProcessor.INSTANCE.quoteIdentifierAlways(identifier);
     }
 
     private static final class DdlLexicalState {

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/SqlServerDBManagerTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-sqlserver/src/test/java/ai/chat2db/plugin/sqlserver/SqlServerDBManagerTest.java
@@ -203,12 +203,18 @@ class SqlServerDBManagerTest {
     void shouldEscapeEveryQualifiedIdentifierPart() {
         assertEquals("[catalog]]archive].[sales].[orders]]2026]",
                 SqlServerDBManager.buildFullTableName("catalog]archive", "sales", "orders]2026"));
-        assertEquals("[catalog].[sales].[orders]",
+        assertEquals("[[catalog]]].[[sales]]].[[orders]]]",
                 SqlServerDBManager.buildFullTableName("[catalog]", "[sales]", "[orders]"));
     }
 
     @Test
-    void shouldNormalizeMetadataFormattedNamesAtCopyBoundary() throws Exception {
+    void truncatePreservesLiteralBracketsInTheRawName() {
+        assertEquals("TRUNCATE TABLE [catalog].[sales].[[orders]]]",
+                new SqlServerDBManager().truncateTable(null, "catalog", "sales", "[orders]"));
+    }
+
+    @Test
+    void shouldUseRawNamesAtCopyBoundary() throws Exception {
         AtomicReference<TableMetadataRequest> ddlRequest = new AtomicReference<>();
         AtomicReference<List<String>> queryParameters = new AtomicReference<>();
         List<String> preparedSql = new ArrayList<>();
@@ -239,7 +245,7 @@ class SqlServerDBManagerTest {
         try {
             new SqlServerDBManager().copyTable(
                     recordingConnection(preparedSql, queryParameters),
-                    "catalog", "sales", "[orders]", "[orders_copy]", true);
+                    "catalog", "sales", "orders", "orders_copy", true);
 
             assertEquals("orders", ddlRequest.get().getTableName());
             assertEquals("CREATE TABLE [sales].[orders_copy]\n([id] int)", preparedSql.get(0));

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/test/java/ai/chat2db/plugin/xugudb/XugudbIdentifierProcessorTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-xugudb/src/test/java/ai/chat2db/plugin/xugudb/XugudbIdentifierProcessorTest.java
@@ -17,6 +17,8 @@ import ai.chat2db.spi.model.request.MultiInsertSqlRequest;
 import ai.chat2db.spi.model.request.SingleInsertSqlRequest;
 import ai.chat2db.spi.model.request.TruncateTableRequest;
 import ai.chat2db.spi.model.request.UpdateSqlRequest;
+import ai.chat2db.spi.model.datasource.ConnectInfo;
+import ai.chat2db.spi.sql.Chat2DBContext;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -328,15 +330,22 @@ class XugudbIdentifierProcessorTest {
     }
 
     @Test
-    void metadataAndManagerRespectRawVersusPrequotedNames() throws Exception {
+    void metadataAndManagerQuoteRawNames() throws Exception {
         XUGUDBMetaData metaData = new XUGUDBMetaData();
         assertEquals("\"App\".\"MixedTable\"", metaData.getMetaDataName("ignored", "App", "MixedTable"));
 
         XUGUDBManager manager = new XUGUDBManager();
         assertEquals("DROP TABLE IF EXISTS \"ta\"\"ble\"",
                 manager.dropTable(null, null, null, "ta\"ble"));
-        assertEquals("TRUNCATE TABLE \"App\".\"MixedTable\"",
-                manager.truncateTable(null, null, null, "\"App\".\"MixedTable\""));
+        ConnectInfo context = new ConnectInfo();
+        context.setDbType("XUGUDB");
+        Chat2DBContext.putContext(context);
+        try {
+            assertEquals("TRUNCATE TABLE \"ta\"\"ble\"",
+                    manager.truncateTable(null, null, null, "ta\"ble"));
+        } finally {
+            Chat2DBContext.removeContext();
+        }
     }
 
     @Test

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultDBManager.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/DefaultDBManager.java
@@ -300,11 +300,14 @@ public class DefaultDBManager implements IDbManager {
 
     @Override
     public String truncateTable(Connection connection, String databaseName, String schemaName, String tableName) throws SQLException {
-        return String.format(SQL_TRUNCATE_TABLE, tableName);
+        return String.format(SQL_TRUNCATE_TABLE, Chat2DBContext.getDbMetaData().getMetaDataName(tableName));
     }
 
     @Override
     public void copyTable(Connection connection, String databaseName, String schemaName, String tableName, String newTableName, boolean copyData) throws SQLException {
+        IDbMetaData metaData = Chat2DBContext.getDbMetaData();
+        tableName = metaData.getMetaDataName(tableName);
+        newTableName = metaData.getMetaDataName(newTableName);
         String sql;
         if (copyData) {
             sql = String.format(SQL_COPY_TABLE_DATA, newTableName, tableName);

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/IDbManager.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/IDbManager.java
@@ -55,9 +55,13 @@ public interface IDbManager {
     void exportTable(Connection connection, String databaseName, String schemaName, String tableName,
             boolean containData, TaskExecutionContext context) throws SQLException;
 
+    /** Builds truncate SQL from raw object names, quoting them inside the implementation. */
     String truncateTable(Connection connection, String databaseName, String schemaName, String tableName)
             throws SQLException;
 
+    /**
+     * Copies a table using raw object names; implementations quote identifiers when building SQL.
+     */
     void copyTable(Connection connection, String databaseName, String schemaName, String tableName, String newTableName,
             boolean copyData) throws SQLException;
 

--- a/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages.properties
+++ b/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages.properties
@@ -1,5 +1,6 @@
 # common
 common.businessError=Please try resubmitting or refreshing the page later
+table.copy.failed=Failed to copy table: {0}
 common.systemError=An exception occurs, you can view the exception details in the log in the help menu.
 common.needLoggedIn=Login required
 common.redirect=Redirect

--- a/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_en_US.properties
+++ b/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_en_US.properties
@@ -1,4 +1,5 @@
 common.businessError=Please try resubmitting or refreshing the page later
+table.copy.failed=Failed to copy table: {0}
 common.systemError=An exception occurs, you can view the exception details in the log in the help menu.
 common.needLoggedIn=Login required
 common.redirect=Redirect

--- a/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_es_ES.properties
+++ b/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_es_ES.properties
@@ -1,4 +1,5 @@
 common.businessError=Vuelva a enviar la solicitud o actualice la página más tarde
+table.copy.failed=No se pudo copiar la tabla: {0}
 common.systemError=Se ha producido una excepción. Puede consultar los detalles en el registro del menú Ayuda.
 common.needLoggedIn=Debe iniciar sesión
 common.redirect=Redirigir

--- a/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_ja_JP.properties
+++ b/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_ja_JP.properties
@@ -1,4 +1,5 @@
 # Japanese translations for Chat2DB menus
+table.copy.failed=テーブルのコピーに失敗しました: {0}
 
 menu.edit=編集
 menu.edit.cut=切り取り

--- a/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_ko_KR.properties
+++ b/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_ko_KR.properties
@@ -1,4 +1,5 @@
 common.businessError=나중에 다시 제출하거나 페이지를 새로 고쳐 주세요
+table.copy.failed=테이블을 복사하지 못했습니다: {0}
 common.systemError=예외가 발생했습니다. 도움말 메뉴의 로그에서 예외 상세 정보를 확인할 수 있습니다.
 common.needLoggedIn=로그인이 필요합니다
 common.redirect=리디렉션

--- a/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_zh_CN.properties
+++ b/chat2db-community-server/chat2db-community-start/src/main/resources/i18n/messages_zh_CN.properties
@@ -1,4 +1,5 @@
 common.businessError=请尝试重新提交或者刷新页面
+table.copy.failed=复制表失败：{0}
 common.systemError=系统发生异常，可在帮助中点击日志查看异常详情。
 common.needLoggedIn=需要登陆页面
 common.redirect=重定向页面

--- a/chat2db-community-server/chat2db-community-start/src/test/java/ai/chat2db/community/start/test/api/TableCopyFlowTest.java
+++ b/chat2db-community-server/chat2db-community-start/src/test/java/ai/chat2db/community/start/test/api/TableCopyFlowTest.java
@@ -1,0 +1,229 @@
+package ai.chat2db.community.start.test.api;
+
+import ai.chat2db.community.domain.api.model.request.db.DbTableCopyRequest;
+import ai.chat2db.community.domain.core.impl.db.DbTableServiceImpl;
+import ai.chat2db.community.tools.exception.BusinessException;
+import ai.chat2db.community.tools.console.ConsoleMessage;
+import ai.chat2db.community.tools.util.I18nUtils;
+import ai.chat2db.community.web.api.config.console.ConsoleHelper;
+import ai.chat2db.community.web.api.config.console.RequestMappingInfo;
+import ai.chat2db.community.web.api.util.ApplicationContextUtil;
+import ai.chat2db.community.web.api.util.RequestMappingUtils;
+import ai.chat2db.plugin.clickhouse.ClickHouseDBManager;
+import ai.chat2db.plugin.dm.DMDBManager;
+import ai.chat2db.plugin.mysql.MysqlDBManager;
+import ai.chat2db.plugin.mysql.MysqlMetaData;
+import ai.chat2db.plugin.oracle.OracleDBManager;
+import ai.chat2db.plugin.postgresql.PostgreSQLDBManager;
+import ai.chat2db.spi.DefaultDBManager;
+import ai.chat2db.spi.DefaultMetaService;
+import ai.chat2db.spi.IDbManager;
+import ai.chat2db.spi.IDbMetaData;
+import ai.chat2db.spi.sql.Chat2DBContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class TableCopyFlowTest {
+    private static final String LONG_TABLE = "inventory_material_record_source12345678901";
+    private final DbTableServiceImpl service = new DbTableServiceImpl(null);
+
+    @Test
+    void preparationOnlyReturnsANameAndNeverTouchesTheDatabase() {
+        try (MockedStatic<Chat2DBContext> context = mockStatic(Chat2DBContext.class)) {
+            String name = service.prepareCopyTable(LONG_TABLE);
+            assertEquals(32, name.length());
+            assertTrue(name.matches("inventory_materi_copy_[0-9]{10}"));
+            context.verifyNoInteractions();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void mysqlCopiesDataAndStructureThroughTheService(boolean copyData) throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:copy_flow;MODE=MySQL")) {
+            connection.createStatement().execute("CREATE TABLE `" + LONG_TABLE + "` (id BIGINT PRIMARY KEY, rev_no VARCHAR(200))");
+            connection.createStatement().execute("INSERT INTO `" + LONG_TABLE + "` VALUES (1, 'A'), (2, NULL)");
+            try (MockedStatic<Chat2DBContext> context = context(connection, new MysqlDBManager(), new MysqlMetaData())) {
+                service.copyTable(request(LONG_TABLE, "material_copy", copyData));
+            }
+            try (ResultSet rows = connection.createStatement().executeQuery("SELECT COUNT(*) FROM `material_copy`")) {
+                assertTrue(rows.next());
+                assertEquals(copyData ? 2 : 0, rows.getInt(1));
+            }
+            if (copyData) {
+                try (ResultSet rows = connection.createStatement().executeQuery("SELECT rev_no FROM `material_copy` ORDER BY id")) {
+                    assertTrue(rows.next());
+                    assertEquals("A", rows.getString(1));
+                    assertTrue(rows.next());
+                    assertNull(rows.getString(1));
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"orders", "select", "order details", "ord`ers", "`orders`", "a`; DROP TABLE b; --"})
+    void mysqlQuotesRawNamesExactlyOnce(String name) throws Exception {
+        Connection connection = recordingConnection();
+        try (MockedStatic<Chat2DBContext> context = context(connection, new MysqlDBManager(), new MysqlMetaData())) {
+            service.copyTable(request(name, "new`table", true));
+        }
+        verify(connection).prepareStatement("CREATE TABLE `new``table` AS SELECT * FROM `"
+                + name.replace("`", "``") + "`");
+    }
+
+    @Test
+    void generatedNameKeepsTheCopySuffixForLongTableNames() throws Exception {
+        Connection connection = recordingConnection();
+        IDbManager manager = mock(IDbManager.class);
+        try (MockedStatic<Chat2DBContext> context = context(connection, manager, new MysqlMetaData())) {
+            service.copyTable(request(LONG_TABLE, null, true));
+        }
+        var target = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(manager).copyTable(eq(connection), eq("app"), isNull(), eq(LONG_TABLE), target.capture(), eq(true));
+        assertEquals(32, target.getValue().length());
+        assertTrue(target.getValue().matches("inventory_materi_copy_[0-9]{10}"), target.getValue());
+    }
+
+    @Test
+    void defaultManagerStillQuotesNamesForPluginsWithoutAnOverride() throws Exception {
+        Connection connection = recordingConnection();
+        IDbMetaData metadata = new DefaultMetaService() {
+            @Override
+            public String getMetaDataName(String... names) {
+                return Arrays.stream(names).map(name -> "\"" + name.replace("\"", "\"\"") + "\"")
+                        .collect(Collectors.joining("."));
+            }
+        };
+        try (MockedStatic<Chat2DBContext> context = context(connection, new DefaultDBManager(), metadata)) {
+            service.copyTable(request("order details", "ord\"ers", false));
+        }
+        verify(connection).prepareStatement("CREATE TABLE \"ord\"\"ers\" AS SELECT * FROM \"order details\" WHERE 1=0");
+    }
+
+    @Test
+    void otherDialectCopyManagersPreserveLiteralQuoteCharacters() throws Exception {
+        for (IDbManager manager : List.of(new PostgreSQLDBManager(), new OracleDBManager(), new DMDBManager())) {
+            Connection connection = recordingConnection();
+            try (MockedStatic<Chat2DBContext> context = context(connection, manager, new DefaultMetaService())) {
+                service.copyTable(request("\"orders\"", "\"copy\"", true));
+            }
+            String source = "\"\"\"orders\"\"\"";
+            String target = "\"\"\"copy\"\"\"";
+            String expected = manager instanceof PostgreSQLDBManager
+                    ? "CREATE TABLE " + target + " AS TABLE " + source + " WITH DATA"
+                    : "CREATE TABLE " + target + " AS SELECT * FROM " + source;
+            verify(connection).prepareStatement(expected);
+        }
+        Connection connection = recordingConnection();
+        try (MockedStatic<Chat2DBContext> context = context(connection, new ClickHouseDBManager(), new DefaultMetaService())) {
+            service.copyTable(request("`orders`", "`copy`", true));
+        }
+        verify(connection).prepareStatement("CREATE TABLE `app`.```copy``` AS `app`.```orders```");
+        verify(connection).prepareStatement("INSERT INTO `app`.```copy``` SELECT * FROM `app`.```orders```");
+    }
+
+    @Test
+    void copyFailurePreservesTheDatabaseMessageInEveryLocale() throws Exception {
+        Connection connection = recordingConnection();
+        SQLException original = new SQLException("Table 'app.orders' doesn't exist", "42S02", 1146);
+        when(connection.prepareStatement(anyString())).thenThrow(original);
+        BusinessException failure;
+        try (MockedStatic<Chat2DBContext> context = context(connection, new MysqlDBManager(), new MysqlMetaData())) {
+            failure = assertThrows(BusinessException.class, () -> service.copyTable(request("orders", "copy", true)));
+        }
+        assertEquals("table.copy.failed", failure.getCode());
+        assertEquals(original.getMessage(), failure.getArgs()[0]);
+        assertSame(original, failure.getCause().getCause());
+        ResourceBundleMessageSource messages = new ResourceBundleMessageSource();
+        messages.setBasename("i18n/messages");
+        messages.setDefaultEncoding("UTF-8");
+        for (Locale locale : List.of(Locale.ROOT, Locale.US, Locale.CHINA, Locale.JAPAN, Locale.KOREA, Locale.forLanguageTag("es-ES"))) {
+            String text = messages.getMessage(failure.getCode(), failure.getArgs(), locale);
+            assertTrue(text.contains(original.getMessage()), text);
+            assertFalse(text.contains("no message"), text);
+            assertFalse(text.contains("{0}"), text);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"zh-CN", "en-US", "ja-JP"})
+    void desktopBridgeIncludesTheOriginalDatabaseError(String language) throws Exception {
+        Connection connection = recordingConnection();
+        String reason = "Table 'app.orders' doesn't exist";
+        when(connection.prepareStatement(anyString())).thenThrow(new SQLException(reason));
+        ResourceBundleMessageSource messages = new ResourceBundleMessageSource();
+        messages.setBasename("i18n/messages");
+        messages.setDefaultEncoding("UTF-8");
+        Locale previousLocale = LocaleContextHolder.getLocale();
+        try (MockedStatic<Chat2DBContext> context = context(connection, new MysqlDBManager(), new MysqlMetaData());
+             MockedStatic<RequestMappingUtils> routing = mockStatic(RequestMappingUtils.class);
+             MockedStatic<ApplicationContextUtil> beans = mockStatic(ApplicationContextUtil.class);
+             MockedStatic<I18nUtils> i18n = mockStatic(I18nUtils.class)) {
+            RequestMappingInfo mapping = RequestMappingInfo.builder().controller(CopyController.class)
+                    .method("copy").params(new Class<?>[0]).build();
+            routing.when(() -> RequestMappingUtils.getRequestMappingInfo("/api/rdb/table/copy", "post")).thenReturn(mapping);
+            beans.when(() -> ApplicationContextUtil.getBeanOfType(CopyController.class)).thenReturn(new CopyController());
+            i18n.when(() -> I18nUtils.getMessage(eq("table.copy.failed"), any(Object[].class)))
+                    .thenAnswer(call -> messages.getMessage(call.getArgument(0), call.getArgument(1), LocaleContextHolder.getLocale()));
+            ConsoleMessage message = new ConsoleMessage();
+            message.setRequestUrl("/api/rdb/table/copy");
+            message.setMethod("post");
+            message.setHeaders(Map.of("Accept-Language", language));
+            Map<String, Object> result = ConsoleHelper.doController(message).getMessage();
+            assertEquals("table.copy.failed", result.get("errorCode"));
+            assertEquals(messages.getMessage("table.copy.failed", new Object[]{reason}, Locale.forLanguageTag(language)),
+                    result.get("errorMessage"));
+        } finally {
+            LocaleContextHolder.setLocale(previousLocale);
+        }
+    }
+
+    public static class CopyController {
+        public void copy() {
+            new DbTableServiceImpl(null).copyTable(request("orders", "copy", true));
+        }
+    }
+
+    private static Connection recordingConnection() throws SQLException {
+        Connection connection = mock(Connection.class);
+        when(connection.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+        return connection;
+    }
+
+    private static MockedStatic<Chat2DBContext> context(Connection connection, IDbManager manager, IDbMetaData metadata) {
+        MockedStatic<Chat2DBContext> context = mockStatic(Chat2DBContext.class);
+        context.when(Chat2DBContext::getConnection).thenReturn(connection);
+        context.when(Chat2DBContext::getDbManager).thenReturn(manager);
+        context.when(Chat2DBContext::getDbMetaData).thenReturn(metadata);
+        return context;
+    }
+
+    private static DbTableCopyRequest request(String source, String target, boolean copyData) {
+        DbTableCopyRequest request = new DbTableCopyRequest();
+        request.setDatabaseName("app");
+        request.setTableName(source);
+        request.setNewName(target);
+        request.setCopyData(copyData);
+        return request;
+    }
+}

--- a/chat2db-community-server/chat2db-community-start/src/test/java/ai/chat2db/community/start/test/api/TableIdentifierContractTest.java
+++ b/chat2db-community-server/chat2db-community-start/src/test/java/ai/chat2db/community/start/test/api/TableIdentifierContractTest.java
@@ -1,0 +1,182 @@
+package ai.chat2db.community.start.test.api;
+
+import ai.chat2db.community.domain.api.model.request.db.DbTableCopyRequest;
+import ai.chat2db.community.domain.api.model.request.db.DbTableQueryRequest;
+import ai.chat2db.community.domain.core.impl.db.DbTableServiceImpl;
+import ai.chat2db.spi.IDbManager;
+import ai.chat2db.spi.IDbMetaData;
+import ai.chat2db.spi.IPlugin;
+import ai.chat2db.spi.model.request.TableMetadataRequest;
+import ai.chat2db.spi.sql.Chat2DBContext;
+import com.alibaba.fastjson2.JSON;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class TableIdentifierContractTest {
+    private static final List<String[]> NAMES = List.of(
+            new String[]{"source data", "target data"},
+            new String[]{"select", "order"},
+            new String[]{"a`b\"c]d", "n`m\"l]k"},
+            new String[]{"`source`", "`target`"},
+            new String[]{"\"source\"", "\"target\""},
+            new String[]{"[source]", "[target]"},
+            new String[]{"a'; DROP TABLE x; --", "b'; DROP TABLE y; --"},
+            new String[]{"inventory_material_record_source12345678901", "custom_material_copy"});
+
+    static Stream<Arguments> databases() {
+        return Chat2DBContext.PLUGIN_MAP.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .flatMap(entry -> NAMES.stream().map(names -> Arguments.of(entry.getKey(), names[0], names[1])));
+    }
+
+    @ParameterizedTest(name = "{0}: copy {1}")
+    @MethodSource("databases")
+    void copyPassesRawNamesToEveryRegisteredPlugin(String dbType, String source, String target) throws Exception {
+        IPlugin plugin = Chat2DBContext.PLUGIN_MAP.get(dbType);
+        IDbManager manager = plugin.getDbManager();
+        IDbMetaData metadata = spy(plugin.getDbMetaData());
+        List<String> executed = new ArrayList<>();
+        Connection connection = recordingConnection(executed);
+        String owner = manager.getClass().getMethod("copyTable", Connection.class, String.class, String.class,
+                String.class, String.class, boolean.class).getDeclaringClass().getSimpleName();
+
+        try (MockedStatic<Chat2DBContext> context = context(plugin, metadata, connection)) {
+            String quotedSource = metadata.getSQLIdentifierProcessor().quoteIdentifierAlways(source);
+            String quotedTarget = metadata.getSQLIdentifierProcessor().quoteIdentifierAlways(target);
+            String defaultSource = metadata.getMetaDataName(source);
+            String defaultTarget = metadata.getMetaDataName(target);
+            if (owner.equals("SqlServerDBManager")) {
+                doReturn("CREATE TABLE " + quotedSource + " ([id] int)").when(metadata)
+                        .tableDDL(any(Connection.class), any(TableMetadataRequest.class));
+            }
+            for (boolean copyData : List.of(false, true)) {
+                executed.clear();
+                clearInvocations(metadata);
+                DbTableCopyRequest request = new DbTableCopyRequest();
+                request.setDatabaseName("app");
+                request.setSchemaName("scope");
+                request.setTableName(source);
+                request.setNewName(target);
+                request.setCopyData(copyData);
+                new DbTableServiceImpl(null).copyTable(request);
+
+                List<String> expected = switch (owner) {
+                    case "MysqlDBManager", "SUNDBDBManager" -> List.of(ctas(quotedTarget, quotedSource, copyData));
+                    case "DefaultDBManager" -> List.of(ctas(defaultTarget, defaultSource, copyData));
+                    case "PostgreSQLDBManager", "KingBaseDBManager" -> List.of("CREATE TABLE \"scope\"." + quotedTarget
+                            + " AS TABLE \"scope\"." + quotedSource + (copyData ? " WITH DATA" : " WITH NO DATA"));
+                    case "OracleDBManager", "DMDBManager", "OscarBaseDBManager" ->
+                            List.of(ctas("\"scope\"." + quotedTarget, "\"scope\"." + quotedSource, copyData));
+                    case "ClickHouseDBManager" -> statements(copyData,
+                            "CREATE TABLE `scope`." + quotedTarget + " AS `scope`." + quotedSource,
+                            "INSERT INTO `scope`." + quotedTarget + " SELECT * FROM `scope`." + quotedSource);
+                    case "DB2DBManager", "HiveDBManager" -> statements(copyData,
+                            "CREATE TABLE " + quotedTarget + " LIKE " + quotedSource
+                                    + (owner.equals("DB2DBManager") ? " INCLUDING INDEXES" : ""),
+                            "INSERT INTO " + quotedTarget + " SELECT * FROM " + quotedSource);
+                    case "SqlServerDBManager" -> statements(copyData,
+                            "CREATE TABLE [scope]." + quotedTarget + " ([id] int)",
+                            "INSERT INTO [app].[scope]." + quotedTarget + " ([id]) SELECT [id] FROM [app].[scope]." + quotedSource);
+                    case "MongodbDBManager" -> List.of("db.getCollection(" + JSON.toJSONString(target)
+                            + ").insertMany(db.getCollection(" + JSON.toJSONString(source) + ").find({}))");
+                    default -> throw new AssertionError("Add contract coverage for " + dbType + ": " + owner);
+                };
+                assertEquals(expected, executed, dbType + ", copyData=" + copyData);
+                if (owner.equals("DefaultDBManager")) {
+                    verify(metadata).getMetaDataName(source);
+                    verify(metadata).getMetaDataName(target);
+                } else {
+                    verify(metadata, never()).getMetaDataName(any(String[].class));
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{0}: truncate {1}")
+    @MethodSource("databases")
+    void truncatePassesRawNamesToEveryRegisteredPlugin(String dbType, String source, String unusedTarget) throws Exception {
+        IPlugin plugin = Chat2DBContext.PLUGIN_MAP.get(dbType);
+        IDbManager manager = plugin.getDbManager();
+        IDbMetaData metadata = spy(plugin.getDbMetaData());
+        List<String> executed = new ArrayList<>();
+        Connection connection = recordingConnection(executed);
+        String owner = manager.getClass().getMethod("truncateTable", Connection.class, String.class,
+                String.class, String.class).getDeclaringClass().getSimpleName();
+
+        try (MockedStatic<Chat2DBContext> context = context(plugin, metadata, connection)) {
+            String quotedSource = metadata.getSQLIdentifierProcessor().quoteIdentifierAlways(source);
+            String defaultSource = metadata.getMetaDataName(source);
+            clearInvocations(metadata);
+            DbTableQueryRequest request = new DbTableQueryRequest();
+            request.setDatabaseName("app");
+            request.setSchemaName("scope");
+            request.setTableName(source);
+            new DbTableServiceImpl(null).truncateTable(request);
+
+            String expected = switch (owner) {
+                case "DefaultDBManager" -> "TRUNCATE TABLE " + defaultSource;
+                case "MysqlDBManager", "DB2DBManager" -> "TRUNCATE TABLE " + quotedSource;
+                case "PostgreSQLDBManager", "OracleDBManager", "DMDBManager", "OscarBaseDBManager" ->
+                        "TRUNCATE TABLE \"scope\"." + quotedSource;
+                case "ClickHouseDBManager" -> "TRUNCATE TABLE `scope`." + quotedSource;
+                case "SqlServerDBManager" -> "TRUNCATE TABLE [app].[scope]." + quotedSource;
+                case "MongodbDBManager" -> "db.getCollection(" + JSON.toJSONString(source) + ").deleteMany({})";
+                default -> throw new AssertionError("Add contract coverage for " + dbType + ": " + owner);
+            };
+            assertEquals(List.of(expected), executed, dbType);
+            if (owner.equals("DefaultDBManager")) {
+                verify(metadata).getMetaDataName(source);
+            } else {
+                verify(metadata, never()).getMetaDataName(any(String[].class));
+            }
+        }
+    }
+
+    private static String ctas(String target, String source, boolean copyData) {
+        return "CREATE TABLE " + target + " AS SELECT * FROM " + source + (copyData ? "" : " WHERE 1=0");
+    }
+
+    private static List<String> statements(boolean copyData, String structure, String data) {
+        return copyData ? List.of(structure, data) : List.of(structure);
+    }
+
+    private static Connection recordingConnection(List<String> executed) throws Exception {
+        Connection connection = mock(Connection.class);
+        when(connection.prepareStatement(anyString())).thenAnswer(call -> {
+            String sql = call.getArgument(0);
+            PreparedStatement statement = mock(PreparedStatement.class);
+            when(statement.execute()).thenAnswer(ignored -> { executed.add(sql); return false; });
+            ResultSet columns = mock(ResultSet.class);
+            when(columns.next()).thenReturn(true, false);
+            when(columns.getString("COLUMN_NAME")).thenReturn("id");
+            when(columns.getString("DATA_TYPE")).thenReturn("int");
+            when(statement.executeQuery()).thenReturn(columns);
+            return statement;
+        });
+        return connection;
+    }
+
+    private static MockedStatic<Chat2DBContext> context(IPlugin plugin, IDbMetaData metadata, Connection connection) {
+        MockedStatic<Chat2DBContext> context = mockStatic(Chat2DBContext.class);
+        context.when(Chat2DBContext::getDBConfig).thenReturn(plugin.getDBConfig());
+        context.when(Chat2DBContext::getDbManager).thenReturn(plugin.getDbManager());
+        context.when(Chat2DBContext::getDbMetaData).thenReturn(metadata);
+        context.when(Chat2DBContext::getConnection).thenReturn(connection);
+        return context;
+    }
+}

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/config/console/ConsoleHelper.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/config/console/ConsoleHelper.java
@@ -314,10 +314,10 @@ public class ConsoleHelper {
                     ActionResult result1 = ActionResult.fail(errorCode, errorCode, null);
                     result.setMessage(ConsoleObjectConverter.object2map(result1));
                     return result;
-                } else if (throwable instanceof BusinessException) {
+                } else if (throwable instanceof BusinessException businessException) {
                     log.error("BusinessException error, param {}", JSON.toJSONString(message), e);
-                    ActionResult result1 = ActionResult.fail(((BusinessException) throwable).getCode()
-                            , I18nUtils.getMessage(((BusinessException) throwable).getCode()), null);
+                    ActionResult result1 = ActionResult.fail(businessException.getCode(),
+                            I18nUtils.getMessage(businessException.getCode(), businessException.getArgs()), null);
                     result.setMessage(ConsoleObjectConverter.object2map(result1));
                     return result;
                 } else if (throwable instanceof SystemException) {

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/controller/DbTableController.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/controller/DbTableController.java
@@ -284,6 +284,12 @@ public class DbTableController {
         return ActionResult.isSuccess();
     }
 
+    /** Returns a suggested target name without creating a table or copying data. */
+    @GetMapping("/copy/prepare")
+    public DataResult<String> prepareCopy(@Valid TableDetailQueryRequest request) {
+        return DataResult.of(tableService.prepareCopyTable(request.getTableName()));
+    }
+
     /**
      * Copies tables.
      * <p>


### PR DESCRIPTION
<!--
Thank you for contributing to Chat2DB.

PR title: type(scope): concise summary
Keep every section below. Use N/A when a section does not apply.
Do not include credentials, private URLs, production data, or generated build output.
-->

## Related issue

N/A. Maintainer-requested fix for failed table copies and a target-name confirmation step.

<!-- Link the approved Issue that defines the problem or requirement. -->

## Summary

Copying a MySQL table could quote an already-quoted name again, producing three backticks and a misleading table-not-found error. Copy and truncate now pass raw names to database managers, which quote them once; compatible dialect implementations and the default manager follow the same contract.

Both copy menu actions first request a suggested target name and display an editable confirmation dialog. The default truncates only the original-name prefix, preserving the copy suffix. Confirm sends the displayed or edited name; cancel and IME composition do not execute a copy, concurrent submissions share one request, and failures retain the entered name. Copy failures now include the database reason in localized web and desktop responses.

## Affected surfaces

<!-- Check every surface affected by this PR. -->

- [x] Frontend / Web
- [x] Backend / API / Storage
- [x] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

<!--
Provide exact commands and their results, plus any manual verification.
For UI changes, attach before/after screenshots or a short recording.
-->

- Commands and results:
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-start -am -Dmaven.test.skip=false -DskipTests=false '-Dtest=TableIdentifierContractTest,TableCopyFlowTest,*IdentifierProcessorTest,SqlServerDBManagerTest,PostgreSQLDBManagerTest,MongodbSqlGuardsTest' -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false package`: passed, 1,586 tests, zero failures/errors. Includes 1,088 copy/truncate contract cases across 68 registered database configurations.
  - In `chat2db-community-client`: `yarn lint`, `yarn test:i18n`, `yarn build:web:community --app_version=0.0.0-copy-pr`: passed.
  - `git diff --check`: passed.
- Manual verification: Playwright CLI against an isolated Community web/backend and MySQL fixture verified prepare-only requests, editable names, cancel, Escape, whitespace validation, IME Enter, duplicate-name errors, retry, rapid Enter deduplication, both copy modes, both table-list/tree entries, automatic refresh, and persistence after reload. Database checks confirmed two source rows, two copied rows, and zero rows for structure-only copies. MySQL 8.4 and PostgreSQL 17 execution checks also passed for seven special-name cases and truncate preserving source data.
- UI evidence: desktop (1440x900) and narrow (375x812) screenshots inspected locally; dialog/input/buttons fit. N/A for uploaded media. Generated screenshots and test state are excluded from the patch.

## Risk and compatibility

<!-- Describe only the applicable risks. Use N/A with a short reason for the rest. -->

- Public API or stored data: adds `GET /api/rdb/table/copy/prepare`; existing copy POST retains fallback naming when `newName` is omitted. No storage migration.
- Database or driver compatibility: database-manager copy/truncate parameters now explicitly require raw names. All registered implementations are covered at SQL generation/call-contract level; real execution was verified on MySQL and PostgreSQL only. Existing dialect copy semantics, including CTAS behavior, are unchanged.
- Network, privacy, or security: identifier escaping stays at SQL construction; prepared names do not execute copy SQL. No credentials or customer data in fixtures.
- Community / Local / Pro boundary: Community changes only; no product selectors or commercial integration added.
- Backward compatibility: existing HTTP clients may omit `newName`. The new UI needs the new prepare endpoint. Plugins calling the management SPI must supply raw names.

## Reviewer map

<!-- Point reviewers to the load-bearing change and provide an operational handoff. -->

- Start here: `DbTableServiceImpl`, `IDbManager`, `DefaultDBManager`, and `src/blocks/NewTree/functions/copyTable.tsx`; then `TableCopyFlowTest` and `TableIdentifierContractTest`.
- Failure condition: quoted names are quoted again, confirmation performs more than one POST, or a copy failure loses its database reason. Local review found no remaining blocking findings after fixing IME submission.
- Rollback or disable path: revert this PR as a unit so service and plugin name contracts stay aligned.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A: requested directly by a maintainer.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex implemented the fix, reviewed the complete diff, and ran the reported automated and Playwright checks under maintainer direction.
