### PR TITLE
fix(ui): align short filters and hide inactive scrollbars

### DIFF
--- a/chat2db-community-client/src/components/NodeFiltering/index.tsx
+++ b/chat2db-community-client/src/components/NodeFiltering/index.tsx
@@ -40,12 +40,20 @@ const NodeFiltering = (props: IProps) => {
 
   const measureScrollWidth = () => {
     const nodes = treeBoxRef.current?.querySelectorAll<HTMLElement>('.ant-tree-treenode');
-    return Array.from(nodes || []).reduce((width, node) => Math.max(width, node.scrollWidth), 1);
+    return Array.from(nodes || []).reduce(
+      (width, node) => Math.max(width, node.scrollWidth),
+      treeBoxRef.current?.clientWidth || 1,
+    );
   };
 
   useLayoutEffect(() => {
-    const frame = requestAnimationFrame(() => setScrollWidth(measureScrollWidth()));
-    return () => cancelAnimationFrame(frame);
+    const treeBox = treeBoxRef.current;
+    if (!treeBox) {
+      return;
+    }
+    const observer = new ResizeObserver(() => setScrollWidth(measureScrollWidth()));
+    observer.observe(treeBox);
+    return () => observer.disconnect();
   }, [treeData]);
 
   const onCheck = (_checkedKeys, halfChecked) => {

--- a/chat2db-community-client/src/components/NodeFiltering/style.tsx
+++ b/chat2db-community-client/src/components/NodeFiltering/style.tsx
@@ -115,9 +115,20 @@ export const useStyles = createStyles(({ css, token }) => {
       .ant-tree-node-content-wrapper {
         padding: 0px !important;
       }
+      .ant-tree-list-scrollbar {
+        pointer-events: none;
+      }
       .ant-tree-list-scrollbar-thumb {
         background-color: ${token.colorFill} !important;
-        transition: background-color 0.1s ease;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.12s ease, background-color 0.1s ease;
+      }
+      &:hover .ant-tree-list-scrollbar-thumb,
+      .ant-tree-list-scrollbar-thumb-moving {
+        opacity: 1;
+        pointer-events: auto;
+        visibility: visible;
       }
     `,
   };


### PR DESCRIPTION
<!--
Thank you for contributing to Chat2DB.

PR title: type(scope): concise summary
Keep every section below. Use N/A when a section does not apply.
Do not include credentials, private URLs, production data, or generated build output.
-->

## Related issue

N/A - maintainer-requested and accepted follow-up to #2878.

<!-- Link the approved Issue that defines this change. -->

## Summary

Short database lists could shift to the right after opening the filter popover because their measured scroll width was smaller than the viewport. Clamp the measured width to the container width and observe layout changes so a popover initially mounted without visible dimensions also aligns correctly.

Fade horizontal and vertical scrollbar thumbs out within 120 ms when the pointer leaves the list. Keep the dragged thumb visible outside the list, restore it on pointer entry, and prevent hidden scrollbars from intercepting content clicks.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `yarn lint`, `yarn run build:web:community --app_version=5.3.6-beta.5`, and `git diff --check` passed. In the isolated PR worktree, `yarn install --frozen-lockfile --offline --non-interactive`, `yarn lint`, and `git diff --check` also passed.
- Manual verification: Playwright CLI against the full Community Web build and an isolated backend connected to local SQL Server and MySQL. Passed short-list first opening, horizontal wheel over short lists, filtering, empty-search recovery, selection, select all, clearing, reopening, long-list scrolling with a fixed header, long-to-short filtering, Shift+wheel, and a narrow viewport. Scrollbars were fully hidden within the 180 ms observation window, did not intercept underlying content, remained visible while dragging outside for 3.3 seconds, and hid after release. Horizontal and vertical scrolling passed; no browser page errors. The maintainer accepted the resulting desktop behavior.
- UI evidence: The original short-list reproduction had a 174 px left margin. Actual Web measurements after the fix showed zero left margin and checkbox alignment with the header. Screenshots were inspected and temporary test processes, data profiles, and screenshots were removed.

## Risk and compatibility

- Public API or stored data: N/A - no API or persistence changes.
- Database or driver compatibility: Shared filter presentation only; no database-specific branches.
- Network, privacy, or security: N/A - no new network destinations or credential handling.
- Community / Local / Pro boundary: N/A - no runtime boundary changes.
- Backward compatibility: Uses the existing ResizeObserver API and rc-virtual-list scrollbar class names. Long lists retain virtualization and horizontal scrolling. The shared component also serves result-column filters.

## Reviewer map

- Start here: `chat2db-community-client/src/components/NodeFiltering/index.tsx` for the viewport width floor and observer lifecycle; `style.tsx` for scrollbar visibility and pointer handling.
- Failure condition: Open a list of short names, filter a long list to one short name, or drag a scrollbar outside the popover. Rows must remain aligned, hidden scrollbars must not block clicks, and the dragged thumb must remain visible until release.
- Rollback or disable path: Revert this PR. No migration or configuration change is required.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex implemented the change and performed code review, automated checks, and Playwright CLI verification under maintainer direction.
