### PR TITLE
fix(result): lazy-load large text values

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/components/ViewData/JsonAwareMonacoEditor.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ViewData/JsonAwareMonacoEditor.tsx
@@ -6,6 +6,7 @@ import MonacoEditor, { IEditorIns } from '@/components/MonacoEditor';
 interface IProps {
   id: string;
   value: string;
+  resetViewRevision: number;
   readOnly: boolean;
   onChange: (value: string) => void;
   onJsonChange: (isJson: boolean) => void;
@@ -16,7 +17,7 @@ interface JsonValidationWorker {
   parseJSONDocument: (uri: string) => Promise<monaco.languages.json.JSONDocument | null>;
 }
 
-const JsonAwareMonacoEditor = ({ id, value, readOnly, onChange, onJsonChange }: IProps) => {
+const JsonAwareMonacoEditor = ({ id, value, resetViewRevision, readOnly, onChange, onJsonChange }: IProps) => {
   const editorRef = useRef<IEditorIns | null>(null);
   const changeDisposerRef = useRef<{ dispose: () => void } | null>(null);
   const validationModelRef = useRef<monaco.editor.ITextModel | null>(null);
@@ -106,6 +107,15 @@ const JsonAwareMonacoEditor = ({ id, value, readOnly, onChange, onJsonChange }: 
   useEffect(() => {
     editorRef.current?.updateOptions({ readOnly });
   }, [readOnly]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    editor.setPosition({ lineNumber: 1, column: 1 });
+    editor.setScrollPosition({ scrollTop: 0, scrollLeft: 0 });
+  }, [resetViewRevision]);
 
   useEffect(() => {
     return () => {

--- a/chat2db-community-client/src/blocks/SearchResult/components/ViewData/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ViewData/index.tsx
@@ -72,6 +72,7 @@ export interface ViewDataRef {
 const ViewData = forwardRef((_props: IProps, ref: ForwardedRef<ViewDataRef>) => {
   const [viewData, setViewData] = useState<IViewData | null>(null);
   const [editorValue, setEditorContent] = useState('');
+  const [editorViewRevision, setEditorViewRevision] = useState(0);
   const [isJsonContent, setIsJsonContent] = useState(false);
   const activeViewDataRef = useRef<IViewData | null>(null);
   const editorValueRef = useRef('');
@@ -414,11 +415,19 @@ const ViewData = forwardRef((_props: IProps, ref: ForwardedRef<ViewDataRef>) => 
     applyEditorValue(value);
   };
 
+  const applyJsonPresentation = (value: string) => {
+    setEditorContent(value);
+    setEditorViewRevision((revision) => revision + 1);
+    if (!isLargeValue) {
+      applyEditorValue(value);
+    }
+  };
+
   const formatJson = () => {
     try {
       const parsed = JSON.parse(editorValue);
       const formatted = JSON.stringify(parsed, null, 2);
-      handleEditorValueChange(formatted);
+      applyJsonPresentation(formatted);
     } catch (err) {
       console.error('无效的 JSON 格式，请检查语法', err);
     }
@@ -428,7 +437,7 @@ const ViewData = forwardRef((_props: IProps, ref: ForwardedRef<ViewDataRef>) => 
     try {
       const parsed = JSON.parse(editorValue);
       const compressed = JSON.stringify(parsed);
-      handleEditorValueChange(compressed);
+      applyJsonPresentation(compressed);
     } catch (err) {
       console.error('无效的 JSON 格式，请检查语法', err);
     }
@@ -528,6 +537,7 @@ const ViewData = forwardRef((_props: IProps, ref: ForwardedRef<ViewDataRef>) => 
             <JsonAwareMonacoEditor
               id={uuid}
               value={editorValue}
+              resetViewRevision={editorViewRevision}
               readOnly={!editorCanEdit}
               onChange={handleEditorValueChange}
               onJsonChange={setIsJsonContent}
@@ -551,6 +561,7 @@ const ViewData = forwardRef((_props: IProps, ref: ForwardedRef<ViewDataRef>) => 
     largeValueStatus,
     displayMode,
     editorValue,
+    editorViewRevision,
     editorCanEdit,
     isJsonContent,
     viewerMode,

--- a/chat2db-community-client/src/blocks/SearchResult/components/ViewData/index.tsx
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ViewData/index.tsx
@@ -429,7 +429,7 @@ const ViewData = forwardRef((_props: IProps, ref: ForwardedRef<ViewDataRef>) => 
       const formatted = JSON.stringify(parsed, null, 2);
       applyJsonPresentation(formatted);
     } catch (err) {
-      console.error('无效的 JSON 格式，请检查语法', err);
+      console.error('Invalid JSON format. Check the syntax.', err);
     }
   };
 
@@ -439,7 +439,7 @@ const ViewData = forwardRef((_props: IProps, ref: ForwardedRef<ViewDataRef>) => 
       const compressed = JSON.stringify(parsed);
       applyJsonPresentation(compressed);
     } catch (err) {
-      console.error('无效的 JSON 格式，请检查语法', err);
+      console.error('Invalid JSON format. Check the syntax.', err);
     }
   };
 

--- a/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/model/value/JDBCDataValue.java
+++ b/chat2db-community-server/chat2db-community-spi/src/main/java/ai/chat2db/spi/model/value/JDBCDataValue.java
@@ -34,6 +34,8 @@ import java.util.regex.Pattern;
 @AllArgsConstructor
 public class JDBCDataValue {
     private static final Logger log = LoggerFactory.getLogger(JDBCDataValue.class);
+    private static final int LARGE_VALUE_THRESHOLD_BYTES = 10 * 1024;
+    private static final int LARGE_VALUE_PREVIEW_CHARS = 200;
     private static final Pattern SUMMARY_SIZE_PATTERN = Pattern.compile("(\\d+(?:\\.\\d+)?)\\s*(B|KB|MB|GB)\\s*$",
             Pattern.CASE_INSENSITIVE);
     private ResultSet resultSet;
@@ -267,10 +269,11 @@ public class JDBCDataValue {
         int sqlType = getSqlType();
         long displayBytes = value == null ? 0L : value.getBytes(StandardCharsets.UTF_8).length;
         long displayChars = value == null ? 0L : value.length();
-        LargeValueInfo largeValueInfo = detectLargeValue(value, columnType, sqlType);
-        Object rawValue = getRawCellValue(largeValueInfo);
+        LargeValueInfo largeValueInfo = detectLargeValue(value, columnType, sqlType, displayBytes);
+        String displayValue = previewValue(value, largeValueInfo);
+        Object rawValue = getRawCellValue(value, largeValueInfo);
         return ResultCell.builder()
-                .value(value)
+                .value(displayValue)
                 .rawValue(rawValue)
                 .largeValue(largeValueInfo.largeValue)
                 .valueType(largeValueInfo.valueType.code())
@@ -278,8 +281,9 @@ public class JDBCDataValue {
                 .columnType(columnType)
                 .sizeBytes(largeValueInfo.sizeBytes)
                 .sizeChars(largeValueInfo.sizeChars)
-                .loadedBytes(largeValueInfo.largeValue ? displayBytes : null)
-                .loadedChars(largeValueInfo.largeValue ? displayChars : null)
+                .loadedBytes(largeValueInfo.largeValue && displayValue != null
+                        ? (long) displayValue.getBytes(StandardCharsets.UTF_8).length : null)
+                .loadedChars(largeValueInfo.largeValue && displayValue != null ? (long) displayValue.length() : null)
                 .truncated(largeValueInfo.largeValue)
                 .build();
     }
@@ -319,7 +323,7 @@ public class JDBCDataValue {
         }
     }
 
-    private LargeValueInfo detectLargeValue(String value, String columnType, int sqlType) {
+    private LargeValueInfo detectLargeValue(String value, String columnType, int sqlType, long valueBytes) {
         LargeValueInfo info = new LargeValueInfo();
         info.valueType = LargeValueTypeEnum.resolve(columnType, sqlType);
         if (!limitSize || value == null) {
@@ -328,6 +332,7 @@ public class JDBCDataValue {
         Long summaryBytes = parseSummaryBytes(value);
         if (summaryBytes != null) {
             info.largeValue = true;
+            info.summary = true;
             info.sizeBytes = summaryBytes;
             if (info.valueType == LargeValueTypeEnum.BINARY && isImageSummary(value)) {
                 info.valueType = LargeValueTypeEnum.IMAGE;
@@ -337,9 +342,10 @@ public class JDBCDataValue {
             }
             return info;
         }
-        if (LargeValueTypeEnum.isPotentialLargeType(columnType, sqlType) && value.length() > LobUnitEnum.M.getSize()) {
+        if (LargeValueTypeEnum.isPotentialLargeType(columnType, sqlType)
+                && valueBytes > LARGE_VALUE_THRESHOLD_BYTES) {
             info.largeValue = true;
-            info.sizeBytes = (long) value.getBytes(StandardCharsets.UTF_8).length;
+            info.sizeBytes = valueBytes;
             info.sizeChars = (long) value.length();
         }
         return info;
@@ -349,10 +355,18 @@ public class JDBCDataValue {
         return value != null && value.toUpperCase(Locale.ROOT).contains(" IMAGE");
     }
 
-    private Object getRawCellValue(LargeValueInfo largeValueInfo) {
+    private String previewValue(String value, LargeValueInfo largeValueInfo) {
+        if (value == null || !largeValueInfo.largeValue || largeValueInfo.summary
+                || value.length() <= LARGE_VALUE_PREVIEW_CHARS) {
+            return value;
+        }
+        return value.substring(0, LARGE_VALUE_PREVIEW_CHARS);
+    }
+
+    private Object getRawCellValue(String value, LargeValueInfo largeValueInfo) {
         try {
             if (largeValueInfo.valueType == LargeValueTypeEnum.JSON) {
-                return getJsonString();
+                return value;
             }
             if (!largeValueInfo.largeValue) {
                 return getObject();
@@ -422,6 +436,7 @@ public class JDBCDataValue {
 
     private static class LargeValueInfo {
         private boolean largeValue;
+        private boolean summary;
         private LargeValueTypeEnum valueType = LargeValueTypeEnum.UNKNOWN;
         private Long sizeBytes;
         private Long sizeChars;

--- a/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/model/JDBCDataValueLargeCellTest.java
+++ b/chat2db-community-server/chat2db-community-spi/src/test/java/ai/chat2db/community/test/spi/model/JDBCDataValueLargeCellTest.java
@@ -66,6 +66,24 @@ class JDBCDataValueLargeCellTest {
     }
 
     @Test
+    void truncatesJsonValuesLargerThanTenKbForLazyLoading() {
+        String json = "{\"payload\":\"" + "x".repeat(11 * 1024) + "\"}";
+        JDBCDataValue value = new JDBCDataValue(resultSet(), metaData("jsonb", Types.OTHER), 1, true);
+
+        ResultCell cell = value.buildResultCell(json);
+
+        assertTrue(cell.isLargeValue());
+        assertTrue(cell.isTruncated());
+        assertEquals("JSON", cell.getValueType());
+        assertEquals(200, cell.getValue().length());
+        assertEquals(json, cell.getRawValue());
+        assertEquals((long) json.getBytes(java.nio.charset.StandardCharsets.UTF_8).length, cell.getSizeBytes());
+        assertEquals((long) json.length(), cell.getSizeChars());
+        assertEquals(200L, cell.getLoadedBytes());
+        assertEquals(200L, cell.getLoadedChars());
+    }
+
+    @Test
     void nullClobReturnsNullInsteadOfDereferencingClob() {
         ResultSet resultSet = resultSet("getClob", null, "getString", null);
         JDBCDataValue value = new JDBCDataValue(resultSet, metaData("CLOB", Types.CLOB), 1, true);


### PR DESCRIPTION
## Related issue

N/A - no existing issue covers this regression.

## Summary

Treat text-like and binary values larger than 10 KiB as lazy-loaded cells and keep only a 200-character preview in initial query results. This prevents large JSON/JSONB result pages from exceeding the desktop response serializer's large-object limit.

Keep large-value identity and actions intact when JSON is formatted or compressed in the value inspector, and reset the editor viewport to the start of the transformed content.

## Affected surfaces

- [x] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `yarn eslint src/blocks/SearchResult/components/ViewData/index.tsx src/blocks/SearchResult/components/ViewData/JsonAwareMonacoEditor.tsx` - passed.
  - `yarn tsx src/blocks/SearchResult/components/ViewData/largeCellValue.test.ts` - passed.
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-spi,:chat2db-community-domain-core -am -Dmaven.test.skip=false -DskipTests=false -Dtest=JDBCDataValueLargeCellTest,LargeValueTokenServiceTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false test` - 12 tests passed.
- Manual verification: Queried 1,000 rows from a 30-column PostgreSQL table whose JSONB value is about 64 KiB per row. The initial result completed without the previous serializer error, returned previews, and loaded complete JSONB values on demand by primary key. JSON format/compress retained the large-value controls.
- UI evidence: Manually verified the result grid and value inspector before and after JSON formatting.

## Risk and compatibility

- Public API or stored data: Response fields are unchanged; large eligible values now contain a bounded preview and existing large-value metadata.
- Database or driver compatibility: Uses the existing type classification and token-based read path. The threshold is measured in UTF-8 bytes.
- Network, privacy, or security: No new network operations or data exposure.
- Community / Local / Pro boundary: Community behavior only; no product-boundary changes.
- Backward compatibility: Small values and pre-existing LOB summaries retain their prior behavior. Results without a stable primary-key locator continue to expose only the preview for large values; lowering the threshold extends that existing limitation to values above 10 KiB.

## Reviewer map

- Start here: `JDBCDataValue.buildResultCell` for threshold/preview behavior, then `ViewData.applyJsonPresentation` for inspector state.
- Failure condition: Large JSON/JSONB result pages still serialize full cell values, or JSON formatting removes large-value actions.
- Rollback or disable path: Revert this commit to restore the previous 1 MiB inline behavior and inspector formatting flow.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Substantial AI assistance was used for diagnosis, implementation, review, and test execution.
