### PR TITLE
fix(frontend): restore driver download and copy icon

### DIFF
--- a/chat2db-community-client/src/blocks/NewTree/hooks/useCreateRightClickMenu.tsx
+++ b/chat2db-community-client/src/blocks/NewTree/hooks/useCreateRightClickMenu.tsx
@@ -1,6 +1,6 @@
 import i18n from '@/i18n';
 import { Form } from 'antd';
-import { SquarePen } from 'lucide-react';
+import { Copy, SquarePen } from 'lucide-react';
 import { type ReactNode, useRef } from 'react';
 import { v4 as uuid } from 'uuid';
 
@@ -366,7 +366,11 @@ export const useCreateRightClickMenu = () => {
       // copyName
       [OperationColumn.CopyName]: {
         text: i18n('common.button.copyName'),
-        icon: <span aria-hidden="true" style={{ display: 'inline-block', width: 20, height: 20 }} />,
+        icon: (
+          <span style={{ alignItems: 'center', display: 'inline-flex', height: 20, justifyContent: 'center', width: 20 }}>
+            <Copy size={18} strokeWidth={1.75} />
+          </span>
+        ),
         handle: () => {
           copyToClipboard(treeNodeData.originalTitle);
         },

--- a/chat2db-community-client/src/components/ConnectionEdit/components/Driver/index.tsx
+++ b/chat2db-community-client/src/components/ConnectionEdit/components/Driver/index.tsx
@@ -167,34 +167,29 @@ export default memo<IProps>((props) => {
         </Form.Item>
       </Form>
       <div className={styles.downloadDriveFooter}>
-        {(driverObj?.driverConfigList && !driverObj?.driverConfigList?.length) ||
-        downloadStatus === DownloadStatus.Success ? (
-          <div onClick={downloadDrive} className={styles.downloadDrive}>
-            {downloadStatus === DownloadStatus.Default && (
-              <div className={classnames(styles.downloadText, styles.downloadTextDownload)}>
-                {i18n('connection.text.downloadDriver')}
-              </div>
-            )}
-            {downloadStatus === DownloadStatus.Loading && (
-              <div className={classnames(styles.downloadText, styles.downloadTextLoading)}>
-                <LoadingGracile />
-                <div className={styles.text}>{i18n('connection.text.downloading')}</div>
-              </div>
-            )}
-            {downloadStatus === DownloadStatus.Error && (
-              <div className={classnames(styles.downloadText, styles.downloadTextError)}>
-                {i18n('connection.text.tryAgainDownload')}
-              </div>
-            )}
-            {downloadStatus === DownloadStatus.Success && (
-              <div className={classnames(styles.downloadText, styles.downloadTextSuccess)}>
-                {i18n('connection.text.downloadSuccess')}
-              </div>
-            )}
-          </div>
-        ) : (
-          <div />
-        )}
+        <div onClick={downloadDrive} className={styles.downloadDrive}>
+          {downloadStatus === DownloadStatus.Default && (
+            <div className={classnames(styles.downloadText, styles.downloadTextDownload)}>
+              {i18n('connection.text.downloadDriver')}
+            </div>
+          )}
+          {downloadStatus === DownloadStatus.Loading && (
+            <div className={classnames(styles.downloadText, styles.downloadTextLoading)}>
+              <LoadingGracile />
+              <div className={styles.text}>{i18n('connection.text.downloading')}</div>
+            </div>
+          )}
+          {downloadStatus === DownloadStatus.Error && (
+            <div className={classnames(styles.downloadText, styles.downloadTextError)}>
+              {i18n('connection.text.tryAgainDownload')}
+            </div>
+          )}
+          {downloadStatus === DownloadStatus.Success && (
+            <div className={classnames(styles.downloadText, styles.downloadTextSuccess)}>
+              {i18n('connection.text.downloadSuccess')}
+            </div>
+          )}
+        </div>
         {(isDesktop || isCommunityEnv) && (
           <div
             className={styles.uploadCustomDrive}


### PR DESCRIPTION
## Related issue

N/A - direct UI fix requested and verified locally.

## Summary

- Add the Lucide Copy icon to the database tree Copy name action while preserving the 20px menu icon slot and matching adjacent icon weight.
- Keep the built-in driver download action visible even when one or more JDBC drivers are already installed, so users can manually re-download drivers.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `yarn eslint src/blocks/NewTree/hooks/useCreateRightClickMenu.tsx src/components/ConnectionEdit/components/Driver/index.tsx --max-warnings=0` passed; `yarn run build:web:community --app_version=0.0.0` passed, including all configured pre-build tests and production bundle validation.
- Manual verification: Playwright CLI verified the Copy icon uses an 18px glyph centered in the existing 20px slot, adjacent labels remain aligned, and the driver list request returns 200 while Download driver remains visible with installed MySQL drivers.
- UI evidence: Verified in the local Community Web runtime with Playwright CLI; user confirmed the final appearance.

## Risk and compatibility

- Public API or stored data: None.
- Database or driver compatibility: No driver contract changes; only restores access to the existing download action.
- Network, privacy, or security: No new requests or data flows.
- Community / Local / Pro boundary: Shared frontend behavior only; existing runtime guards remain unchanged.
- Backward compatibility: Existing download states and handlers are preserved.

## Reviewer map

- Start here: `chat2db-community-client/src/blocks/NewTree/hooks/useCreateRightClickMenu.tsx` and `chat2db-community-client/src/components/ConnectionEdit/components/Driver/index.tsx`.
- Failure condition: Copy name lacks a visually aligned icon, or Download driver is hidden when installed drivers are present.
- Rollback or disable path: Revert this commit.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A - direct UI fix.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex traced the existing menu and driver rendering paths, implemented the scoped frontend changes, and ran lint, build, and Playwright verification.