### PR TITLE
fix(import): enable preview in desktop runtimes

### DIFF
--- a/chat2db-community-client/package.json
+++ b/chat2db-community-client/package.json
@@ -97,7 +97,7 @@
     "test:driver-upload": "tsx src/components/ConnectionEdit/components/Driver/driverUpload.test.ts",
     "test:terminal": "tsx src/constants/terminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceExtend/WorkspaceExtendNav/quickTerminal.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/terminalTabPlacement.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/terminalAttachmentLifecycle.test.ts && tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabSelection.test.ts",
     "test:task-center": "tsx src/store/importExport/taskCenterUtils.test.ts",
-    "test:import-preview": "tsx src/blocks/ImportAndExport/components/ImportMappingContent/mapping.test.ts && tsx src/blocks/ImportAndExport/components/ImportExportFile/selection.test.ts && tsx src/blocks/ImportAndExport/components/ImportFileModal/submission.test.ts",
+    "test:import-preview": "tsx src/blocks/ImportAndExport/components/ImportMappingContent/mapping.test.ts && tsx src/blocks/ImportAndExport/components/ImportMappingContent/fileStaging.test.ts && tsx src/blocks/ImportAndExport/components/ImportExportFile/selection.test.ts && tsx src/blocks/ImportAndExport/components/ImportFileModal/submission.test.ts",
     "test:workspace-tab-drag": "tsx src/pages/main/workspace/components/WorkspaceTabs/workspaceTabDrop.test.ts",
     "test:verification-code-countdown": "tsx src/utils/verificationCodeCountdown.test.ts && tsx src/utils/latestRequest.test.ts",
     "test:account-grants-request": "tsx src/pages/main/workspace/components/WorkspaceExtend/GlobalExtendComponents/accountGrantsRequest.test.ts",

--- a/chat2db-community-client/src/blocks/ImportAndExport/components/ImportExportFile/index.tsx
+++ b/chat2db-community-client/src/blocks/ImportAndExport/components/ImportExportFile/index.tsx
@@ -14,7 +14,7 @@ import { hasSelectedImportFile } from './selection';
 interface IProps {
   className?: string;
   setIsReady?: (p: boolean) => void;
-  onImportFileChange?: (file?: File) => void;
+  onImportFileChange?: (file?: FileUrl) => void;
 }
 
 export interface ImportExportFileRef {
@@ -80,7 +80,7 @@ const ImportExportFile = forwardRef((props: IProps, ref: ForwardedRef<ImportExpo
     setSelectedFilePaths(files.map((item) => item.filePath).filter((path): path is string => !!path));
     if (isImport) {
       setIsReady?.(hasSelectedImportFile(files));
-      onImportFileChange?.(files[0]?.file);
+      onImportFileChange?.(files[0]);
     }
   };
 

--- a/chat2db-community-client/src/blocks/ImportAndExport/components/ImportFileModal/index.tsx
+++ b/chat2db-community-client/src/blocks/ImportAndExport/components/ImportFileModal/index.tsx
@@ -18,13 +18,14 @@ import {
   IMPORT_TARGET_TABLE_REFRESH_EVENT,
   shouldRefreshImportTargetTable,
 } from '@/store/importExport/taskCenterUtils';
+import type { FileUrl } from '@/components/UploadLocalFile';
 
 interface IProps {
   className?: string;
 }
 
-const isPreviewFile = (file?: File) => {
-  const name = file?.name.toLowerCase();
+const isPreviewFile = (file?: FileUrl) => {
+  const name = (file?.fileName || file?.file?.name)?.toLowerCase();
   return name?.endsWith('.csv') || name?.endsWith('.xls') || name?.endsWith('.xlsx');
 };
 
@@ -34,7 +35,7 @@ export default memo<IProps>((_props) => {
   const previousTaskDetailsRef = useRef<ImportExportTaskDetails>();
   const [taskId, setTaskId] = useState<number>();
   const [taskDetails, setTaskDetails] = useState<ImportExportTaskDetails>();
-  const [importFile, setImportFile] = useState<File>();
+  const [importFile, setImportFile] = useState<FileUrl>();
 
   const { importExportDataBoundInfo, setImportExportDataBoundInfo, getTaskList } = useImportExportStore((state) => {
     return {
@@ -60,8 +61,8 @@ export default memo<IProps>((_props) => {
     if ('sourceFile' in params) {
       let importParams = params;
       if (!isDesktop) {
-        if (!importFile) return;
-        importParams = await prepareWebImportParams(importParams, importFile, sqlService.uploadImportFile);
+        if (!importFile?.file) return;
+        importParams = await prepareWebImportParams(importParams, importFile.file, sqlService.uploadImportFile);
       }
       response = await importExportServices.submitImport(importParams);
     } else {
@@ -71,7 +72,7 @@ export default memo<IProps>((_props) => {
     getTaskList();
   };
 
-  const handleImportFileChange = (file?: File) => {
+  const handleImportFileChange = (file?: FileUrl) => {
     setImportFile(file);
   };
 
@@ -147,7 +148,6 @@ export default memo<IProps>((_props) => {
 
   const importPreviewContext =
     importExportDataBoundInfo?.type === ImportExportType.IMPORT &&
-    !isDesktop &&
     isPreviewFile(importFile) &&
     importExportDataBoundInfo.dataSourceId != null &&
     importExportDataBoundInfo.databaseName != null &&

--- a/chat2db-community-client/src/blocks/ImportAndExport/components/ImportMappingContent/fileStaging.test.ts
+++ b/chat2db-community-client/src/blocks/ImportAndExport/components/ImportMappingContent/fileStaging.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { stageSelectedImportFile } from './fileStaging';
+
+test('stages browser files through multipart upload', async () => {
+  const browserFile = { name: 'users.csv' } as File;
+  const fileId = await stageSelectedImportFile(
+    { file: browserFile, fileName: browserFile.name },
+    async ({ file }) => {
+      assert.equal(file, browserFile);
+      return 'browser-file-id';
+    },
+    async () => {
+      throw new Error('desktop staging must not be used');
+    },
+  );
+
+  assert.equal(fileId, 'browser-file-id');
+});
+
+test('stages desktop paths through the JCEF-only endpoint', async () => {
+  const fileId = await stageSelectedImportFile(
+    { filePath: '/tmp/users.xlsx', fileName: 'users.xlsx' },
+    async () => {
+      throw new Error('browser upload must not be used');
+    },
+    async (request) => {
+      assert.deepEqual(request, { sourceFile: '/tmp/users.xlsx', originalFileName: 'users.xlsx' });
+      return 'desktop-file-id';
+    },
+  );
+
+  assert.equal(fileId, 'desktop-file-id');
+});
+
+test('rejects incomplete selections', async () => {
+  await assert.rejects(() => stageSelectedImportFile({}, async () => '', async () => ''));
+});

--- a/chat2db-community-client/src/blocks/ImportAndExport/components/ImportMappingContent/fileStaging.ts
+++ b/chat2db-community-client/src/blocks/ImportAndExport/components/ImportMappingContent/fileStaging.ts
@@ -1,0 +1,18 @@
+import type { FileUrl } from '@/components/UploadLocalFile';
+
+type UploadBrowserFile = (params: { file: File }) => Promise<string>;
+type StageDesktopFile = (params: { sourceFile: string; originalFileName: string }) => Promise<string>;
+
+export const stageSelectedImportFile = (
+  selection: FileUrl,
+  uploadBrowserFile: UploadBrowserFile,
+  stageDesktopFile: StageDesktopFile,
+): Promise<string> => {
+  if (selection.file) {
+    return uploadBrowserFile({ file: selection.file });
+  }
+  if (selection.filePath && selection.fileName) {
+    return stageDesktopFile({ sourceFile: selection.filePath, originalFileName: selection.fileName });
+  }
+  return Promise.reject(new Error('Import file selection is incomplete'));
+};

--- a/chat2db-community-client/src/blocks/ImportAndExport/components/ImportMappingContent/index.tsx
+++ b/chat2db-community-client/src/blocks/ImportAndExport/components/ImportMappingContent/index.tsx
@@ -13,13 +13,15 @@ import {
   ImportMappingRow,
 } from './mapping';
 import { useStyles } from './style';
+import type { FileUrl } from '@/components/UploadLocalFile';
+import { stageSelectedImportFile } from './fileStaging';
 
 interface IProps {
   dataSourceId: number;
   databaseName: string;
   schemaName?: string;
   tableName: string;
-  file: File;
+  file: FileUrl;
   onSubmitted: (taskId: number) => void;
 }
 
@@ -68,8 +70,7 @@ const ImportMappingContent = ({ dataSourceId, databaseName, schemaName, tableNam
   useEffect(() => {
     setLoading(true);
     setError(null);
-    sqlService
-      .uploadImportFile({ file })
+    stageSelectedImportFile(file, sqlService.uploadImportFile, sqlService.stageDesktopImportFile)
       .then((id) => {
         setFileId(id);
         load(id);

--- a/chat2db-community-client/src/service/sql.ts
+++ b/chat2db-community-client/src/service/sql.ts
@@ -465,6 +465,11 @@ const uploadImportFile = createRequest<{ file: File }, string>('/api/rdb/import_
   contentType: 'formData',
 });
 
+const stageDesktopImportFile = createRequest<
+  { sourceFile: string; originalFileName: string },
+  string
+>('/api/rdb/import_preview/upload_local', { method: 'post' });
+
 const getImportPreview = createRequest<
   { dataSourceId: number; databaseName: string; schemaName?: string; tableName: string; fileId: string },
   IImportPreview
@@ -603,6 +608,7 @@ export default {
   getImportPreview,
   executeImportWithMapping,
   uploadImportFile,
+  stageDesktopImportFile,
   getActiveTransactionList,
   getDataSourceList,
 };

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/db/ImportFileUploadAdapter.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/adapter/db/ImportFileUploadAdapter.java
@@ -2,6 +2,8 @@ package ai.chat2db.community.web.api.adapter.db;
 
 import ai.chat2db.community.domain.api.service.file.IImportFileStagingService;
 import ai.chat2db.community.domain.api.service.file.IUploadFileService;
+import ai.chat2db.community.web.api.config.console.DesktopBridgeRequestContext;
+import ai.chat2db.community.web.api.model.request.db.DesktopImportFileRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -33,5 +35,10 @@ public class ImportFileUploadAdapter {
                 transferredFile.delete();
             }
         }
+    }
+
+    public String stageDesktopFile(DesktopImportFileRequest request) {
+        DesktopBridgeRequestContext.requireActive();
+        return importFileStagingService.stage(new File(request.getSourceFile()), request.getOriginalFileName());
     }
 }

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/config/console/DesktopBridgeRequestContext.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/config/console/DesktopBridgeRequestContext.java
@@ -1,0 +1,35 @@
+package ai.chat2db.community.web.api.config.console;
+
+import ai.chat2db.community.tools.exception.BusinessException;
+
+import java.util.function.Supplier;
+
+public final class DesktopBridgeRequestContext {
+
+    private static final ThreadLocal<Boolean> ACTIVE = new ThreadLocal<>();
+
+    private DesktopBridgeRequestContext() {
+    }
+
+    public static <T> T invoke(Supplier<T> operation) {
+        boolean nested = isActive();
+        ACTIVE.set(true);
+        try {
+            return operation.get();
+        } finally {
+            if (!nested) {
+                ACTIVE.remove();
+            }
+        }
+    }
+
+    public static void requireActive() {
+        if (!isActive()) {
+            throw new BusinessException("common.permissionDenied");
+        }
+    }
+
+    static boolean isActive() {
+        return Boolean.TRUE.equals(ACTIVE.get());
+    }
+}

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/config/console/WebJcefServerBridge.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/config/console/WebJcefServerBridge.java
@@ -33,7 +33,7 @@ public class WebJcefServerBridge implements IJcefServerBridge {
 
     @Override
     public ConsoleResult doController(ConsoleMessage message) {
-        return ConsoleHelper.doController(message);
+        return DesktopBridgeRequestContext.invoke(() -> ConsoleHelper.doController(message));
     }
 
     @Override

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/controller/DbImportPreviewController.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/controller/DbImportPreviewController.java
@@ -8,6 +8,7 @@ import ai.chat2db.community.tools.wrapper.result.DataResult;
 import ai.chat2db.community.web.api.adapter.db.ImportFileUploadAdapter;
 import ai.chat2db.community.web.api.aspect.connection.ConnectionInfoAspect;
 import ai.chat2db.community.web.api.converter.db.DbImportWebConverter;
+import ai.chat2db.community.web.api.model.request.db.DesktopImportFileRequest;
 import ai.chat2db.community.web.api.model.request.db.ImportExecuteRequest;
 import ai.chat2db.community.web.api.model.request.db.ImportPreviewRequest;
 import ai.chat2db.community.web.api.model.response.task.TaskSubmitResponse;
@@ -52,6 +53,11 @@ public class DbImportPreviewController {
     @PostMapping("/upload")
     public DataResult<String> upload(@RequestParam("file") MultipartFile file) {
         return DataResult.of(importFileUploadAdapter.stage(file));
+    }
+
+    @PostMapping("/upload_local")
+    public DataResult<String> uploadDesktopFile(@Valid @RequestBody DesktopImportFileRequest request) {
+        return DataResult.of(importFileUploadAdapter.stageDesktopFile(request));
     }
 
     @PostMapping("/preview")

--- a/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/model/request/db/DesktopImportFileRequest.java
+++ b/chat2db-community-server/chat2db-community-web/src/main/java/ai/chat2db/community/web/api/model/request/db/DesktopImportFileRequest.java
@@ -1,0 +1,14 @@
+package ai.chat2db.community.web.api.model.request.db;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class DesktopImportFileRequest {
+
+    @NotBlank
+    private String sourceFile;
+
+    @NotBlank
+    private String originalFileName;
+}

--- a/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/adapter/db/ImportFileUploadAdapterTest.java
+++ b/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/adapter/db/ImportFileUploadAdapterTest.java
@@ -1,0 +1,63 @@
+package ai.chat2db.community.web.api.adapter.db;
+
+import ai.chat2db.community.domain.api.service.file.IImportFileStagingService;
+import ai.chat2db.community.tools.exception.BusinessException;
+import ai.chat2db.community.web.api.config.console.DesktopBridgeRequestContext;
+import ai.chat2db.community.web.api.model.request.db.DesktopImportFileRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ImportFileUploadAdapterTest {
+
+    @Test
+    void stagesDesktopFileOnlyInsideJcefBridge(@TempDir Path directory) throws Exception {
+        File selectedFile = Files.writeString(directory.resolve("users.csv"), "name\nAda\n").toFile();
+        RecordingStagingService stagingService = new RecordingStagingService();
+        ImportFileUploadAdapter adapter = new ImportFileUploadAdapter(null, stagingService);
+        DesktopImportFileRequest request = new DesktopImportFileRequest();
+        request.setSourceFile(selectedFile.getAbsolutePath());
+        request.setOriginalFileName("users.csv");
+
+        assertThrows(BusinessException.class, () -> adapter.stageDesktopFile(request));
+
+        String fileId = DesktopBridgeRequestContext.invoke(() -> adapter.stageDesktopFile(request));
+        assertEquals("file-id", fileId);
+        assertEquals(selectedFile, stagingService.sourceFile);
+        assertEquals("users.csv", stagingService.originalFileName);
+    }
+
+    private static final class RecordingStagingService implements IImportFileStagingService {
+
+        private File sourceFile;
+        private String originalFileName;
+
+        @Override
+        public String stage(File file, String fileName) {
+            sourceFile = file;
+            originalFileName = fileName;
+            return "file-id";
+        }
+
+        @Override
+        public File resolve(String fileId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void claimForTask(String fileId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void release(String fileId) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/config/console/DesktopBridgeRequestContextTest.java
+++ b/chat2db-community-server/chat2db-community-web/src/test/java/ai/chat2db/community/web/api/config/console/DesktopBridgeRequestContextTest.java
@@ -1,0 +1,34 @@
+package ai.chat2db.community.web.api.config.console;
+
+import ai.chat2db.community.tools.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DesktopBridgeRequestContextTest {
+
+    @Test
+    void marksOnlyTheCurrentBridgeInvocationAsActive() {
+        assertFalse(DesktopBridgeRequestContext.isActive());
+
+        DesktopBridgeRequestContext.invoke(() -> {
+            assertTrue(DesktopBridgeRequestContext.isActive());
+            DesktopBridgeRequestContext.requireActive();
+            return null;
+        });
+
+        assertFalse(DesktopBridgeRequestContext.isActive());
+        assertThrows(BusinessException.class, DesktopBridgeRequestContext::requireActive);
+    }
+
+    @Test
+    void clearsContextWhenBridgeInvocationFails() {
+        assertThrows(IllegalStateException.class, () -> DesktopBridgeRequestContext.invoke(() -> {
+            throw new IllegalStateException("failed");
+        }));
+
+        assertFalse(DesktopBridgeRequestContext.isActive());
+    }
+}


### PR DESCRIPTION
## Related issue

N/A - follow-up to #2652 desktop compatibility review.

## Summary

Enable CSV/XLS/XLSX import preview and column mapping in JCEF desktop runtimes. Desktop file paths are staged through a JCEF-only request context before reusing the existing preview and execution flow; ordinary HTTP requests cannot invoke the local-path staging operation.

## Affected surfaces

- [x] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `yarn run lint` passed; `yarn run build:web:community --app_version=0.0.0` passed; focused Web tests ran 3 tests with 0 failures; full 48-module backend package passed.
- Manual verification: Runtime-level Pro and Local desktop verification will use the generated thin runtime after this commit.
- UI evidence: N/A - runtime verification pending.

## Risk and compatibility

- Public API or stored data: Adds a local staging endpoint guarded by an active JCEF bridge context; no stored-data contract changes.
- Database or driver compatibility: Database-independent; existing CSV/XLS/XLSX parser and mapping execution are reused.
- Network, privacy, or security: Local paths are accepted only during JCEF controller dispatch and copied into the existing server-managed staging area.
- Community / Local / Pro boundary: Enables the same preview flow for Community, Local, and Pro desktop runtimes while preserving Web multipart upload.
- Backward compatibility: JSON/SQL desktop imports keep their existing direct local-path flow.

## Reviewer map

- Start here: `ImportFileModal`, `fileStaging.ts`, and `DesktopBridgeRequestContext`.
- Failure condition: Desktop selection bypasses preview, ordinary HTTP can stage a local path, or the staged file is not released after task completion.
- Rollback or disable path: Revert this commit to restore Web-only preview behavior.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex implemented and tested the desktop compatibility follow-up under maintainer direction.
