### PR TITLE
fix(jcef): create browser during hidden startup

### DIFF
--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
@@ -809,7 +809,15 @@ public class MainJFrame extends JFrame {
                 }
             }
         });
+        createBrowserImmediatelyForHiddenStartup(browser_, showWindowOnStartup);
         log.info("4. CefBrowser and UI component creation completed.");
+    }
+
+    static void createBrowserImmediatelyForHiddenStartup(CefBrowser browser, boolean showWindowOnStartup) {
+        if (!showWindowOnStartup) {
+            // Windowed JCEF normally creates the browser when Swing makes its component displayable.
+            browser.createImmediately();
+        }
     }
 
     private static String resolveWebFrontendUrl() {

--- a/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/MainJFrameTest.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/frame/MainJFrameTest.java
@@ -1,0 +1,46 @@
+package ai.chat2db.community.jcef.frame;
+
+import org.cef.browser.CefBrowser;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MainJFrameTest {
+
+    @Test
+    void shouldCreateBrowserImmediatelyForHiddenStartup() {
+        AtomicInteger immediateCreationCount = new AtomicInteger();
+        CefBrowser browser = recordingBrowser(immediateCreationCount);
+
+        MainJFrame.createBrowserImmediatelyForHiddenStartup(browser, false);
+
+        assertEquals(1, immediateCreationCount.get());
+    }
+
+    @Test
+    void shouldKeepLazyBrowserCreationForVisibleStartup() {
+        AtomicInteger immediateCreationCount = new AtomicInteger();
+        CefBrowser browser = recordingBrowser(immediateCreationCount);
+
+        MainJFrame.createBrowserImmediatelyForHiddenStartup(browser, true);
+
+        assertEquals(0, immediateCreationCount.get());
+    }
+
+    private static CefBrowser recordingBrowser(AtomicInteger immediateCreationCount) {
+        return (CefBrowser) Proxy.newProxyInstance(
+                CefBrowser.class.getClassLoader(),
+                new Class<?>[]{CefBrowser.class},
+                (proxy, method, args) -> {
+                    if ("createImmediately".equals(method.getName())) {
+                        immediateCreationCount.incrementAndGet();
+                        return null;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                }
+        );
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #2889

## Summary

Explicitly create the windowed JCEF browser when the desktop starts with its initial JFrame hidden. Windowed JCEF normally waits for Swing to make the browser component displayable; hidden startup skips that event, so the frontend never loads or reports readiness.

Visible startup keeps the existing lazy creation behavior.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `mvn -pl chat2db-community-jcef -am -Dmaven.test.skip=false -Dtest=MainJFrameTest -Dsurefire.failIfNoSpecifiedTests=false test`: 2 tests passed.
  - `mvn -pl chat2db-community-jcef -am -Dmaven.test.skip=false test`: 110 tests passed, 0 failures, 0 errors, 1 platform-conditional skip.
  - Downstream desktop runtime compatibility suite: 6 tests passed.
- Manual verification: Windows packaged hidden-start integration remains to be verified because the current development environment is macOS.
- UI evidence: N/A; the affected startup mode intentionally has no visible window.

## Risk and compatibility

- Public API or stored data: N/A; no public API or persistence changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: The change is limited to the shared Community JCEF window lifecycle and adds no product-specific behavior.
- Backward compatibility: Visible startup remains unchanged; only callers that explicitly request a hidden initial window use immediate browser creation.

## Reviewer map

- Start here: `MainJFrame#createBrowserImmediatelyForHiddenStartup` and its call after browser UI assembly.
- Failure condition: A hidden startup does not create the browser, so its frontend readiness signal never occurs.
- Rollback or disable path: Revert the single immediate-creation call and helper method.

## Contributor declaration

- [x] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex analyzed the JCEF lifecycle, implemented the focused change and regression tests, and ran the reported verification. The maintainer reviewed the diagnosis and selected the final scope.
