### PR TITLE
fix(jcef): stop editor cursor flicker

### DIFF
--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/frame/MainJFrame.java
@@ -799,16 +799,6 @@ public class MainJFrame extends JFrame {
         } else {
             this.splitPane.setBackground(ThemeUtil.getThemeColor());
         }
-        this.splitPane.addMouseMotionListener(new MouseAdapter() {
-            @Override
-            public void mouseMoved(MouseEvent e) {
-                if (Math.abs(e.getX() - splitPane.getDividerLocation()) < 3) {
-                    splitPane.setCursor(Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR));
-                } else {
-                    splitPane.setCursor(Cursor.getDefaultCursor());
-                }
-            }
-        });
         createBrowserImmediatelyForHiddenStartup(browser_, showWindowOnStartup);
         log.info("4. CefBrowser and UI component creation completed.");
     }

--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/handler/mouse/CursorHandler.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/handler/mouse/CursorHandler.java
@@ -5,10 +5,16 @@ import org.cef.handler.CefDisplayHandlerAdapter;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 public class CursorHandler extends CefDisplayHandlerAdapter {
 
     private static final Object FORCED_CURSOR_LOCK = new Object();
+    private static final Map<Component, CursorState> FORCED_CURSOR_RESTORE_VALUES = new IdentityHashMap<>();
+    private static final Map<Component, Integer> BROWSER_CURSOR_TYPES = Collections.synchronizedMap(new WeakHashMap<>());
     private static volatile Integer forcedCursorType;
     private static long forcedCursorSequence;
 
@@ -18,7 +24,7 @@ public class CursorHandler extends CefDisplayHandlerAdapter {
         if (!isPredefinedCursorType(effectiveCursorType)) {
             return false;
         }
-        applyCursor(browser, cursorType);
+        applyCursor(browser, isPredefinedCursorType(cursorType) ? cursorType : null);
         return true;
     }
 
@@ -26,7 +32,7 @@ public class CursorHandler extends CefDisplayHandlerAdapter {
         if (!updateForcedCursor(cssCursor, sequence)) {
             return;
         }
-        applyCursor(browser, Cursor.DEFAULT_CURSOR);
+        applyCursor(browser, null);
     }
 
     static boolean updateForcedCursor(String cssCursor, long sequence) {
@@ -54,6 +60,8 @@ public class CursorHandler extends CefDisplayHandlerAdapter {
         synchronized (FORCED_CURSOR_LOCK) {
             forcedCursorSequence = 0;
             forcedCursorType = null;
+            FORCED_CURSOR_RESTORE_VALUES.clear();
+            BROWSER_CURSOR_TYPES.clear();
         }
     }
 
@@ -68,22 +76,48 @@ public class CursorHandler extends CefDisplayHandlerAdapter {
         };
     }
 
-    private static void applyCursor(CefBrowser browser, int cursorType) {
+    private static void applyCursor(CefBrowser browser, Integer browserCursorType) {
         if (browser == null) {
             return;
         }
         SwingUtilities.invokeLater(() -> {
-            int effectiveCursorType = effectiveCursorType(cursorType);
-            if (!isPredefinedCursorType(effectiveCursorType)) {
+            Component browserComponent = browser.getUIComponent();
+            if (browserComponent == null) {
                 return;
             }
-            Cursor awtCursor = Cursor.getPredefinedCursor(effectiveCursorType);
-            Component component = browser.getUIComponent();
-            while (component != null) {
-                component.setCursor(awtCursor);
-                component = component.getParent();
+            if (browserCursorType != null) {
+                BROWSER_CURSOR_TYPES.put(browserComponent, browserCursorType);
             }
+
+            Integer forcedType = forcedCursorType;
+            if (forcedType != null) {
+                applyForcedCursor(browserComponent, forcedType);
+                return;
+            }
+
+            restoreForcedCursorComponents();
+            int cursorType = BROWSER_CURSOR_TYPES.getOrDefault(browserComponent, Cursor.DEFAULT_CURSOR);
+            browserComponent.setCursor(Cursor.getPredefinedCursor(cursorType));
         });
+    }
+
+    private static void applyForcedCursor(Component browserComponent, int cursorType) {
+        Cursor cursor = Cursor.getPredefinedCursor(cursorType);
+        Component component = browserComponent;
+        while (component != null) {
+            FORCED_CURSOR_RESTORE_VALUES.putIfAbsent(
+                    component,
+                    new CursorState(component.isCursorSet(), component.getCursor())
+            );
+            component.setCursor(cursor);
+            component = component.getParent();
+        }
+    }
+
+    private static void restoreForcedCursorComponents() {
+        FORCED_CURSOR_RESTORE_VALUES.forEach((component, state) ->
+                component.setCursor(state.explicitlySet() ? state.cursor() : null));
+        FORCED_CURSOR_RESTORE_VALUES.clear();
     }
 
     static int effectiveCursorType(int cursorType) {
@@ -93,5 +127,8 @@ public class CursorHandler extends CefDisplayHandlerAdapter {
 
     static boolean isPredefinedCursorType(int cursorType) {
         return cursorType >= Cursor.DEFAULT_CURSOR && cursorType <= Cursor.MOVE_CURSOR;
+    }
+
+    private record CursorState(boolean explicitlySet, Cursor cursor) {
     }
 }

--- a/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/handler/mouse/CursorHandlerTest.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/handler/mouse/CursorHandlerTest.java
@@ -90,6 +90,82 @@ class CursorHandlerTest {
     }
 
     @Test
+    void normalBrowserCursorDoesNotOverwriteParentCursor() throws Exception {
+        Panel parent = new Panel();
+        parent.setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
+        Panel browserComponent = new Panel();
+        parent.add(browserComponent);
+
+        assertTrue(new CursorHandler().onCursorChange(
+                browserWithUiComponent(browserComponent),
+                Cursor.TEXT_CURSOR
+        ));
+        flushEventQueue();
+
+        assertEquals(Cursor.TEXT_CURSOR, browserComponent.getCursor().getType());
+        assertEquals(Cursor.CROSSHAIR_CURSOR, parent.getCursor().getType());
+    }
+
+    @Test
+    void forcedCursorRestoresComponentHierarchyAndLatestBrowserCursor() throws Exception {
+        Panel root = new Panel();
+        root.setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
+        Panel parent = new Panel();
+        parent.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        Panel inheritedParent = new Panel();
+        Panel browserComponent = new Panel();
+        root.add(parent);
+        parent.add(inheritedParent);
+        inheritedParent.add(browserComponent);
+        CefBrowser browser = browserWithUiComponent(browserComponent);
+        CursorHandler handler = new CursorHandler();
+
+        assertTrue(handler.onCursorChange(browser, Cursor.TEXT_CURSOR));
+        flushEventQueue();
+        CursorHandler.setForcedCursor(browser, "ns-resize", 20);
+        flushEventQueue();
+
+        assertEquals(Cursor.N_RESIZE_CURSOR, browserComponent.getCursor().getType());
+        assertEquals(Cursor.N_RESIZE_CURSOR, inheritedParent.getCursor().getType());
+        assertEquals(Cursor.N_RESIZE_CURSOR, parent.getCursor().getType());
+        assertEquals(Cursor.N_RESIZE_CURSOR, root.getCursor().getType());
+
+        assertTrue(handler.onCursorChange(browser, Cursor.HAND_CURSOR));
+        flushEventQueue();
+        assertEquals(Cursor.N_RESIZE_CURSOR, browserComponent.getCursor().getType());
+
+        CursorHandler.setForcedCursor(browser, "default", 21);
+        flushEventQueue();
+
+        assertEquals(Cursor.HAND_CURSOR, browserComponent.getCursor().getType());
+        assertFalse(inheritedParent.isCursorSet());
+        assertEquals(Cursor.HAND_CURSOR, inheritedParent.getCursor().getType());
+        assertEquals(Cursor.HAND_CURSOR, parent.getCursor().getType());
+        assertEquals(Cursor.CROSSHAIR_CURSOR, root.getCursor().getType());
+    }
+
+    @Test
+    void eachBrowserRestoresItsOwnLatestCursor() throws Exception {
+        Panel firstComponent = new Panel();
+        Panel secondComponent = new Panel();
+        CefBrowser firstBrowser = browserWithUiComponent(firstComponent);
+        CefBrowser secondBrowser = browserWithUiComponent(secondComponent);
+        CursorHandler handler = new CursorHandler();
+
+        assertTrue(handler.onCursorChange(firstBrowser, Cursor.TEXT_CURSOR));
+        assertTrue(handler.onCursorChange(secondBrowser, Cursor.HAND_CURSOR));
+        flushEventQueue();
+
+        CursorHandler.setForcedCursor(firstBrowser, "ns-resize", 20);
+        flushEventQueue();
+        CursorHandler.setForcedCursor(firstBrowser, "default", 21);
+        flushEventQueue();
+
+        assertEquals(Cursor.TEXT_CURSOR, firstComponent.getCursor().getType());
+        assertEquals(Cursor.HAND_CURSOR, secondComponent.getCursor().getType());
+    }
+
+    @Test
     void highestConcurrentSequenceOwnsForcedCursor() throws Exception {
         ExecutorService executor = Executors.newFixedThreadPool(8);
         try {
@@ -116,5 +192,10 @@ class CursorHandlerTest {
                 new Class<?>[]{CefBrowser.class},
                 (proxy, method, args) -> method.getName().equals("getUIComponent") ? component : null
         );
+    }
+
+    private void flushEventQueue() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+        });
     }
 }


### PR DESCRIPTION
## Related issue

N/A - reported through a desktop user recording.

## Summary

- Stop the hidden DevTools split pane from resetting the cursor to the default arrow on every mouse move.
- Keep normal Chromium cursor updates scoped to the browser component.
- Apply workspace resize cursors across the component hierarchy only while resizing, then restore the prior parent cursors and the latest browser cursor.
- Track browser cursors independently so the main browser and DevTools cannot overwrite each other's restore state.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `mvn -B -f chat2db-community-server/pom.xml -pl chat2db-community-jcef -am -Dmaven.test.skip=false -DskipTests=false -Dtest=CursorHandlerTest,MainJFrameTest -Dsurefire.failIfNoSpecifiedTests=false test`: 10 tests passed.
  - `mvn -B -f chat2db-community-server/pom.xml -pl chat2db-community-jcef -am -Dmaven.test.skip=false -DskipTests=false test`: tools 73 tests passed; JCEF 113 tests ran with 0 failures, 0 errors, and 1 platform skip.
- Manual verification: The supplied recording and temporary cursor instrumentation isolated competing writes from the split pane and Chromium. A replacement desktop runtime was built for follow-up acceptance testing.
- UI evidence: Supplied user recording demonstrates the pre-fix cursor flicker.

## Risk and compatibility

- Public API or stored data: N/A - no API or persistence changes.
- Database or driver compatibility: N/A.
- Network, privacy, or security: N/A.
- Community boundary: The change is limited to the Community JCEF desktop runtime.
- Backward compatibility: Workspace resize cursors and their sequence ordering are preserved; normal browser cursors no longer overwrite parent containers.

## Reviewer map

- Start here: `CursorHandler.applyCursor` and the removed `JSplitPane` mouse-motion listener in `MainJFrame`.
- Failure condition: Moving over a text editor alternates between the text cursor and default arrow, or a resize cursor remains after resizing ends.
- Rollback or disable path: Revert this commit.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A - no public Issue exists.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex analyzed the supplied recording, added temporary runtime instrumentation, implemented the fix, reviewed the final diff, and added regression tests. The temporary instrumentation is not included in this PR.
