### PR TITLE
fix(redis): support RedisJSON keys

### DIFF
--- a/chat2db-community-client/src/blocks/RedisAllData/EditData/index.tsx
+++ b/chat2db-community-client/src/blocks/RedisAllData/EditData/index.tsx
@@ -10,6 +10,7 @@ import redisServices from '@/service/nonRelationalDatabase/redis';
 import { RedisDataItem } from '@/typings/redis';
 import { useUpdateEffect } from 'ahooks';
 import { cloneDeep } from 'lodash';
+import feedback from '@/utils/feedback';
 
 interface IProps {
   className?: string;
@@ -69,7 +70,7 @@ export default memo<IProps>((props) => {
       ttl: values.ttl,
       type: values.type,
     };
-    if (baseData.type === RedisFieldType.STRING) {
+    if (baseData.type === RedisFieldType.STRING || baseData.type === RedisFieldType.JSON) {
       baseData.value = values.value;
     } else if (baseData.type === RedisFieldType.STREAM) {
       baseData.streamValues = createStreamRef?.current?.getStreamList() || [];
@@ -91,6 +92,9 @@ export default memo<IProps>((props) => {
         .then((_redisDataItem) => {
           submitSuccess && submitSuccess(_redisDataItem);
         })
+        .catch((error) => {
+          feedback.error(error instanceof Error ? error.message : String(error));
+        })
         .finally(() => {
           setTimeout(() => {
             setButtonLoading(false);
@@ -106,6 +110,9 @@ export default memo<IProps>((props) => {
         })
         .then((_redisDataItem) => {
           submitSuccess && submitSuccess(_redisDataItem);
+        })
+        .catch((error) => {
+          feedback.error(error instanceof Error ? error.message : String(error));
         })
         .finally(() => {
           setTimeout(() => {
@@ -142,13 +149,13 @@ export default memo<IProps>((props) => {
         </div>
         <div className={styles.fullFormItemBox}>
           {/* string */}
-          {formValue.type === RedisFieldType.STRING && (
+          {(formValue.type === RedisFieldType.STRING || formValue.type === RedisFieldType.JSON) && (
             <Form.Item label={i18n('redis.value')} name="value" className={styles.textAreaFormItem}>
               <TextArea style={{ resize: 'none' }} />
             </Form.Item>
           )}
 
-          {formValue.type !== RedisFieldType.STRING && formValue.type !== RedisFieldType.STREAM && (
+          {formValue.type !== RedisFieldType.STRING && formValue.type !== RedisFieldType.JSON && formValue.type !== RedisFieldType.STREAM && (
             <div className={styles.createList}>
               <Form.Item label={i18n('redis.value')}>
                 <CreateList

--- a/chat2db-community-client/src/blocks/RedisAllData/redisDetail.test.ts
+++ b/chat2db-community-client/src/blocks/RedisAllData/redisDetail.test.ts
@@ -24,6 +24,11 @@ assert.equal(
 );
 assert.equal(isRedisDataItemLoaded(item({ detailLoaded: true, value: '' })), true, 'empty strings are values');
 assert.equal(
+  isRedisDataItemLoaded(item({ type: RedisFieldType.JSON, detailLoaded: true, value: '{"name":"alice"}' })),
+  true,
+  'RedisJSON documents are loaded as JSON text',
+);
+assert.equal(
   isRedisDataItemLoaded(item({ type: RedisFieldType.LIST, detailLoaded: true, listValues: [] })),
   true,
   'empty arrays are loaded payloads',

--- a/chat2db-community-client/src/blocks/RedisAllData/redisDetail.ts
+++ b/chat2db-community-client/src/blocks/RedisAllData/redisDetail.ts
@@ -7,6 +7,7 @@ export type RedisDetailLoadStatus = 'idle' | 'loading' | 'loaded' | 'failed';
 export function hasRedisDetailPayload(redisDataItem: RedisDataItem) {
   switch (redisDataItem.type) {
     case RedisFieldType.STRING:
+    case RedisFieldType.JSON:
       return redisDataItem.value !== null && redisDataItem.value !== undefined;
     case RedisFieldType.LIST:
       return redisDataItem.listValues !== null && redisDataItem.listValues !== undefined;

--- a/chat2db-community-client/src/constants/redis.ts
+++ b/chat2db-community-client/src/constants/redis.ts
@@ -5,6 +5,7 @@ export enum RedisFieldType {
   ZSET = 'zset',
   HASH = 'hash',
   STREAM = 'stream',
+  JSON = 'json',
 }
 
 export enum ActionType {
@@ -21,4 +22,5 @@ export const redisFieldTypeList = [
   { label: RedisFieldType.ZSET, value: RedisFieldType.ZSET },
   { label: RedisFieldType.HASH, value: RedisFieldType.HASH },
   { label: RedisFieldType.STREAM, value: RedisFieldType.STREAM },
+  { label: RedisFieldType.JSON, value: RedisFieldType.JSON },
 ];

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisKeyScanner.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisKeyScanner.java
@@ -3,6 +3,7 @@ package ai.chat2db.plugin.redis;
 import ai.chat2db.plugin.redis.config.RedisScanConfig;
 import ai.chat2db.plugin.redis.constant.RedisCommandTemplates;
 import ai.chat2db.plugin.redis.constant.RedisConstants;
+import ai.chat2db.plugin.redis.enums.type.RedisDataType;
 import ai.chat2db.plugin.redis.model.RedisKey;
 import ai.chat2db.plugin.redis.model.RedisKeyScanResult;
 import ai.chat2db.plugin.redis.type.RedisScanStoppedReason;
@@ -96,7 +97,7 @@ public final class RedisKeyScanner {
     private RedisKey buildKeyHandle(String keyName) {
         RedisKey redisKey = new RedisKey();
         redisKey.setName(keyName);
-        redisKey.setType(RedisScriptExecutor.getInstance().getKeyType(keyName));
+        redisKey.setType(RedisDataType.normalizeCode(RedisScriptExecutor.getInstance().getKeyType(keyName)));
         String ttl = RedisScriptExecutor.getInstance().getTtl(keyName);
         if (StringUtils.isNotBlank(ttl)) {
             redisKey.setTtl(Long.parseLong(ttl));

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisMetaData.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisMetaData.java
@@ -277,7 +277,7 @@ public class RedisMetaData extends DefaultMetaService implements IDbMetaData {
         RedisKey redisKey = new RedisKey();
         redisKey.setName(key);
         String keyType = RedisScriptExecutor.getInstance().getKeyType(connection, key);
-        redisKey.setType(keyType);
+        redisKey.setType(RedisDataType.normalizeCode(keyType));
         ITypeScript typeScript = RedisDataType.fromCode(keyType).getScript();
         return typeScript.getKeyR(connection, redisKey);
     }
@@ -305,9 +305,12 @@ public class RedisMetaData extends DefaultMetaService implements IDbMetaData {
                         RedisKey redisKey = new RedisKey();
                         redisKey.setName(keyName);
                         String keyType = RedisScriptExecutor.getInstance().getKeyType(keyName);
-                        redisKey.setType(keyType);
+                        redisKey.setType(RedisDataType.normalizeCode(keyType));
                         ITypeScript typeScript = RedisDataType.fromCode(keyType).getScript();
-                        redisKeys.add(typeScript.getKeyR(connection, redisKey));
+                        RedisKey detail = typeScript.getKeyR(connection, redisKey);
+                        if (detail != null) {
+                            redisKeys.add(detail);
+                        }
                     }
                 }
                 return nextCursor;

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisScriptExecutor.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisScriptExecutor.java
@@ -68,7 +68,7 @@ public class RedisScriptExecutor extends DefaultSQLExecutor {
                 .build();
         // getKeyType/getTtl yield null on empty driver result sets; Map.of would NPE on null values.
         Map<String, Object> extra = new HashMap<>();
-        extra.put(RedisConstants.FIELD_KEY_TYPE, keyType);
+        extra.put(RedisConstants.FIELD_KEY_TYPE, RedisDataType.normalizeCode(keyType));
         extra.put(RedisConstants.FIELD_KEY, command.getTableName());
         extra.put(RedisConstants.FIELD_TTL, getTtl(command.getTableName()));
         String script = typeScript.getKey(redisKey);
@@ -297,7 +297,7 @@ public class RedisScriptExecutor extends DefaultSQLExecutor {
         ITypeScript typeScript = RedisDataType.fromCode(keyType).getScript();
         RedisKey redisKey = RedisKey.builder()
                 .name(key)
-                .type(keyType)
+                .type(RedisDataType.normalizeCode(keyType))
                 .build();
         return typeScript.getKeyR(connection, redisKey);
     }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisSqlBuilder.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/RedisSqlBuilder.java
@@ -204,6 +204,8 @@ public class RedisSqlBuilder implements ISqlBuilder, IDqlSqlBuilder, IDmlSqlBuil
             case STRING:
                 appendStringOperation(script, keyName, operationType, newRow);
                 break;
+            case JSON:
+                throw unsupported(RedisConstants.METHOD_BUILD_JSON_OPERATION);
             default:
                 break;
         }

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/constant/RedisConstants.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/constant/RedisConstants.java
@@ -15,6 +15,8 @@ public final class RedisConstants {
     public static final String COMMAND_EXPIRE_KEY_PREFIX = "EXPIRE ";
     public static final String COMMAND_PERSIST_KEY_PREFIX = "PERSIST ";
     public static final String COMMAND_GET_KEY_PREFIX = "GET ";
+    public static final String COMMAND_JSON_GET_KEY_PREFIX = "JSON.GET ";
+    public static final String COMMAND_JSON_SET_KEY_PREFIX = "JSON.SET ";
     public static final String COMMAND_HASH_DELETE_PREFIX = "HDEL ";
     public static final String COMMAND_HASH_GET_ALL_PREFIX = "HGETALL ";
     public static final String COMMAND_HASH_GET_PREFIX = "HGET ";
@@ -88,6 +90,7 @@ public final class RedisConstants {
     public static final String METHOD_BUILD_SHOW_CREATE_VIEW = "buildShowCreateView";
     public static final String METHOD_BUILD_TRUNCATE_TABLE = "buildTruncateTable";
     public static final String METHOD_BUILD_UPDATE = "buildUpdate";
+    public static final String METHOD_BUILD_JSON_OPERATION = "buildJsonOperation";
     public static final String METHOD_BUILD_USE_DATABASE = "buildUseDatabase";
     public static final String REDIS_EXEC_COMMAND = "EXEC";
     public static final String REDIS_MULTI_COMMAND = "MULTI \n";

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/enums/type/RedisDataType.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/enums/type/RedisDataType.java
@@ -2,6 +2,7 @@ package ai.chat2db.plugin.redis.enums.type;
 
 import ai.chat2db.plugin.redis.type.HashTypeScript;
 import ai.chat2db.plugin.redis.type.ITypeScript;
+import ai.chat2db.plugin.redis.type.JsonTypeScript;
 import ai.chat2db.plugin.redis.type.ListTypeScript;
 import ai.chat2db.plugin.redis.type.SetTypeScript;
 import ai.chat2db.plugin.redis.type.StreamTypeScript;
@@ -15,6 +16,7 @@ public enum RedisDataType {
     ZSET,
     HASH,
     STREAM,
+    JSON,
     NONE;
 
     public ITypeScript getScript() {
@@ -31,6 +33,8 @@ public enum RedisDataType {
                 return new HashTypeScript();
             case STREAM:
                 return new StreamTypeScript();
+            case JSON:
+                return new JsonTypeScript();
             default:
                 return new StringTypeScript();
         }
@@ -41,12 +45,21 @@ public enum RedisDataType {
     }
 
     public static RedisDataType fromCode(String code) {
+        if (code != null && (code.equalsIgnoreCase("json")
+                || code.equalsIgnoreCase("ReJSON-RL")
+                || code.equalsIgnoreCase("ReJSON-RS"))) {
+            return JSON;
+        }
         for (RedisDataType type : values()) {
             if (type.getCode().equals(code)) {
                 return type;
             }
         }
         return NONE;
+    }
+
+    public static String normalizeCode(String code) {
+        return fromCode(code) == JSON ? JSON.getCode() : code;
     }
 
 

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/JsonTypeScript.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/main/java/ai/chat2db/plugin/redis/type/JsonTypeScript.java
@@ -1,0 +1,83 @@
+package ai.chat2db.plugin.redis.type;
+
+import ai.chat2db.plugin.redis.RedisScriptExecutor;
+import ai.chat2db.plugin.redis.constant.RedisConstants;
+import ai.chat2db.plugin.redis.enums.type.RedisDataType;
+import ai.chat2db.plugin.redis.model.RedisKey;
+import ai.chat2db.spi.DefaultSQLExecutor;
+import org.apache.commons.lang3.StringUtils;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.Objects;
+
+import static ai.chat2db.plugin.redis.util.RedisValueUtils.getRedisValue;
+
+public class JsonTypeScript extends BaseTypeScript implements ITypeScript {
+
+    @Override
+    public String getKey(RedisKey redisKey) {
+        return RedisConstants.COMMAND_JSON_GET_KEY_PREFIX + getRedisValue(redisKey.getName());
+    }
+
+    @Override
+    public RedisKey getKeyR(Connection connection, RedisKey redisKey) {
+        if (!existKey(connection, redisKey.getName())) {
+            return null;
+        }
+        RedisKey result = new RedisKey();
+        result.setName(redisKey.getName());
+        result.setType(RedisDataType.JSON.getCode());
+        DefaultSQLExecutor.getInstance().execute(connection, getKey(redisKey), resultSet -> {
+            while (resultSet.next()) {
+                String value = resultSet.getString(RedisConstants.FIELD_VALUE);
+                if (Objects.nonNull(value)) {
+                    result.setValue(value);
+                }
+            }
+        });
+        String ttl = RedisScriptExecutor.getInstance().getTtl(connection, redisKey.getName());
+        result.setTtl(StringUtils.isNotBlank(ttl) ? Long.parseLong(ttl) : -1L);
+        return result;
+    }
+
+    @Override
+    public List<String> createKey(RedisKey redisKey) {
+        if (redisKey == null || redisKey.getValue() == null) {
+            return List.of();
+        }
+        String script = jsonSet(redisKey.getName(), redisKey.getValue());
+        if (redisKey.getTtl() != null && redisKey.getTtl() > 0) {
+            return List.of(script, RedisConstants.COMMAND_EXPIRE_KEY_PREFIX + getRedisValue(redisKey.getName())
+                    + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + redisKey.getTtl());
+        }
+        return List.of(script);
+    }
+
+    @Override
+    public List<String> updateKey(RedisKey oldKey, RedisKey newKey) {
+        if (oldKey == null && newKey == null) {
+            return null;
+        }
+        if (oldKey == null) {
+            return createKey(newKey);
+        }
+        if (newKey == null) {
+            return List.of(delete(oldKey.getName()));
+        }
+        if (Objects.equals(oldKey.getValue(), newKey.getValue())) {
+            return null;
+        }
+        if (newKey.getValue() == null) {
+            return null;
+        }
+        return List.of(jsonSet(newKey.getName(), newKey.getValue())
+                + RedisConstants.COMMAND_SET_KEY_IF_EXISTS_SUFFIX);
+    }
+
+    private String jsonSet(String name, String value) {
+        return RedisConstants.COMMAND_JSON_SET_KEY_PREFIX + getRedisValue(name)
+                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue("$")
+                + RedisConstants.COMMAND_ARGUMENT_SEPARATOR + getRedisValue(value);
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/enums/type/RedisDataTypeTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/enums/type/RedisDataTypeTest.java
@@ -1,0 +1,17 @@
+package ai.chat2db.plugin.redis.enums.type;
+
+import ai.chat2db.plugin.redis.type.JsonTypeScript;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RedisDataTypeTest {
+
+    @Test
+    void mapsRedisJsonModuleTypesToJsonScript() {
+        assertEquals(RedisDataType.JSON, RedisDataType.fromCode("ReJSON-RL"));
+        assertEquals("json", RedisDataType.normalizeCode("ReJSON-RS"));
+        assertInstanceOf(JsonTypeScript.class, RedisDataType.fromCode("ReJSON-RL").getScript());
+    }
+}

--- a/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/JsonTypeScriptTest.java
+++ b/chat2db-community-server/chat2db-community-plugins/chat2db-community-redis/src/test/java/ai/chat2db/plugin/redis/type/JsonTypeScriptTest.java
@@ -1,0 +1,45 @@
+package ai.chat2db.plugin.redis.type;
+
+import ai.chat2db.plugin.redis.model.RedisKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsonTypeScriptTest {
+
+    private final JsonTypeScript typeScript = new JsonTypeScript();
+
+    private RedisKey key(String name, String value) {
+        return RedisKey.builder().name(name).type("json").value(value).build();
+    }
+
+    @Test
+    void readsTheJsonDocumentWithJsonGet() {
+        assertEquals("JSON.GET 'profile'", typeScript.getKey(key("profile", null)));
+    }
+
+    @Test
+    void createsTheJsonDocumentWithJsonSet() {
+        assertEquals(List.of("JSON.SET 'profile' '$' '{\"name\":\"alice\"}'"),
+                typeScript.createKey(key("profile", "{\"name\":\"alice\"}")));
+    }
+
+    @Test
+    void preservesTheRequestedTtlWhenCreatingTheJsonDocument() {
+        RedisKey redisKey = key("profile", "{\"name\":\"alice\"}");
+        redisKey.setTtl(60L);
+
+        assertEquals(List.of("JSON.SET 'profile' '$' '{\"name\":\"alice\"}'",
+                        "EXPIRE 'profile' 60"),
+                typeScript.createKey(redisKey));
+    }
+
+    @Test
+    void updatesTheJsonDocumentWithJsonSet() {
+        assertEquals(List.of("JSON.SET 'profile' '$' '{\"name\":\"bob\"}' XX \n"),
+                typeScript.updateKey(key("profile", "{\"name\":\"alice\"}"),
+                        key("profile", "{\"name\":\"bob\"}")));
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #2674

## Summary

RedisJSON module keys were treated as unknown Redis strings and opened with `GET`. This change recognizes RedisJSON type aliases, uses `JSON.GET`/`JSON.SET` with separate expiry handling, and keeps ordinary Redis strings on `GET`.

## Affected surfaces

- [ ] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `git diff --check` passed. Focused Maven tests and frontend tests/lint were not run because Java/Maven and the required frontend executables are unavailable.
- Manual verification: Not run; no RedisJSON service is available.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: The API exposes the normalized `json` type; no stored-data migration.
- Database or driver compatibility: RedisJSON keys require the RedisJSON command set; ordinary Redis core types are unchanged.
- Network, privacy, or security: N/A.
- Community / Local / Pro boundary: Community Redis plugin and Redis browser only.
- Backward compatibility: Existing Redis types retain their existing commands and payload shapes.

## Reviewer map

- Start here: Redis type normalization, JSON command handling, and Redis detail dispatch.
- Failure condition: RedisJSON keys were treated as unknown strings and opened with `GET`.
- Rollback or disable path: Revert the RedisJSON type and editor changes; existing core Redis type handling is independent.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [ ] I tested the affected behavior and reported the actual results above.
- [ ] I did not include credentials, private data, or generated build output.