### PR TITLE
fix(table): preserve filters after query errors

### DIFF
--- a/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/viewTablePagingFlow.test.ts
+++ b/chat2db-community-client/src/blocks/SearchResult/components/ResultSet/viewTablePagingFlow.test.ts
@@ -226,6 +226,31 @@ test('a cancelled table browse never publishes its buffered partial rows', () =>
   assert.equal(transition.completedResult, undefined, 'cancellation leaves the visible completed result untouched');
 });
 
+test('a failed filter keeps the mounted table and allows a corrected query to replace it', () => {
+  const [initialResult] = normalizeViewTablePageResults([result()], { sql: BASE_SQL, dataSourceId: 42 });
+  const failedParams = { ...initialResult.executeSqlParams!, sql: `${BASE_SQL} WHERE %asda` };
+  const failed = reduceViewTablePagingEvent(
+    createViewTablePagingState(1, failedParams),
+    event('resultFinished', result({ success: false, headerList: [], message: 'Invalid WHERE condition' })),
+    1,
+  );
+
+  assert.equal(failed.completedResult, undefined, 'a SQL error must not replace and unmount the table');
+  assert.equal(failed.state.result?.message, 'Invalid WHERE condition', 'the request retains the error to report');
+
+  const correctedParams = { ...failedParams, sql: `${BASE_SQL} WHERE id = 1` };
+  const corrected = reduceViewTablePagingEvent(
+    createViewTablePagingState(2, correctedParams),
+    event('resultFinished', result({ dataList: [[{ value: '1' }]] as any })),
+    2,
+  );
+  assert.ok(corrected.completedResult);
+  const [replaced] = replaceViewTableResult([initialResult], corrected.completedResult);
+  assert.equal(replaced.uuid, initialResult.uuid);
+  assert.equal(replaced.originalSql, BASE_SQL);
+  assert.deepEqual(replaced.dataList, [[{ value: '1' }]]);
+});
+
 test('table browse cancellation targets the active JCEF execution and releases the request', async () => {
   const tracker = createSqlExecutionRequestTracker();
   const requestSequence = beginSqlExecutionRequest(tracker)!;

--- a/chat2db-community-client/src/hooks/useViewTablePaging.ts
+++ b/chat2db-community-client/src/hooks/useViewTablePaging.ts
@@ -44,6 +44,10 @@ export default function useViewTablePaging() {
       paramsRef.current = params;
       return executeSQL(params).then((data) => {
         const normalizedData = normalizeViewTablePageResults(data, params);
+        const pageResult = normalizedData[0] || pagingStateRef.current?.result;
+        if (pageResult?.success === false) {
+          throw new Error(pageResult.message);
+        }
         if (normalizedData.length) {
           setResultData(normalizedData[0]);
         }

--- a/chat2db-community-client/src/hooks/viewTablePagingModel.ts
+++ b/chat2db-community-client/src/hooks/viewTablePagingModel.ts
@@ -73,7 +73,7 @@ export function reduceViewTablePagingEvent(
   const nextState = { ...state, result };
   return {
     state: nextState,
-    completedResult: event.eventType === 'resultFinished' ? result : undefined,
+    completedResult: event.eventType === 'resultFinished' && result.success ? result : undefined,
   };
 }
 


### PR DESCRIPTION
## Related issue

N/A — maintainer-reported and reproduced during this session; no issue was created.

## Summary

Entering an invalid WHERE or ORDER BY expression while browsing a table replaced the result with an error page and unmounted the filter editors, leaving no way to correct the expression. Failed page results now retain the last successful table and its editors, and report the error through the existing inline error panel. Correcting or clearing the expression allows the next query to succeed.

The change covers HTTP responses and desktop stream completion, with a regression test for failure followed by recovery.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

The shared frontend also handles desktop table browsing; no Java bridge or packaging changes.

## Verification

- Commands and results (from `chat2db-community-client`):
  - `yarn install --frozen-lockfile --offline` — passed in the PR worktree.
  - `yarn test:result-pagination` — 12 tests passed, including the new failure/recovery case.
  - `yarn test:search-result-query-composer` — passed.
  - `yarn test:i18n` — passed.
  - `yarn lint` — passed.
  - `yarn build:web:community --app_version=0.0.0` — passed before handoff; includes the build prechecks and production bundle validation.
  - `git diff --check` — passed.
- Manual verification: Playwright CLI against an isolated SQLite fixture (3 rows), frontend port 8895 and backend port 10895. `%asda` reports an error while retaining both editors and the previous rows; changing to `id = 1` returns one row; clearing the filter returns all three. Consecutive filters and invalid/corrected ORDER BY expressions also recover. The editor DOM nodes remain mounted, request SQL matches the expressions, and the final browser console has no errors. The maintainer also tested and accepted the page.
- Desktop verification: a temporary React hook harness simulated successful, failed, corrected, and cancelled execution callbacks; failed and cancelled executions retained the confirmed result. Native desktop packaging was not rebuilt.
- UI evidence: N/A — screenshots were visually checked during local verification and removed with the temporary test artifacts; no screenshot is attached.

## Risk and compatibility

- Public API or stored data: N/A — no contract or persistence changes.
- Database or driver compatibility: Uses the existing result `success` and `message` fields; database-specific execution is unchanged.
- Network, privacy, or security: N/A — no new requests, permissions, or data exposure.
- Community / Local / Pro boundary: N/A — no edition-routing changes.
- Backward compatibility: Success behavior is retained. On failure, the visible rows remain the last successful result while the existing error panel explains the failed query.

## Reviewer map

- Start here: `src/hooks/useViewTablePaging.ts` rejects failed page responses before replacing visible data; `src/hooks/viewTablePagingModel.ts` publishes only successful completed stream results. Paths are under `chat2db-community-client`.
- Failure condition: Browse a table, enter `%asda` in WHERE, and press Enter. Both WHERE and ORDER BY editors must remain usable; correcting or clearing the expression must recover.
- Rollback or disable path: Revert this commit; there is no data migration or feature flag.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A — maintainer-reported issue, no separate ticket.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: OpenAI Codex investigated, implemented, reviewed, and tested this change. The maintainer manually verified the corrected page and requested this PR.
