### PR TITLE
fix(tree): expand namespace after datasource creation

### DIFF
--- a/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeftActionBar/components/AddDatasourceBar/index.tsx
+++ b/chat2db-community-client/src/pages/main/workspace/components/WorkspaceLeftActionBar/components/AddDatasourceBar/index.tsx
@@ -208,7 +208,7 @@ export default memo<IProps>(() => {
         .then(async (res: any) => {
           setIsModalVisible(false);
           if (res?.id) {
-            await refreshDataSourceAfterMutation(res.id);
+            await refreshDataSourceAfterMutation(res.id, { expandParent: true });
           }
         });
     }

--- a/chat2db-community-client/src/store/tree/dataSourceMutationRefresh.test.ts
+++ b/chat2db-community-client/src/store/tree/dataSourceMutationRefresh.test.ts
@@ -21,6 +21,7 @@ async function testUsesCanonicalNodeLoadedAfterMutation() {
       return true;
     },
     getDataSourceList: () => dataSourceList,
+    expandParent: (node) => events.push(`expand:${String(node.key)}`),
     setSelectedKeys: (keys) => events.push(`select:${String(keys[0])}`),
     setScrollTargetKey: (key) => events.push(`scroll:${String(key)}`),
     loadData: async (node) => {
@@ -31,6 +32,7 @@ async function testUsesCanonicalNodeLoadedAfterMutation() {
   assert.equal(result, canonicalNode);
   assert.deepEqual(events, [
     'refresh',
+    'expand:dataSource_42',
     'select:dataSource_42',
     'scroll:dataSource_42',
     'load:dataSource_42',

--- a/chat2db-community-client/src/store/tree/dataSourceMutationRefresh.ts
+++ b/chat2db-community-client/src/store/tree/dataSourceMutationRefresh.ts
@@ -4,6 +4,7 @@ import type { Key } from 'react';
 interface DataSourceMutationRefreshDependencies {
   refreshTreeData: () => Promise<boolean>;
   getDataSourceList: () => TreeNodeData[] | null;
+  expandParent?: (node: TreeNodeData) => void;
   setSelectedKeys: (keys: Key[]) => void;
   setScrollTargetKey: (key: Key | null) => void;
   loadData: (node: TreeNodeData) => Promise<unknown>;
@@ -27,6 +28,7 @@ export async function hydrateDataSourceAfterMutation(
       return null;
     }
 
+    dependencies.expandParent?.(dataSource);
     dependencies.setSelectedKeys([dataSource.key]);
     dependencies.setScrollTargetKey(dataSource.key);
     await dependencies.loadData(dataSource);

--- a/chat2db-community-client/src/store/tree/index.tsx
+++ b/chat2db-community-client/src/store/tree/index.tsx
@@ -124,7 +124,7 @@ export interface TreeAction {
   setTreeData: (treeData: TreeState['treeData'] | any) => void;
   getTreeData: (props?: { refresh?: boolean; force?: boolean; throwOnError?: boolean }) => Promise<boolean>;
   refreshTreeData: () => Promise<boolean>;
-  refreshDataSourceAfterMutation: (dataSourceId: number) => Promise<void>;
+  refreshDataSourceAfterMutation: (dataSourceId: number, options?: { expandParent?: boolean }) => Promise<void>;
   // Database structure synchronization
   schemaSync: () => void;
   setSelectedKeys: (selectedKeys: TreeState['selectedKeys']) => void;
@@ -219,10 +219,19 @@ export const createTreeAction: StateCreator<TreeStore, [['zustand/devtools', nev
       refreshNode: (node) => get().handleLoadData(node, { refresh: true, preserveInteraction: true }),
       refreshRoot: () => get().getTreeData({ refresh: true }),
     }),
-  refreshDataSourceAfterMutation: async (dataSourceId) => {
+  refreshDataSourceAfterMutation: async (dataSourceId, options) => {
     await hydrateDataSourceAfterMutation(dataSourceId, {
       refreshTreeData: () => get().getTreeData({ refresh: true, throwOnError: true }),
       getDataSourceList: () => get().dataSourceList,
+      expandParent: options?.expandParent
+        ? (dataSource) => {
+            const treeData = get().treeData;
+            const parentNode = treeData ? getParentNode(dataSource.key, treeData) : null;
+            if (parentNode) {
+              get().setExpandedKeys(appendExpandedTreeKey(get().expandedKeys, parentNode.key));
+            }
+          }
+        : undefined,
       setSelectedKeys: get().setSelectedKeys,
       setScrollTargetKey: get().setScrollTargetKey,
       loadData: (node) => get().handleLoadData(node),


### PR DESCRIPTION
## Related issue

N/A - regression found during datasource tree verification.

## Summary

Automatically expand the containing group after a datasource is created from that group's context menu. The refresh continues to use the canonical server tree, then expands the actual parent before selecting, scrolling to, and loading the new datasource.

## Affected surfaces

- [x] Frontend / Web
- [ ] Backend / API / Storage
- [ ] Database plugin / Driver
- [ ] JCEF / Desktop packaging
- [ ] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results: `yarn test:data-source-mutation-refresh` passed; `yarn build:web:community` passed, including the full frontend test chain and production bundle verification.
- Manual verification: Playwright CLI created a MySQL datasource through the group context menu; exactly one create request returned 200, the datasource remained under the selected group, and the group became expanded immediately.
- UI evidence: Playwright accessibility snapshot verified `pw-auto-expand-group [expanded]` with the new datasource visible below it.

## Risk and compatibility

- Public API or stored data: No API or storage format changes.
- Database or driver compatibility: N/A - UI state only.
- Network, privacy, or security: N/A - no new network or data handling.
- Community / Local / Pro boundary: Shared Community tree behavior only; no commercial implementation is included.
- Backward compatibility: Existing create and edit flows retain their refresh behavior; parent expansion is enabled only for creation.

## Reviewer map

- Start here: `chat2db-community-client/src/store/tree/index.tsx` and `dataSourceMutationRefresh.ts`.
- Failure condition: a datasource created inside a collapsed group remains hidden after the refresh.
- Rollback or disable path: remove the `expandParent` option passed by `AddDatasourceBar`.

## Contributor declaration

- [ ] I linked the Issue that defines this change.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex assisted with diagnosis, implementation, test updates, Playwright CLI verification, and review.
