### PR TITLE
build(deps): upgrade Fastjson2 to 2.0.65

### DIFF
--- a/chat2db-community-server/chat2db-community-bom/pom.xml
+++ b/chat2db-community-server/chat2db-community-bom/pom.xml
@@ -25,7 +25,7 @@
         <commons-collections4.version>4.4</commons-collections4.version>
         <guava.version>32.0.1-jre</guava.version>
         <hutool.version>5.8.20</hutool.version>
-        <fastjson2.version>2.0.49</fastjson2.version>
+        <fastjson2.version>2.0.65</fastjson2.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <lombok.version>1.18.44</lombok.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>

--- a/chat2db-community-server/chat2db-community-tools/src/test/java/ai/chat2db/community/tools/util/JsonFileUtilsTest.java
+++ b/chat2db-community-server/chat2db-community-tools/src/test/java/ai/chat2db/community/tools/util/JsonFileUtilsTest.java
@@ -1,5 +1,6 @@
 package ai.chat2db.community.tools.util;
 
+import com.alibaba.fastjson2.JSONException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -39,6 +40,18 @@ class JsonFileUtilsTest {
         for (String content : List.of("broken JSON", "null")) {
             Files.writeString(path, content);
             assertThrows(RuntimeException.class, () -> JsonFileUtils.readArray(path.toFile(), Entry.class));
+            assertEquals(content, Files.readString(path));
+        }
+    }
+
+    @Test
+    void excessiveNumberLiteralsAreRejectedWithoutChangingTheFile() throws IOException {
+        Path path = directory.resolve("records.json");
+        String digits = "9".repeat(10_001);
+        for (String content : List.of("[" + digits + "]", "[{\"value\":-" + digits + "}]")) {
+            Files.writeString(path, content);
+
+            assertThrows(JSONException.class, () -> JsonFileUtils.readArray(path.toFile(), Object.class));
             assertEquals(content, Files.readString(path));
         }
     }


### PR DESCRIPTION
## Related issue

N/A — maintainer-requested dependency maintenance based on upstream release notes.

## Summary

Upgrade the shared Fastjson2 dependency from 2.0.49 to 2.0.65 so Community builds include the upstream parser and AutoType security updates. Add a regression through `JsonFileUtils.readArray` that rejects excessive numeric literals without changing the stored file.

Reviewed upstream releases from 2.0.50 through 2.0.65 and the commit ranges covering versions without separate release notes. The APIs used by Community retain binary compatibility; removed internal APIs are not used. Existing annotations require no changes because the new `JSONField` members have defaults.

Upstream: https://github.com/alibaba/fastjson2/releases/tag/2.0.63 and https://github.com/alibaba/fastjson2/releases/tag/2.0.65.

## Affected surfaces

- [ ] Frontend / Web
- [x] Backend / API / Storage
- [ ] Database plugin / Driver
- [x] JCEF / Desktop packaging
- [x] CI / Build / Release
- [ ] Documentation only

## Verification

- Commands and results:
  - `mvn -B -f chat2db-community-server/pom.xml -pl :chat2db-community-tools,:chat2db-community-domain-api,:chat2db-community-storage,:chat2db-community-web -am -Dmaven.test.skip=false -DskipTests=false -Dtest=NamespaceSerializationTest,OperationSerializationTest,JsonFileUtilsTest,SmallDataStorageAtomicWriteTest,SmallDataStorageUpdateTest,LargeDataStorageTest,TreeNodeStorageTest,FileTaskStorageTest,ConsoleSseEmitterTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.test.failure.ignore=false clean test` — 44 tests passed on Java 17. The original 43 tests also passed with 2.0.49 before the change.
  - `mvn -B -f chat2db-community-server/pom.xml -Dmaven.test.skip=true -DskipTests=true -Dchat2db.finalName=chat2db-community clean install` — full reactor build passed; tests intentionally skipped in this separate build.
  - The new excessive-number test fails with 2.0.49 because parsing succeeds, and passes with 2.0.65 for both a root array number and a negative number nested in an object.
  - A temporary compatibility probe compiled against 2.0.49 ran against 2.0.65; recompilation against 2.0.65 also passed. A fixture generated by 2.0.49 retained generic DTOs, JSON object/array representations, null fields, annotation/filter behavior, numeric precision, dates and escaped Unicode strings.
  - `git diff --check` — passed. Final runtime dependency directory contains only `fastjson2-2.0.65.jar`.
- Manual verification: source review and upstream JAR/API comparison completed; native installers and GUI were not exercised.
- UI evidence: N/A

## Risk and compatibility

- Public API or stored data: no application API or storage-format changes; JSON read/write and legacy-field behavior covered by the focused tests.
- Database or driver compatibility: no driver API changes. Arbitrary user-supplied driver JARs were not tested.
- Network, privacy, or security: adopts upstream AutoType and parser hardening; no application AutoType enablement or network-setting changes. This does not claim reproduction or confirmation of an application RCE path.
- Community / Local / Pro boundary: no runtime-edition behavior changes.
- Backward compatibility: numeric literals exceeding 10,000 digits are now rejected as intended upstream hardening. Previously tolerated malformed JSON may also be rejected. No reliance on these inputs was found in the inspected Community paths.

## Reviewer map

- Start here: `chat2db-community-server/chat2db-community-bom/pom.xml` and `chat2db-community-server/chat2db-community-tools/src/test/java/ai/chat2db/community/tools/util/JsonFileUtilsTest.java`.
- Failure condition: unexpected deserialization or persistence differences after changing the dependency; focus on numeric values, nulls, annotations and nested objects.
- Rollback or disable path: revert the dependency bump and regression together only if a confirmed incompatibility requires it; doing so restores the older dependency without these upstream fixes.

## Contributor declaration

- [ ] I linked the Issue that defines this change. N/A — direct maintainer request.
- [x] I tested the affected behavior and reported the actual results above.
- [x] I did not include credentials, private data, or generated build output.
- [x] I disclosed substantial AI assistance below, or this PR contains no substantial AI-generated code.

AI assistance: Codex inspected upstream changes and callers, updated the dependency, added the regression, ran verification, and prepared this PR with an independent read-only review.
