### PR TITLE
fix(desktop): tolerate malformed Windows PATH entries

### DIFF
--- a/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/terminal/TerminalSessionManager.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/main/java/ai/chat2db/community/jcef/terminal/TerminalSessionManager.java
@@ -16,6 +16,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -409,26 +410,62 @@ public final class TerminalSessionManager {
     }
 
     private static String findCommand(String os, String... candidates) {
-        for (String candidate : candidates) {
-            Path directPath = Path.of(candidate);
-            if (directPath.isAbsolute() && Files.isRegularFile(directPath) && Files.isExecutable(directPath)) {
-                return directPath.toString();
+        return findCommandOnPath(os, System.getenv("PATH"), candidates);
+    }
+
+    static String findCommandOnPath(String os, String pathValue, String... candidates) {
+        boolean windows = isWindows(os);
+        for (String rawCandidate : candidates) {
+            String candidate = normalizePathToken(rawCandidate, windows);
+            if (candidate.isBlank()) {
+                continue;
             }
-            String pathValue = System.getenv("PATH");
+            try {
+                Path directPath = Path.of(candidate);
+                if (directPath.isAbsolute() && Files.isRegularFile(directPath) && Files.isExecutable(directPath)) {
+                    return directPath.toString();
+                }
+            } catch (InvalidPathException ignored) {
+                continue;
+            }
             if (pathValue == null || pathValue.isBlank()) {
                 continue;
             }
-            for (String pathEntry : pathValue.split(java.util.regex.Pattern.quote(File.pathSeparator))) {
+            for (String rawPathEntry : pathValue.split(java.util.regex.Pattern.quote(File.pathSeparator))) {
+                String pathEntry = normalizePathToken(rawPathEntry, windows);
                 if (pathEntry.isBlank()) {
                     continue;
                 }
-                Path executable = Path.of(pathEntry, candidate);
-                if (Files.isRegularFile(executable) && (isWindows(os) || Files.isExecutable(executable))) {
-                    return executable.toString();
+                try {
+                    Path executable = Path.of(pathEntry, candidate);
+                    if (Files.isRegularFile(executable) && (windows || Files.isExecutable(executable))) {
+                        return executable.toString();
+                    }
+                } catch (InvalidPathException ignored) {
+                    // Ignore a malformed PATH entry and continue checking the remaining directories.
                 }
             }
         }
         return null;
+    }
+
+    private static String normalizePathToken(String value, boolean trimBoundaryQuotes) {
+        if (value == null) {
+            return "";
+        }
+        String normalized = value.trim();
+        if (!trimBoundaryQuotes) {
+            return normalized;
+        }
+        int start = 0;
+        int end = normalized.length();
+        while (start < end && normalized.charAt(start) == '"') {
+            start++;
+        }
+        while (end > start && normalized.charAt(end - 1) == '"') {
+            end--;
+        }
+        return normalized.substring(start, end).trim();
     }
 
     private static String normalizedOsName() {

--- a/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/terminal/TerminalSessionManagerTest.java
+++ b/chat2db-community-server/chat2db-community-jcef/src/test/java/ai/chat2db/community/jcef/terminal/TerminalSessionManagerTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -112,6 +114,31 @@ class TerminalSessionManagerTest {
         assertTrue(((java.util.List<?>) capabilities.get("shells")).stream()
                 .map(option -> (Map<?, ?>) option)
                 .anyMatch(option -> "system".equals(option.get("id")) && Boolean.TRUE.equals(option.get("available"))));
+    }
+
+    @Test
+    void findsCommandInQuotedPathEntries() throws Exception {
+        Path executable = Files.createFile(directory.resolve("bash.exe"));
+
+        assertEquals(
+                executable.toString(),
+                TerminalSessionManager.findCommandOnPath("windows", '"' + directory.toString() + '"', "bash.exe")
+        );
+        assertEquals(
+                executable.toString(),
+                TerminalSessionManager.findCommandOnPath("windows", '"' + directory.toString(), "bash.exe")
+        );
+    }
+
+    @Test
+    void skipsInvalidPathEntriesWhenFindingCommand() throws Exception {
+        Path executable = Files.createFile(directory.resolve("powershell.exe"));
+        String pathValue = "\0invalid" + File.pathSeparator + directory;
+
+        assertEquals(
+                executable.toString(),
+                TerminalSessionManager.findCommandOnPath("windows", pathValue, "powershell.exe")
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary

- normalize leading/trailing quotes around Windows command and `PATH` tokens before resolving installed shells
- skip individual entries that still raise `InvalidPathException` instead of failing the entire terminal-capabilities request
- add regression coverage for quoted, unmatched-quote, and malformed entries followed by a valid shell directory

Fixes #2892

## Verification

- focused regression tests: `TerminalSessionManagerTest#findsCommandInQuotedPathEntries+skipsInvalidPathEntriesWhenFindingCommand` — 2 tests, 0 failures, 0 errors
- complete `TerminalSessionManagerTest` on the latest `main` — 18 tests, 0 failures, 0 errors, 1 platform-specific skip
- JCEF module reactor package with Java 17 and tests explicitly skipped — passed
- `git diff --check` — passed

Windows desktop runtime verification remains CI/platform-only because the local verification host is macOS.
